### PR TITLE
TUI: thinking-streaming gates, dashboard, and quick triage pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,382 @@ on:
   pull_request:
 
 jobs:
+  compat_break_guard:
+    name: Compat break guard
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const core = require('@actions/core');
+            const fs = require('fs');
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.info('No pull_request context; skipping.');
+              return;
+            }
+            const labels = new Set((pr.labels || []).map(l => l.name));
+            const body = pr.body || '';
+            const bodyChecked = /\[x\]\s*\*\*Compat break\*\*/i.test(body) || /\[x\]\s*Compat break/i.test(body);
+
+            const patterns = [
+              "agentic_coder_prototype/state/session_state.py",
+              "agentic_coder_prototype/api/cli_bridge/events.py",
+              "agentic_coder_prototype/api/cli_bridge/service.py",
+              "agentic_coder_prototype/api/cli_bridge/app.py",
+              "implementations/tools/defs/",
+              "implementations/system_prompts/",
+              "agent_configs/",
+              "agentic_coder_prototype/tools.py",
+              "agentic_coder_prototype/tool_calling/",
+              "agentic_coder_prototype/tool_prompt_planner.py",
+              "agentic_coder_prototype/guardrail_orchestrator.py",
+              "agentic_coder_prototype/permission_broker.py",
+              "agentic_coder_prototype/guardrails/",
+              "agentic_coder_prototype/provider_runtime.py",
+              "agentic_coder_prototype/provider_ir.py",
+              "agentic_coder_prototype/agent_llm_openai.py",
+              "agentic_coder_prototype/compilation/system_prompt_compiler.py",
+              "agentic_coder_prototype/parity.py",
+              "scripts/run_parity_replays.py",
+              "scripts/replay_opencode_session.py",
+              "breadboard/ext/interfaces.py",
+              "breadboard/ext/registry.py",
+              "agentic_coder_prototype/api/cli_bridge/extension_loader.py",
+              "tests/fixtures/compat/",
+            ];
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const touched = files.filter(f => patterns.some(p => f.filename === p || f.filename.startsWith(p)));
+            const fixtureTouched = files.filter(f => f.filename.startsWith("tests/fixtures/compat/"));
+            const hasLabel = labels.has('compat-break') || labels.has('compat_break') || labels.has('compat');
+            const hasKernelChanges = touched.length > 0 || fixtureTouched.length > 0;
+            const report = {
+              event: context.eventName,
+              repository: `${context.repo.owner}/${context.repo.repo}`,
+              pull_number: pr.number,
+              labels: Array.from(labels).sort(),
+              has_compat_break_label: hasLabel,
+              has_template_checkbox: bodyChecked,
+              has_kernel_changes: hasKernelChanges,
+              requires_compat_break: hasKernelChanges,
+              touched_paths: touched.map(f => f.filename),
+              compat_fixture_paths: fixtureTouched.map(f => f.filename),
+              ok: !hasKernelChanges || hasLabel || bodyChecked,
+            };
+
+            fs.mkdirSync('artifacts', { recursive: true });
+            fs.writeFileSync('artifacts/compat_break_guard_report.json', JSON.stringify(report, null, 2) + "\n");
+
+            if (!hasKernelChanges) {
+              core.info('No parity-kernel paths touched.');
+              return;
+            }
+
+            if (!report.ok) {
+              core.setFailed(
+                [
+                  "Compat-break label required for parity-kernel changes.",
+                  "Add label 'compat-break' or check the Compat break box in the PR template.",
+                  "Touched paths:",
+                  ...touched.map(f => `- ${f.filename}`),
+                  ...(fixtureTouched.length ? ["Compat fixtures changed:", ...fixtureTouched.map(f => `- ${f.filename}`)] : []),
+                ].join("\\n")
+              );
+            } else {
+              core.info('Compat-break label/body present for parity-kernel changes.');
+            }
+
+      - name: Upload compat-break guard report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compat-break-guard-report
+          path: artifacts/compat_break_guard_report.json
+          if-no-files-found: error
+
+  conformance_gate:
+    name: Conformance gate (ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Resolve conformance regression override context
+        if: ${{ github.event_name == 'pull_request' }}
+        id: conformance_override
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import re
+
+          data = json.loads(open(os.environ["GITHUB_EVENT_PATH"], "r", encoding="utf-8").read())
+          pr = data.get("pull_request") or {}
+          labels = {str(item.get("name", "")) for item in (pr.get("labels") or []) if isinstance(item, dict)}
+          body = pr.get("body") or ""
+          match = re.search(r"Conformance override reason:\\s*(.+)", body, flags=re.IGNORECASE)
+          reason = (match.group(1).strip() if match else "")
+          allow = bool(reason and "conformance-override" in labels)
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"allow={str(allow).lower()}\n")
+              fh.write(f"reason={reason}\n")
+          PY
+
+      - name: Conformance scoreboard strict+regression gate
+        env:
+          SCORE_ALLOW: ${{ steps.conformance_override.outputs.allow }}
+          SCORE_REASON: ${{ steps.conformance_override.outputs.reason }}
+        run: |
+          set -euo pipefail
+          EXTRA=()
+          if [[ "${SCORE_ALLOW:-}" == "true" && -n "${SCORE_REASON:-}" ]]; then
+            EXTRA+=(--allow-regression --override-reason "${SCORE_REASON}")
+          fi
+          python scripts/conformance_scoreboard.py \
+            --strict-all-five \
+            --baseline-json docs/conformance/scoreboard_baseline.json \
+            --require-no-regression \
+            "${EXTRA[@]}"
+          python scripts/conformance_scoreboard.py \
+            --baseline-json docs/conformance/scoreboard_baseline.json \
+            --require-no-regression \
+            "${EXTRA[@]}" \
+            --json-out artifacts/conformance/scoreboard.json \
+            --markdown-out artifacts/conformance/scoreboard.md
+      - name: Provider conformance report
+        run: |
+          python scripts/provider_conformance_report.py \
+            --out artifacts/provider_conformance/report.json
+
+      - name: Docs references guard (core + conformance docs)
+        run: |
+          python scripts/check_docs_references.py \
+            docs/INSTALL_AND_DEV_QUICKSTART.md \
+            docs/REPLAY_EVAL_LANE.md \
+            docs/PROVIDER_CONFORMANCE_MATRIX.md \
+            docs/EXECUTION_BUDGETS_AND_CANCELLATION.md \
+            docs/ORCHESTRATION_EVENT_TAXONOMY.md \
+            docs/SDK_DOCS_INDEX.md \
+            docs/MIGRATION_AND_COMPATIBILITY.md \
+            docs/KNOWN_LIMITS_AND_ROADMAP.md \
+            docs/CONFORMANCE_5_0_SPEC.md \
+            docs/CONFORMANCE_SCOREBOARD.md \
+            docs/CONFORMANCE_GOVERNANCE.md \
+            docs/CONFORMANCE_REGRESSION_PLAYBOOK.md \
+            docs/CONFORMANCE_DEV_GUIDE.md
+
+      - name: Upload conformance artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: conformance-scoreboard
+          path: |
+            artifacts/conformance/**
+            artifacts/provider_conformance/report.json
+          if-no-files-found: error
+
+  compat_core:
+    name: Compat core (ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-core.txt
+
+      - name: Install core dependencies
+        run: python -m pip install -r requirements-core.txt
+
+      - name: Core install smoke
+        run: python -c "import breadboard"
+
+      - name: SDK doctor + smoke guardrail
+        env:
+          RAY_SCE_LOCAL_MODE: "1"
+          OPENAI_API_KEY: compat-dummy
+          ANTHROPIC_API_KEY: compat-dummy
+          OPENROUTER_API_KEY: compat-dummy
+        run: bash scripts/sdk_ci_guardrail.sh agent_configs/opencode_mock_c_fs.yaml
+
+      - name: Kernel import lint
+        run: python tools/import_lint.py
+
+      - name: Core compat suite
+        env:
+          RAY_SCE_LOCAL_MODE: "1"
+          AGENT_SCHEMA_V2_ENABLED: "1"
+          OPENAI_API_KEY: compat-dummy
+          ANTHROPIC_API_KEY: compat-dummy
+          OPENROUTER_API_KEY: compat-dummy
+          BB_COMPAT_WORKSPACE_ROOT: /tmp/bb_compat_workspaces
+        run: >
+          python -m pytest -q
+          tests/test_request_body_golden.py
+          tests/test_tool_schema_golden.py
+          tests/test_prompt_compilation_golden.py
+          tests/test_ctrees_determinism_corpus.py
+          tests/test_compat_break_guard_sim.py
+          tests/test_compat_break_guard_ci_parity.py
+          tests/test_compat_default_behavior_report.py
+          tests/test_atp_route_gating.py
+          tests/test_atp_repl_batch.py
+          tests/test_atp_replay_fixtures.py
+          tests/test_atp_vsock_protocol_conformance.py
+          tests/test_atp_benchmark_drift_checker.py
+          tests/test_atp_state_ref_regression_recovery.py
+          tests/test_atp_state_ref_variance_report.py
+          tests/test_state_store_lifecycle.py
+          tests/test_firecracker_file_io_fallback.py
+          tests/test_evolake_route_gating.py
+          tests/test_extension_route_prefix_policy.py
+          tests/test_extension_endpoint_enablement_matrix.py
+          tests/test_feature_audit_contract_schema.py
+          tests/test_requirements_profiles.py
+          tests/test_import_boundaries.py
+          tests/test_kernel_imports.py
+          tests/test_vsock_protocol.py
+          tests/test_vsock_protocol_fallback.py
+          tests/test_vsock_fixture_parity.py
+          tests/test_vsock_envelope_policy.py
+          tests/test_vsock_legacy_scope.py
+          tests/test_firecracker_protocol_errors.py
+          tests/test_firecracker_ci_opt_in_policy.py
+          tests/test_atp_runbook_guardrails.py
+          tests/test_pr_template_governance.py
+          tests/test_sdk_compat_bridges.py
+          tests/test_export_bridge_views_script.py
+
+      - name: Extension-off invariants
+        env:
+          ATP_REPL_ENABLE: "1"
+          ATP_REPL_ROUTE: "1"
+        run: |
+          cat > /tmp/extensions_off.yaml <<'YAML'
+          extensions:
+            atp:
+              enabled: false
+            evolake:
+              enabled: false
+          YAML
+          export BREADBOARD_EXTENSIONS_CONFIG_PATH=/tmp/extensions_off.yaml
+          python -m pytest -q \
+            tests/test_atp_route_gating.py::test_atp_routes_explicitly_disabled_override_env \
+            tests/test_evolake_route_gating.py::test_evolake_routes_explicitly_disabled_override_env \
+            tests/test_feature_audit.py::test_feature_audit_defaults
+
+      - name: Build compatibility governance artifacts
+        run: |
+          python scripts/compat_surface_summary.py --out artifacts/compat_surface_summary.json
+          python scripts/compat_break_guard_sim.py --self-test --json-out artifacts/compat_break_guard_simulation.json
+          python scripts/compat_default_behavior_report.py --out artifacts/compat_default_behavior_report.json
+
+      - name: Upload compatibility governance artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compat-governance-artifacts
+          path: |
+            artifacts/compat_surface_summary.json
+            artifacts/compat_break_guard_simulation.json
+            artifacts/compat_default_behavior_report.json
+          if-no-files-found: error
+
+  compat_break_regen:
+    name: Compat break regen guard
+    if: >-
+      ${{
+        github.event_name == 'pull_request' && (
+          contains(github.event.pull_request.labels.*.name, 'compat-break') ||
+          contains(github.event.pull_request.labels.*.name, 'compat_break') ||
+          contains(github.event.pull_request.labels.*.name, 'compat') ||
+          contains(github.event.pull_request.body || '', '[x] **Compat break**') ||
+          contains(github.event.pull_request.body || '', '[x] Compat break') ||
+          contains(github.event.pull_request.body || '', '[X] **Compat break**') ||
+          contains(github.event.pull_request.body || '', '[X] Compat break')
+        )
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements-core.txt
+
+      - name: Install core dependencies
+        run: python -m pip install -r requirements-core.txt
+
+      - name: Regenerate request-body fixtures
+        env:
+          RAY_SCE_LOCAL_MODE: "1"
+          AGENT_SCHEMA_V2_ENABLED: "1"
+          OPENAI_API_KEY: compat-dummy
+          ANTHROPIC_API_KEY: compat-dummy
+          OPENROUTER_API_KEY: compat-dummy
+          BB_COMPAT_WORKSPACE_ROOT: /tmp/bb_compat_workspaces
+        run: python scripts/compat_dump_request_bodies.py
+
+      - name: Ensure fixtures checked in
+        run: git diff --exit-code tests/fixtures/compat/request_bodies
+
+  firecracker_atp:
+    name: ATP Firecracker (self-hosted)
+    if: ${{ vars.ATP_FIRECRACKER_SMOKE == '1' }}
+    runs-on: [self-hosted, linux]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Snapshot preflight (firecracker ATP)
+        env:
+          FIRECRACKER_SNAPSHOT: ${{ vars.FIRECRACKER_SNAPSHOT }}
+          FIRECRACKER_SNAPSHOT_DIRS: ${{ vars.FIRECRACKER_SNAPSHOT_DIRS }}
+        run: python scripts/atp_snapshot_preflight.py --json
+
+      - name: Run Firecracker ATP smoke + bench
+        env:
+          FIRECRACKER_SNAPSHOT: ${{ vars.FIRECRACKER_SNAPSHOT }}
+          FIRECRACKER_SNAPSHOT_MEM: ${{ vars.FIRECRACKER_SNAPSHOT_MEM }}
+          FIRECRACKER_SNAPSHOT_VSOCK: ${{ vars.FIRECRACKER_SNAPSHOT_VSOCK }}
+          FIRECRACKER_ROOTFS: ${{ vars.FIRECRACKER_ROOTFS }}
+          FIRECRACKER_BIN: ${{ vars.FIRECRACKER_BIN }}
+          FIRECRACKER_VSOCK_PORT: ${{ vars.FIRECRACKER_VSOCK_PORT }}
+          BUDGET_P95_MS: ${{ vars.ATP_REPL_BUDGET_P95_MS }}
+          ITERS: ${{ vars.ATP_REPL_BENCH_ITERS }}
+          ATP_REPL_BENCH_VALIDATE: ${{ vars.ATP_REPL_BENCH_VALIDATE || '1' }}
+          ATP_REPL_BENCH_SUMMARY_PATH: ${{ vars.ATP_REPL_BENCH_SUMMARY_PATH }}
+          ATP_REPL_LOAD_VALIDATE: ${{ vars.ATP_REPL_LOAD_VALIDATE || '1' }}
+          ATP_REPL_LOAD_CONCURRENCY: ${{ vars.ATP_REPL_LOAD_CONCURRENCY }}
+          ATP_REPL_LOAD_ITERS: ${{ vars.ATP_REPL_LOAD_ITERS }}
+          ATP_REPL_LOAD_SUMMARY_PATH: ${{ vars.ATP_REPL_LOAD_SUMMARY_PATH }}
+          ATP_SNAPSHOT_POOL_PROBE: ${{ vars.ATP_SNAPSHOT_POOL_PROBE || '0' }}
+          ATP_SNAPSHOT_POOL_MIN_HEALTHY: ${{ vars.ATP_SNAPSHOT_POOL_MIN_HEALTHY || '1' }}
+        run: bash scripts/atp_firecracker_ci.sh
+
   tui:
     name: TUI (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -32,6 +408,95 @@ jobs:
       - name: Unit tests
         working-directory: tui_skeleton
         run: npm test
+
+      - name: Runtime gate suite (strict, ubuntu only)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        working-directory: tui_skeleton
+        run: npm run runtime:gates:strict
+
+      - name: Runtime gate artifacts (ubuntu only)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        working-directory: tui_skeleton
+        run: |
+          mkdir -p ../artifacts/runtime_gates
+          cat > ../artifacts/runtime_gates/jitter_baseline.json <<'JSON'
+          ["x\ny\nz", "x\nY\nz"]
+          JSON
+          cat > ../artifacts/runtime_gates/jitter_candidate.json <<'JSON'
+          ["x\ny\nz", "x\ny\nz\nw"]
+          JSON
+          npm run runtime:gate:jitter -- \
+            --baseline ../artifacts/runtime_gates/jitter_baseline.json \
+            --candidate ../artifacts/runtime_gates/jitter_candidate.json \
+            --strict \
+            --out ../artifacts/runtime_gates/jitter_gate.json
+          npm run runtime:gate:noise -- \
+            --fixture src/commands/repl/__tests__/fixtures/multi_turn_interleave.jsonl \
+            --threshold 2 \
+            --strict \
+            --out ../artifacts/runtime_gates/noise_gate.json
+          npm run runtime:gate:noise:matrix -- \
+            --fixtures src/commands/repl/__tests__/fixtures/tool_call_result.jsonl,src/commands/repl/__tests__/fixtures/multi_turn_interleave.jsonl \
+            --threshold 100 \
+            --strict \
+            --out ../artifacts/runtime_gates/noise_matrix.json
+          npm run runtime:gate:dashboard -- \
+            --artifacts ../artifacts/runtime_gates \
+            --strict-tests-ok \
+            --strict \
+            --out ../artifacts/runtime_gates/dashboard.json \
+            --markdown-out ../artifacts/runtime_gates/dashboard.md
+
+      - name: Runtime gate summary (ubuntu only)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          if [ -f artifacts/runtime_gates/dashboard.md ]; then
+            cat artifacts/runtime_gates/dashboard.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "### Runtime Gate Dashboard" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "missing artifacts/runtime_gates/dashboard.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: TUI goldens (report-only)
+        working-directory: tui_skeleton
+        run: npm run tui:goldens:report
+
+      - name: Claude alignment (report-only)
+        working-directory: tui_skeleton
+        run: npm run claude:compare:report
+
+      - name: TUI goldens (strict gate, ubuntu only)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        working-directory: tui_skeleton
+        run: npm run tui:goldens:strict
+
+      - name: Upload TUI golden artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tui-goldens-${{ matrix.os }}
+          path: |
+            misc/tui_goldens/artifacts/run-*/**
+          if-no-files-found: ignore
+
+      - name: Upload Claude alignment artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-compare-${{ matrix.os }}
+          path: |
+            misc/tui_goldens/claude_compare/run-*/**
+          if-no-files-found: ignore
+
+      - name: Upload runtime gate artifacts
+        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-gates-${{ matrix.os }}
+          path: |
+            artifacts/runtime_gates/**
+          if-no-files-found: ignore
 
       - name: Build
         working-directory: tui_skeleton
@@ -116,6 +581,43 @@ jobs:
           tests/test_plugin_loader.py
           tests/test_skills_registry.py
           tests/test_mcp_manager.py
+          tests/test_atp_snapshot_preflight.py
+          tests/test_snapshot_dirs.py
+          tests/test_atp_firecracker_repl_load_snapshot_dirs.py
+          tests/test_feature_audit_contract_schema.py
+          tests/test_atp_snapshot_dir_validation.py
+          tests/test_atp_snapshot_pool_health.py
+          tests/test_atp_snapshot_pool_locks.py
+          tests/test_atp_snapshot_pool_builder.py
+          tests/test_atp_snapshot_pool_stability.py
+          tests/test_atp_ops_digest.py
+          tests/test_atp_seven_day_stability_report.py
+          tests/test_atp_threshold_policy.py
+          tests/test_atp_runbook_commands.py
+          tests/test_atp_artifact_validation.py
+          tests/test_atp_benchmark_drift_checker.py
+          tests/test_atp_state_ref_variance_report.py
+          tests/test_promote_atp_state_ref_baseline.py
+          tests/test_firecracker_file_io_fallback.py
+          tests/test_evolake_route_gating.py
+          tests/test_evolake_tools.py
+          tests/test_evolake_campaign_route.py
+
+      - name: Stream chaos suite
+        run: |
+          mkdir -p artifacts/stream_chaos
+          python -m pytest -q \
+            tests/test_cli_backend_streaming.py \
+            tests/test_cli_bridge_eventlog.py \
+            --junitxml artifacts/stream_chaos/pytest.xml
+
+      - name: Upload stream chaos artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stream-chaos-${{ matrix.os }}
+          path: artifacts/stream_chaos/pytest.xml
+          if-no-files-found: error
 
   python_smoke:
     name: Python smoke (${{ matrix.os }})

--- a/.github/workflows/tui-goldens-tier2-nightly.yml
+++ b/.github/workflows/tui-goldens-tier2-nightly.yml
@@ -1,0 +1,188 @@
+name: tui-goldens-tier2-nightly
+
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+
+jobs:
+  tier2_matrix_report:
+    name: "Tier2 ${{ matrix.lane }} / ${{ matrix.tui_preset }} / w${{ matrix.width }} / ${{ matrix.mode }}"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lane: u1
+            tui_preset: breadboard_default
+            width: "120"
+            mode: unicode-color
+            ascii: "0"
+            no_color: "0"
+          - lane: u1
+            tui_preset: claude_code_like
+            width: "120"
+            mode: unicode-color
+            ascii: "0"
+            no_color: "0"
+          - lane: u1
+            tui_preset: codex_cli_like
+            width: "120"
+            mode: unicode-color
+            ascii: "0"
+            no_color: "0"
+          - lane: u2
+            tui_preset: breadboard_default
+            width: "100"
+            mode: unicode-color
+            ascii: "0"
+            no_color: "0"
+          - lane: u2
+            tui_preset: claude_code_like
+            width: "120"
+            mode: unicode-color
+            ascii: "0"
+            no_color: "0"
+          - lane: u2
+            tui_preset: codex_cli_like
+            width: "160"
+            mode: unicode-color
+            ascii: "0"
+            no_color: "0"
+          - lane: u3
+            tui_preset: breadboard_default
+            width: "100"
+            mode: ascii-no-color
+            ascii: "1"
+            no_color: "1"
+          - lane: u3
+            tui_preset: claude_code_like
+            width: "120"
+            mode: unicode-color
+            ascii: "0"
+            no_color: "0"
+          - lane: u3
+            tui_preset: codex_cli_like
+            width: "160"
+            mode: unicode-color
+            ascii: "0"
+            no_color: "0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install deps (tui_skeleton)
+        working-directory: tui_skeleton
+        run: npm ci
+
+      - name: Run tier2 report compare
+        working-directory: tui_skeleton
+        run: |
+          MANIFEST="ui_baselines/${{ matrix.lane }}/manifests/${{ matrix.lane }}.yaml"
+          RUNS_ROOT="ui_baselines/${{ matrix.lane }}/_runs_tier2"
+          BLESSED_ROOT="ui_baselines/${{ matrix.lane }}/scenarios"
+
+          if [[ "${{ matrix.no_color }}" == "1" ]]; then
+            export NO_COLOR=1
+          else
+            unset NO_COLOR || true
+          fi
+          export BREADBOARD_ASCII="${{ matrix.ascii }}"
+          export BREADBOARD_TUI_PRESET="${{ matrix.tui_preset }}"
+
+          node --import tsx scripts/run_tui_goldens.ts \
+            --manifest "$MANIFEST" \
+            --out "$RUNS_ROOT" \
+            --config ../agent_configs/codex_cli_gpt51mini_e4_live.yaml \
+            --max-width "${{ matrix.width }}"
+
+          LATEST_RUN="$(ls -td "$RUNS_ROOT"/run-* | head -n 1)"
+          echo "LATEST_RUN=$LATEST_RUN" >> "$GITHUB_ENV"
+
+          node --import tsx scripts/compare_tui_goldens.ts \
+            --manifest "$MANIFEST" \
+            --candidate "$LATEST_RUN" \
+            --blessed-root "$BLESSED_ROOT" \
+            --summary
+
+      - name: Append summary
+        run: |
+          python - <<'PY'
+          import glob, json, os
+          lane = os.environ["LANE"]
+          roots = sorted(glob.glob(f"tui_skeleton/ui_baselines/{lane}/_runs_tier2/run-*/_diffs/index.json"))
+          if not roots:
+              print("No diff summary found")
+              raise SystemExit(0)
+          p = roots[-1]
+          with open(p, "r", encoding="utf-8") as f:
+              d = json.load(f)
+          total = int(d.get("okCount", 0)) + int(d.get("failCount", 0))
+          lines = [
+              f"### Tier2 {lane} summary",
+              f"- preset: `{os.environ.get('PRESET')}`",
+              f"- mode: `{os.environ.get('MODE')}`",
+              f"- width: `{os.environ.get('WIDTH')}`",
+              f"- scenarios: `{total}`",
+              f"- ok: `{d.get('okCount', 0)}`",
+              f"- fail: `{d.get('failCount', 0)}`",
+              f"- diff index: `{p}`",
+              "",
+          ]
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with open(summary, "a", encoding="utf-8") as out:
+                  out.write("\n".join(lines))
+          print("\n".join(lines))
+          PY
+        env:
+          LANE: ${{ matrix.lane }}
+          PRESET: ${{ matrix.tui_preset }}
+          MODE: ${{ matrix.mode }}
+          WIDTH: ${{ matrix.width }}
+
+      - name: Upload tier2 artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tui-tier2-${{ matrix.lane }}-${{ matrix.tui_preset }}-w${{ matrix.width }}-${{ matrix.mode }}
+          path: |
+            tui_skeleton/ui_baselines/${{ matrix.lane }}/_runs_tier2
+          if-no-files-found: ignore
+
+  runtime_triage_pack:
+    name: "Runtime quick triage pack"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install deps (tui_skeleton)
+        working-directory: tui_skeleton
+        run: npm ci
+
+      - name: Build quick triage snapshots
+        working-directory: tui_skeleton
+        run: |
+          npm run runtime:triage:quick -- \
+            --out-dir ../artifacts/runtime_triage_nightly
+
+      - name: Upload runtime triage pack
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-triage-nightly
+          path: |
+            artifacts/runtime_triage_nightly/**
+          if-no-files-found: ignore

--- a/docs/TUI_THINKING_STREAMING_CONFIG.md
+++ b/docs/TUI_THINKING_STREAMING_CONFIG.md
@@ -1,0 +1,62 @@
+# TUI Thinking + Streaming Runtime Config
+
+This document defines the runtime knobs for activity status, thinking artifacts, and streaming markdown behavior.
+
+## Activity Runtime
+
+- `BREADBOARD_ACTIVITY_ENABLED` (default: `true`)
+  - Enables reducer-driven activity status surfaces.
+- `BREADBOARD_ACTIVITY_MIN_DISPLAY_MS` (default: `200`)
+  - Hysteresis window to suppress low-priority status flapping.
+- `BREADBOARD_STATUS_UPDATE_MS` (default: `120`)
+  - Coalescing cadence for repeated status updates.
+- `BREADBOARD_ACTIVITY_TRANSITION_DEBUG` (default: `false`)
+  - Emits reducer transition traces to debug output.
+
+## Thinking Runtime
+
+- `BREADBOARD_THINKING_ENABLED` (default: `true`)
+  - Enables per-turn thinking artifact lifecycle.
+- `BREADBOARD_THINKING_FULL_OPT_IN` (default: `false`)
+  - Required guard for full-mode reasoning retention/display.
+- `BREADBOARD_THINKING_PEEK_RAW_ALLOWED` (default: `false`)
+  - Allows raw reasoning peek surfaces; summary-only remains default-safe.
+- `BREADBOARD_THINKING_INLINE_COLLAPSIBLE` (default: `false`)
+  - Developer-only prototype for inline collapsible thinking summaries in transcript.
+  - Safe default is disabled; when enabled, summary lines are shown while raw deltas stay gated behind full+raw opt-in.
+- `BREADBOARD_THINKING_MAX_CHARS` (default: `600`)
+  - Character cap for summary peek and retained summary blocks.
+- `BREADBOARD_THINKING_MAX_LINES` (default: `6`)
+  - Line cap for summary peek and retained summary blocks.
+
+## Streaming Markdown Runtime
+
+- `BREADBOARD_MARKDOWN_COALESCING_ENABLED` (default: `true`)
+  - Enables buffered append policy instead of per-token appends.
+- `BREADBOARD_MARKDOWN_COALESCE_MS` (default: inherits `BREADBOARD_STATUS_UPDATE_MS`)
+  - Flush cadence for stable-prefix markdown chunks.
+- `BREADBOARD_MARKDOWN_MIN_CHUNK_CHARS` (default: `24`)
+  - Minimum buffered chunk size before immediate flush.
+- `BREADBOARD_MARKDOWN_ADAPTIVE_CADENCE` (default: `false`)
+  - Optional adaptive cadence for boundary/burst-aware markdown flushing.
+- `BREADBOARD_MARKDOWN_ADAPTIVE_MIN_CHUNK_CHARS` (default: `8`)
+  - Minimum chunk floor used by adaptive cadence.
+- `BREADBOARD_MARKDOWN_ADAPTIVE_MIN_COALESCE_MS` (default: `12`)
+  - Minimum coalescing delay used by adaptive cadence.
+- `BREADBOARD_MARKDOWN_ADAPTIVE_BURST_CHARS` (default: `48`)
+  - Burst threshold used to accelerate flush cadence.
+- `BREADBOARD_STREAM_MDX_LIVE_TOKENS` (default: `0`)
+  - Optional live tokenization mode for stream-mdx worker path.
+
+## Provider Capability Layering
+
+- `BREADBOARD_TUI_CAPABILITY_PRESET`
+  - Built-in presets: `claude_like`, `codex_like`.
+- `BREADBOARD_TUI_PROVIDER_CAPABILITIES_OVERRIDES`
+  - JSON schema overlays applied in deterministic order:
+  - `default -> preset -> provider -> model -> runtime`
+  - Supported capability keys include:
+  - `reasoningEvents`, `thoughtSummaryEvents`, `contextUsage`, `activitySurface`, `rawThinkingPeek`, `inlineThinkingBlock`
+
+Reference implementation:
+- `tui_skeleton/src/commands/repl/providerCapabilityResolution.ts`

--- a/docs/TUI_THINKING_STREAMING_TROUBLESHOOTING.md
+++ b/docs/TUI_THINKING_STREAMING_TROUBLESHOOTING.md
@@ -1,0 +1,82 @@
+# TUI Thinking + Streaming Troubleshooting and Rollback
+
+## Common Failure Signatures
+
+1. Status gets stuck in `compacting` or `reconnecting`.
+- Check transition legality counters:
+  - `state.runtimeTelemetry.illegalTransitions`
+- Run strict gate tests:
+  - `npm run test -- src/commands/repl/__tests__/runtimeTransitionGate.test.ts`
+
+2. Raw reasoning appears when not expected.
+- Verify guard flags are not enabled:
+  - `BREADBOARD_THINKING_FULL_OPT_IN`
+  - `BREADBOARD_THINKING_PEEK_RAW_ALLOWED`
+- Validate safety gate:
+  - `npm run test -- src/commands/repl/__tests__/runtimeSafetyGate.test.ts`
+
+3. Streaming markdown appears jittery or reflows heavily.
+- Tune coalescing:
+  - `BREADBOARD_MARKDOWN_COALESCE_MS`
+  - `BREADBOARD_MARKDOWN_MIN_CHUNK_CHARS`
+- If testing adaptive cadence, tune:
+  - `BREADBOARD_MARKDOWN_ADAPTIVE_CADENCE`
+  - `BREADBOARD_MARKDOWN_ADAPTIVE_MIN_CHUNK_CHARS`
+  - `BREADBOARD_MARKDOWN_ADAPTIVE_MIN_COALESCE_MS`
+  - `BREADBOARD_MARKDOWN_ADAPTIVE_BURST_CHARS`
+- Evaluate jitter gate:
+  - `npm run runtime:gate:jitter -- --baseline <baseline.json> --candidate <candidate.json> --strict`
+
+4. Transcript contains too much runtime noise vs canonical conversation.
+- Evaluate noise ratio gate:
+  - `npm run runtime:gate:noise -- --fixture <events.jsonl> --threshold <ratio> --strict`
+
+## Runtime Dashboard (Local)
+
+After generating runtime gate artifacts, render a consolidated summary:
+
+- `npm run runtime:gate:dashboard -- --artifacts ../artifacts/runtime_gates --strict-tests-ok --out ../artifacts/runtime_gates/dashboard.json --markdown-out ../artifacts/runtime_gates/dashboard.md`
+
+This produces:
+- `dashboard.json` for machine-read CI/report ingestion.
+- `dashboard.md` for human triage and `GITHUB_STEP_SUMMARY`.
+
+5. Inline thinking block appears unexpectedly.
+- Verify the developer-only flag:
+  - `BREADBOARD_THINKING_INLINE_COLLAPSIBLE`
+- Verify provider capability overlays do not force enable:
+  - `BREADBOARD_TUI_PROVIDER_CAPABILITIES_OVERRIDES`
+
+## Rollback Controls
+
+Use these toggles for controlled degradation without code rollback:
+
+1. Disable activity reducer surfaces:
+- `BREADBOARD_ACTIVITY_ENABLED=0`
+
+2. Disable thinking artifact lifecycle:
+- `BREADBOARD_THINKING_ENABLED=0`
+
+3. Disable markdown coalescing path:
+- `BREADBOARD_MARKDOWN_COALESCING_ENABLED=0`
+
+4. Disable adaptive markdown cadence experiment:
+- `BREADBOARD_MARKDOWN_ADAPTIVE_CADENCE=0`
+
+5. Force summary-only thinking behavior:
+- `BREADBOARD_THINKING_FULL_OPT_IN=0`
+- `BREADBOARD_THINKING_PEEK_RAW_ALLOWED=0`
+
+6. Disable inline thinking prototype:
+- `BREADBOARD_THINKING_INLINE_COLLAPSIBLE=0`
+
+## Recovery Procedure
+
+1. Reproduce with strict tests and capture failing summary.
+2. Apply the narrowest rollback toggle needed to restore user-visible stability.
+3. Re-run:
+- `npm run typecheck`
+- `npm run test -- src/commands/repl/__tests__/controllerActivityRuntime.test.ts src/commands/repl/__tests__/controllerActivitySequence.test.ts src/commands/repl/__tests__/runtimeTransitionGate.test.ts src/commands/repl/__tests__/runtimeSafetyGate.test.ts`
+4. Generate quick triage artifacts for review:
+- `npm run runtime:triage:quick -- --out-dir ../artifacts/runtime_triage`
+5. Re-enable toggles incrementally and re-check gates.

--- a/tui_skeleton/package.json
+++ b/tui_skeleton/package.json
@@ -12,7 +12,18 @@
     "postbuild": "tsx scripts/installLocalBin.ts",
     "start": "node dist/main.js",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run"
+    "test": "vitest run",
+    "runtime:gate:jitter": "node --import tsx scripts/runtime_jitter_gate.ts",
+    "runtime:gate:jitter:matrix": "node --import tsx scripts/runtime_jitter_matrix.ts",
+    "runtime:gate:noise": "node --import tsx scripts/runtime_transcript_noise_gate.ts",
+    "runtime:gate:noise:matrix": "node --import tsx scripts/runtime_noise_matrix.ts",
+    "runtime:gate:dashboard": "node --import tsx scripts/runtime_gate_dashboard.ts",
+    "runtime:triage:quick": "node --import tsx scripts/runtime_quick_triage_snapshots.ts",
+    "runtime:gates:strict": "vitest run src/commands/repl/__tests__/runtimeTransitionGate.test.ts src/commands/repl/__tests__/runtimeSafetyGate.test.ts src/repl/markdown/__tests__/jitterGate.test.ts src/repl/markdown/__tests__/streamingStressGate.test.ts src/commands/repl/__tests__/transcriptNoiseGate.test.ts",
+    "runtime:gates:p2": "bash scripts/runtime_p2_gate_pack.sh",
+    "tui:goldens:report": "node --import tsx scripts/tui_goldens_report.ts",
+    "tui:goldens:strict": "node --import tsx scripts/tui_goldens_strict.ts",
+    "claude:compare:report": "node --import tsx scripts/claude_compare_report.ts"
   },
   "dependencies": {
     "@effect/cli": "^0.69.0",
@@ -21,8 +32,8 @@
     "@effect/platform-node": "^0.95.0",
     "@effect/printer": "^0.45.0",
     "@effect/printer-ansi": "^0.45.0",
-    "@stream-mdx/core": "^0.0.2",
-    "@stream-mdx/worker": "^0.0.2",
+    "@stream-mdx/core": "^0.3.0",
+    "@stream-mdx/worker": "^0.3.0",
     "@types/node": "^24.2.1",
     "chalk": "^5.3.0",
     "chroma-js": "^2.4.2",
@@ -35,7 +46,8 @@
     "ink-select-input": "^6.2.0",
     "ink-text-input": "^6.0.0",
     "react": "^18.2.0",
-    "shiki": "^3.20.0"
+    "shiki": "^3.20.0",
+    "yaml": "^2.8.1"
   },
   "optionalDependencies": {
     "keytar": "^7.9.0"

--- a/tui_skeleton/scripts/runtime_gate_dashboard.ts
+++ b/tui_skeleton/scripts/runtime_gate_dashboard.ts
@@ -1,0 +1,184 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+
+interface Args {
+  artifactsDir: string
+  out: string | null
+  markdownOut: string | null
+  strict: boolean
+  strictTestsOk: boolean
+  thresholdsPath: string | null
+}
+
+interface GateRow {
+  key: string
+  label: string
+  ok: boolean
+  source: string
+  threshold: string
+  observed: string
+  summary: string
+}
+
+const parseArgs = (): Args => {
+  const argv = process.argv.slice(2)
+  let artifactsDir = path.resolve("../artifacts/runtime_gates")
+  let out: string | null = null
+  let markdownOut: string | null = null
+  let strict = false
+  let strictTestsOk = false
+  let thresholdsPath: string | null = null
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === "--artifacts") artifactsDir = path.resolve(argv[++i] ?? artifactsDir)
+    else if (arg === "--out") out = path.resolve(argv[++i] ?? "")
+    else if (arg === "--markdown-out") markdownOut = path.resolve(argv[++i] ?? "")
+    else if (arg === "--strict") strict = true
+    else if (arg === "--strict-tests-ok") strictTestsOk = true
+    else if (arg === "--thresholds") thresholdsPath = argv[++i] ?? null
+  }
+  return { artifactsDir, out, markdownOut, strict, strictTestsOk, thresholdsPath }
+}
+
+const loadJson = (filePath: string): any | null => {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8"))
+  } catch {
+    return null
+  }
+}
+
+const loadThresholds = (customPath: string | null): { jitterPrefix: number; jitterReflow: number; noise: number } => {
+  const fallbackPath = path.resolve("config/runtime_gate_thresholds.json")
+  const target = customPath ? path.resolve(customPath) : fallbackPath
+  const parsed = loadJson(target)
+  return {
+    jitterPrefix: Number.isFinite(Number(parsed?.jitter?.maxPrefixChurnDelta))
+      ? Number(parsed?.jitter?.maxPrefixChurnDelta)
+      : 0,
+    jitterReflow: Number.isFinite(Number(parsed?.jitter?.maxReflowDelta))
+      ? Number(parsed?.jitter?.maxReflowDelta)
+      : 0,
+    noise: Number.isFinite(Number(parsed?.noise?.threshold)) ? Number(parsed?.noise?.threshold) : 0.8,
+  }
+}
+
+const toPassFail = (ok: boolean): string => (ok ? "PASS" : "FAIL")
+
+const renderMarkdown = (rows: GateRow[], overallOk: boolean): string => {
+  const lines = [
+    "### Runtime Gate Dashboard",
+    "",
+    `Overall: **${toPassFail(overallOk)}**`,
+    "",
+    "| Gate | Status | Source | Threshold | Observed | Summary |",
+    "| --- | --- | --- | --- | --- | --- |",
+    ...rows.map((row) =>
+      `| ${row.label} | ${toPassFail(row.ok)} | ${row.source} | ${row.threshold} | ${row.observed} | ${row.summary} |`,
+    ),
+    "",
+  ]
+  return lines.join("\n")
+}
+
+const main = (): void => {
+  const args = parseArgs()
+  const thresholds = loadThresholds(args.thresholdsPath)
+  const jitterGate = loadJson(path.join(args.artifactsDir, "jitter_gate.json"))
+  const noiseGate = loadJson(path.join(args.artifactsDir, "noise_gate.json"))
+  const noiseMatrix = loadJson(path.join(args.artifactsDir, "noise_matrix.json"))
+
+  const rows: GateRow[] = []
+  const strictStatus = args.strictTestsOk
+
+  rows.push({
+    key: "transition_legality",
+    label: "Transition legality/stuck state",
+    ok: strictStatus,
+    source: "runtime:gates:strict",
+    threshold: "0 illegal, no stuck state",
+    observed: strictStatus ? "strict suite passed" : "strict suite status unavailable",
+    summary: strictStatus ? "ok" : "missing strict-suite confirmation",
+  })
+  rows.push({
+    key: "reasoning_safety",
+    label: "Reasoning safety defaults",
+    ok: strictStatus,
+    source: "runtime:gates:strict",
+    threshold: "default-safe visibility",
+    observed: strictStatus ? "strict suite passed" : "strict suite status unavailable",
+    summary: strictStatus ? "ok" : "missing strict-suite confirmation",
+  })
+  rows.push({
+    key: "streaming_stress",
+    label: "Streaming stress (table/fence)",
+    ok: strictStatus,
+    source: "runtime:gates:strict",
+    threshold: "stress gate pass",
+    observed: strictStatus ? "strict suite passed" : "strict suite status unavailable",
+    summary: strictStatus ? "ok" : "missing strict-suite confirmation",
+  })
+
+  const jitterOk = Boolean(jitterGate?.ok)
+  const jitterObservedPrefix = Number(jitterGate?.comparison?.deltaPrefixChurn)
+  const jitterObservedReflow = Number(jitterGate?.comparison?.deltaReflowCount)
+  rows.push({
+    key: "jitter_threshold",
+    label: "Jitter threshold",
+    ok: jitterOk,
+    source: "runtime_jitter_gate.ts",
+    threshold: `prefix<=${thresholds.jitterPrefix}, reflow<=${thresholds.jitterReflow}`,
+    observed:
+      Number.isFinite(jitterObservedPrefix) && Number.isFinite(jitterObservedReflow)
+        ? `prefix=${jitterObservedPrefix}, reflow=${jitterObservedReflow}`
+        : "missing",
+    summary: String(jitterGate?.summary ?? "missing jitter_gate.json"),
+  })
+
+  const noiseOk = Boolean(noiseGate?.ok)
+  const noiseObserved = Number(noiseGate?.metrics?.ratio)
+  rows.push({
+    key: "transcript_noise",
+    label: "Transcript noise ratio",
+    ok: noiseOk,
+    source: "runtime_transcript_noise_gate.ts",
+    threshold: `ratio<=${thresholds.noise}`,
+    observed: Number.isFinite(noiseObserved) ? `ratio=${noiseObserved.toFixed(3)}` : "missing",
+    summary: String(noiseGate?.summary ?? "missing noise_gate.json"),
+  })
+
+  if (noiseMatrix && typeof noiseMatrix === "object") {
+    const failCount = Number(noiseMatrix.failCount)
+    rows.push({
+      key: "noise_matrix",
+      label: "Noise matrix sweep",
+      ok: Boolean(noiseMatrix.ok),
+      source: "runtime_noise_matrix.ts",
+      threshold: `fail_count=0`,
+      observed: Number.isFinite(failCount) ? `fail_count=${failCount}` : "missing",
+      summary: String(noiseMatrix.ok ? "ok" : "failed"),
+    })
+  }
+
+  const overallOk = rows.every((row) => row.ok)
+  const summary = {
+    ok: overallOk,
+    generatedAt: new Date().toISOString(),
+    artifactsDir: args.artifactsDir,
+    rows,
+  }
+  const markdown = renderMarkdown(rows, overallOk)
+  if (args.out) {
+    writeFileSync(args.out, `${JSON.stringify(summary, null, 2)}\n`, "utf8")
+  }
+  if (args.markdownOut) {
+    writeFileSync(args.markdownOut, `${markdown}\n`, "utf8")
+  }
+  console.log(markdown)
+  if (args.strict && !overallOk) {
+    process.exit(1)
+  }
+  process.exit(0)
+}
+
+main()

--- a/tui_skeleton/scripts/runtime_noise_matrix.ts
+++ b/tui_skeleton/scripts/runtime_noise_matrix.ts
@@ -1,0 +1,123 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { ReplSessionController } from "../src/commands/repl/controller.js"
+import { evaluateTranscriptNoiseGate } from "../src/commands/repl/transcriptNoiseGate.js"
+
+type RawEvent = Record<string, unknown>
+
+interface Args {
+  fixtures: string[]
+  strict: boolean
+  threshold: number | null
+  out: string | null
+  thresholdsPath: string | null
+}
+
+const parseArgs = (): Args => {
+  let fixtures: string[] = []
+  let strict = false
+  let threshold: number | null = null
+  let out: string | null = null
+  let thresholdsPath: string | null = null
+  const argv = process.argv.slice(2)
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === "--fixtures") {
+      fixtures = (argv[++i] ?? "")
+        .split(",")
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0)
+    } else if (arg === "--strict") strict = true
+    else if (arg === "--threshold") threshold = Number(argv[++i] ?? "0.8")
+    else if (arg === "--out") out = argv[++i] ?? null
+    else if (arg === "--thresholds") thresholdsPath = argv[++i] ?? null
+  }
+  if (fixtures.length === 0) {
+    throw new Error("Usage: runtime_noise_matrix.ts --fixtures <a.jsonl,b.jsonl,...> [--strict]")
+  }
+  return { fixtures, strict, threshold, out, thresholdsPath }
+}
+
+const parseEvent = (raw: string): RawEvent | null => {
+  let parsed: any
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (parsed && typeof parsed === "object") {
+    if (parsed.event && typeof parsed.event === "object") return parsed.event as RawEvent
+    if (typeof parsed.data === "string") {
+      try {
+        const inner = JSON.parse(parsed.data)
+        if (inner && typeof inner === "object") return inner as RawEvent
+      } catch {
+        return null
+      }
+    }
+    if (parsed.type) return parsed as RawEvent
+  }
+  return null
+}
+
+const loadNoiseThreshold = (customPath: string | null): number => {
+  const fallbackPath = path.resolve("config/runtime_gate_thresholds.json")
+  const target = customPath ? path.resolve(customPath) : fallbackPath
+  try {
+    const parsed = JSON.parse(readFileSync(target, "utf8")) as any
+    const value = Number(parsed?.noise?.threshold)
+    return Number.isFinite(value) ? value : 0.8
+  } catch {
+    return 0.8
+  }
+}
+
+const stateFromFixture = (fixturePath: string): any => {
+  const controller = new ReplSessionController({
+    configPath: "agent_configs/test_simple_native.yaml",
+    workspace: ".",
+  }) as unknown as {
+    applyEvent: (evt: any) => void
+    getState: () => any
+  }
+  const lines = readFileSync(path.resolve(fixturePath), "utf8")
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+  for (const line of lines) {
+    const event = parseEvent(line)
+    if (!event) continue
+    controller.applyEvent(event)
+  }
+  return controller.getState()
+}
+
+const main = (): void => {
+  const args = parseArgs()
+  const threshold = args.threshold ?? loadNoiseThreshold(args.thresholdsPath)
+  const results = args.fixtures.map((fixturePath) => {
+    const gate = evaluateTranscriptNoiseGate(stateFromFixture(fixturePath), threshold)
+    return {
+      fixture: fixturePath,
+      ...gate,
+    }
+  })
+  const failCount = results.filter((entry) => !entry.ok).length
+  const summary = {
+    ok: failCount === 0,
+    threshold,
+    total: results.length,
+    failCount,
+    results,
+  }
+  const output = JSON.stringify(summary, null, 2)
+  console.log(output)
+  if (args.out) {
+    writeFileSync(path.resolve(args.out), `${output}\n`, "utf8")
+  }
+  if (args.strict && failCount > 0) {
+    process.exit(1)
+  }
+  process.exit(0)
+}
+
+main()

--- a/tui_skeleton/scripts/runtime_quick_triage_snapshots.ts
+++ b/tui_skeleton/scripts/runtime_quick_triage_snapshots.ts
@@ -1,0 +1,232 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { renderGridFromFrames } from "../tools/tty/vtgrid.js"
+import { normalizeSessionEvent } from "../src/repl/transcript/normalizeSessionEvent.js"
+
+type RawEvent = Record<string, unknown>
+
+interface Args {
+  outDir: string
+  baselineDir: string | null
+  fixtures: string[]
+  rows: number
+  cols: number
+  strict: boolean
+  configPath: string
+}
+
+const DEFAULT_FIXTURES = [
+  "src/commands/repl/__tests__/fixtures/assistant_tool_interleave.jsonl",
+  "src/commands/repl/__tests__/fixtures/multi_turn_interleave.jsonl",
+  "src/commands/repl/__tests__/fixtures/system_notice_tool_error.jsonl",
+  "src/commands/repl/__tests__/fixtures/tool_call_result.jsonl",
+  "src/commands/repl/__tests__/fixtures/tool_display_head_tail.jsonl",
+  "src/commands/repl/__tests__/fixtures/runtime_plan_path.jsonl",
+  "src/commands/repl/__tests__/fixtures/inline_thinking_permission_tool_answer.jsonl",
+]
+
+const parseArgs = (): Args => {
+  const argv = process.argv.slice(2)
+  let outDir = path.resolve("../artifacts/runtime_triage")
+  let baselineDir: string | null = null
+  let fixtures = [...DEFAULT_FIXTURES]
+  let rows = Number(process.env.BREADBOARD_TUI_FRAME_HEIGHT ?? "40")
+  let cols = Number(process.env.BREADBOARD_TUI_FRAME_WIDTH ?? "120")
+  let strict = false
+  let configPath = path.resolve("../agent_configs/codex_cli_gpt51mini_e4_live.yaml")
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === "--out-dir") outDir = path.resolve(argv[++i] ?? outDir)
+    else if (arg === "--baseline-dir") baselineDir = path.resolve(argv[++i] ?? "")
+    else if (arg === "--fixtures") {
+      fixtures = (argv[++i] ?? "")
+        .split(",")
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0)
+    } else if (arg === "--rows") rows = Number(argv[++i] ?? rows)
+    else if (arg === "--cols") cols = Number(argv[++i] ?? cols)
+    else if (arg === "--strict") strict = true
+    else if (arg === "--config") configPath = path.resolve(argv[++i] ?? configPath)
+  }
+  return {
+    outDir,
+    baselineDir,
+    fixtures,
+    rows: Number.isFinite(rows) ? Math.max(1, Math.floor(rows)) : 40,
+    cols: Number.isFinite(cols) ? Math.max(10, Math.floor(cols)) : 120,
+    strict,
+    configPath,
+  }
+}
+
+const parseEvent = (raw: string): RawEvent | null => {
+  let parsed: any
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  const normalize = (input: Record<string, unknown>): RawEvent | null => {
+    const normalized = normalizeSessionEvent(input) as RawEvent | null
+    if (!normalized) return null
+    const payload = input.payload
+    if (payload && typeof payload === "object") {
+      return { ...normalized, payload }
+    }
+    return normalized
+  }
+  if (parsed && typeof parsed === "object") {
+    if (parsed.event && typeof parsed.event === "object") return normalize(parsed.event as RawEvent)
+    if (typeof parsed.data === "string") {
+      try {
+        const inner = JSON.parse(parsed.data)
+        if (inner && typeof inner === "object") return normalize(inner as RawEvent)
+      } catch {
+        return null
+      }
+    }
+    if (parsed.type) return normalize(parsed as RawEvent)
+  }
+  return null
+}
+
+const readFixtureEvents = (fixturePath: string): RawEvent[] =>
+  readFileSync(path.resolve(fixturePath), "utf8")
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map(parseEvent)
+    .filter((event): event is RawEvent => Boolean(event))
+
+const renderFixture = async (
+  fixturePath: string,
+  options: { rows: number; cols: number; configPath: string },
+): Promise<{ renderText: string; grid: any }> => {
+  const { ReplSessionController } = await import("../src/commands/repl/controller.js")
+  const { renderStateToText } = await import("../src/commands/repl/renderText.js")
+  const controller = new ReplSessionController({
+    configPath: options.configPath,
+    workspace: null,
+    model: null,
+    remotePreference: null,
+    permissionMode: null,
+  }) as unknown as {
+    applyEvent: (evt: RawEvent) => void
+    getState: () => any
+    liveSlots?: Map<string, unknown>
+    liveSlotTimers?: Map<string, NodeJS.Timeout>
+  }
+  for (const evt of readFixtureEvents(fixturePath)) {
+    controller.applyEvent(evt)
+  }
+  try {
+    controller.liveSlots?.clear?.()
+    controller.liveSlotTimers?.forEach?.((timer: NodeJS.Timeout) => clearTimeout(timer))
+    controller.liveSlotTimers?.clear?.()
+  } catch {
+    // best effort cleanup for deterministic render
+  }
+  const renderText = renderStateToText(controller.getState(), {
+    includeHeader: false,
+    includeStatus: true,
+    includeHints: false,
+    includeModelMenu: false,
+    colors: false,
+    asciiOnly: true,
+    maxWidth: options.cols,
+  })
+  const grid = renderGridFromFrames([{ timestamp: Date.now(), chunk: `${renderText}\n` }], options.rows, options.cols)
+  return { renderText, grid }
+}
+
+const main = async (): Promise<void> => {
+  const args = parseArgs()
+  mkdirSync(args.outDir, { recursive: true })
+  const diffDir = path.join(args.outDir, "_diffs")
+  mkdirSync(diffDir, { recursive: true })
+
+  const scenarios: Array<{
+    name: string
+    fixture: string
+    renderPath: string
+    gridPath: string
+    changed: boolean
+  }> = []
+
+  for (const fixture of args.fixtures) {
+    const absoluteFixture = path.resolve(fixture)
+    const name = path.basename(absoluteFixture).replace(/\.jsonl$/i, "")
+    const scenarioDir = path.join(args.outDir, name)
+    mkdirSync(scenarioDir, { recursive: true })
+    const { renderText, grid } = await renderFixture(absoluteFixture, {
+      rows: args.rows,
+      cols: args.cols,
+      configPath: args.configPath,
+    })
+    const renderPath = path.join(scenarioDir, "render.txt")
+    const gridPath = path.join(scenarioDir, "frame.grid.json")
+    writeFileSync(renderPath, `${renderText}\n`, "utf8")
+    writeFileSync(
+      gridPath,
+      `${JSON.stringify(
+        {
+          rows: args.rows,
+          cols: args.cols,
+          grid: grid.grid,
+          activeBuffer: grid.activeBuffer,
+          normalGrid: grid.normalGrid,
+          alternateGrid: grid.alternateGrid,
+          timestamp: Date.now(),
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    )
+    let changed = false
+    if (args.baselineDir) {
+      const baselineRender = path.join(args.baselineDir, name, "render.txt")
+      try {
+        const previous = readFileSync(baselineRender, "utf8")
+        changed = previous !== `${renderText}\n`
+      } catch {
+        changed = true
+      }
+    }
+    scenarios.push({
+      name,
+      fixture: absoluteFixture,
+      renderPath,
+      gridPath,
+      changed,
+    })
+  }
+
+  const changedScenarios = scenarios.filter((entry) => entry.changed).map((entry) => entry.name)
+  const diffIndex = {
+    total: scenarios.length,
+    changedCount: changedScenarios.length,
+    changedScenarios,
+  }
+  writeFileSync(path.join(diffDir, "index.json"), `${JSON.stringify(diffIndex, null, 2)}\n`, "utf8")
+
+  const index = {
+    generatedAt: new Date().toISOString(),
+    rows: args.rows,
+    cols: args.cols,
+    fixtures: args.fixtures,
+    scenarios,
+    diff: diffIndex,
+  }
+  writeFileSync(path.join(args.outDir, "index.json"), `${JSON.stringify(index, null, 2)}\n`, "utf8")
+  console.log(`[runtime_quick_triage_snapshots] wrote ${args.outDir} (${scenarios.length} scenarios)`)
+
+  if (args.strict && args.baselineDir && changedScenarios.length > 0) {
+    process.exit(1)
+  }
+  process.exit(0)
+}
+
+main().catch((error) => {
+  console.error("[runtime_quick_triage_snapshots] failed:", error)
+  process.exit(1)
+})

--- a/tui_skeleton/scripts/runtime_transcript_noise_gate.ts
+++ b/tui_skeleton/scripts/runtime_transcript_noise_gate.ts
@@ -1,0 +1,104 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { ReplSessionController } from "../src/commands/repl/controller.js"
+import { evaluateTranscriptNoiseGate, renderTranscriptNoiseGateJson } from "../src/commands/repl/transcriptNoiseGate.js"
+
+type RawEvent = Record<string, unknown>
+
+interface Args {
+  fixture: string
+  strict: boolean
+  threshold: number | null
+  out: string | null
+  thresholdsPath: string | null
+}
+
+const parseArgs = (): Args => {
+  let fixture = ""
+  let strict = false
+  let threshold: number | null = null
+  let out: string | null = null
+  let thresholdsPath: string | null = null
+  const argv = process.argv.slice(2)
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === "--fixture") fixture = argv[++i] ?? ""
+    else if (arg === "--strict") strict = true
+    else if (arg === "--threshold") threshold = Number(argv[++i] ?? "0.8")
+    else if (arg === "--out") out = argv[++i] ?? null
+    else if (arg === "--thresholds") thresholdsPath = argv[++i] ?? null
+  }
+  if (!fixture) {
+    throw new Error("Usage: runtime_transcript_noise_gate.ts --fixture <events.jsonl> [--strict] [--threshold <n>]")
+  }
+  return { fixture, strict, threshold, out, thresholdsPath }
+}
+
+const loadNoiseThreshold = (customPath: string | null): number => {
+  const fallbackPath = path.resolve("config/runtime_gate_thresholds.json")
+  const target = customPath ? path.resolve(customPath) : fallbackPath
+  try {
+    const parsed = JSON.parse(readFileSync(target, "utf8")) as any
+    const value = Number(parsed?.noise?.threshold)
+    return Number.isFinite(value) ? value : 0.8
+  } catch {
+    return 0.8
+  }
+}
+
+const parseEvent = (raw: string): RawEvent | null => {
+  let parsed: any
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (parsed && typeof parsed === "object") {
+    if (parsed.event && typeof parsed.event === "object") return parsed.event as RawEvent
+    if (typeof parsed.data === "string") {
+      try {
+        const inner = JSON.parse(parsed.data)
+        if (inner && typeof inner === "object") return inner as RawEvent
+      } catch {
+        return null
+      }
+    }
+    if (parsed.type) return parsed as RawEvent
+  }
+  return null
+}
+
+const main = (): void => {
+  const args = parseArgs()
+  const fixturePath = path.resolve(args.fixture)
+  const defaultThreshold = loadNoiseThreshold(args.thresholdsPath)
+  const controller = new ReplSessionController({
+    configPath: "agent_configs/test_simple_native.yaml",
+    workspace: ".",
+  }) as unknown as {
+    applyEvent: (evt: any) => void
+    getState: () => any
+  }
+
+  const lines = readFileSync(fixturePath, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+  for (const line of lines) {
+    const event = parseEvent(line)
+    if (!event) continue
+    controller.applyEvent(event)
+  }
+
+  const result = evaluateTranscriptNoiseGate(controller.getState(), args.threshold ?? defaultThreshold)
+  const output = renderTranscriptNoiseGateJson(result)
+  console.log(output)
+  if (args.out) {
+    writeFileSync(path.resolve(args.out), `${output}\n`, "utf8")
+  }
+  if (args.strict && !result.ok) {
+    process.exit(1)
+  }
+  process.exit(0)
+}
+
+main()

--- a/tui_skeleton/src/commands/repl/__tests__/controllerActivityRuntime.test.ts
+++ b/tui_skeleton/src/commands/repl/__tests__/controllerActivityRuntime.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest"
+import {
+  activityPriority,
+  appendThinkingArtifact,
+  createActivitySnapshot,
+  createRuntimeTelemetry,
+  createThinkingArtifact,
+  finalizeThinkingArtifact,
+  isLegalActivityTransition,
+  normalizeThinkingSignal,
+  reduceActivityTransition,
+  resolveRuntimeBehaviorFlags,
+} from "../controllerActivityRuntime.js"
+
+describe("controllerActivityRuntime", () => {
+  it("resolves runtime flag defaults", () => {
+    const flags = resolveRuntimeBehaviorFlags({})
+    expect(flags.activityEnabled).toBe(true)
+    expect(flags.lifecycleToastsEnabled).toBe(false)
+    expect(flags.thinkingEnabled).toBe(true)
+    expect(flags.allowFullThinking).toBe(false)
+    expect(flags.allowRawThinkingPeek).toBe(false)
+    expect(flags.inlineThinkingBlockEnabled).toBe(false)
+    expect(flags.markdownCoalescingEnabled).toBe(true)
+    expect(flags.adaptiveMarkdownCadenceEnabled).toBe(false)
+    expect(flags.minDisplayMs).toBeGreaterThanOrEqual(0)
+    expect(flags.statusUpdateMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it("applies env overrides for runtime flags", () => {
+    const flags = resolveRuntimeBehaviorFlags({
+      BREADBOARD_ACTIVITY_ENABLED: "0",
+      BREADBOARD_ACTIVITY_LIFECYCLE_TOASTS: "1",
+      BREADBOARD_THINKING_ENABLED: "false",
+      BREADBOARD_THINKING_FULL_OPT_IN: "1",
+      BREADBOARD_THINKING_PEEK_RAW_ALLOWED: "1",
+      BREADBOARD_THINKING_INLINE_COLLAPSIBLE: "1",
+      BREADBOARD_MARKDOWN_COALESCING_ENABLED: "off",
+      BREADBOARD_MARKDOWN_ADAPTIVE_CADENCE: "1",
+      BREADBOARD_ACTIVITY_TRANSITION_DEBUG: "1",
+      BREADBOARD_ACTIVITY_MIN_DISPLAY_MS: "333",
+      BREADBOARD_STATUS_UPDATE_MS: "77",
+      BREADBOARD_THINKING_MAX_CHARS: "1234",
+      BREADBOARD_THINKING_MAX_LINES: "9",
+      BREADBOARD_MARKDOWN_ADAPTIVE_MIN_CHUNK_CHARS: "5",
+      BREADBOARD_MARKDOWN_ADAPTIVE_MIN_COALESCE_MS: "11",
+      BREADBOARD_MARKDOWN_ADAPTIVE_BURST_CHARS: "42",
+    })
+    expect(flags.activityEnabled).toBe(false)
+    expect(flags.lifecycleToastsEnabled).toBe(true)
+    expect(flags.thinkingEnabled).toBe(false)
+    expect(flags.allowFullThinking).toBe(true)
+    expect(flags.allowRawThinkingPeek).toBe(true)
+    expect(flags.inlineThinkingBlockEnabled).toBe(true)
+    expect(flags.markdownCoalescingEnabled).toBe(false)
+    expect(flags.adaptiveMarkdownCadenceEnabled).toBe(true)
+    expect(flags.transitionDebug).toBe(true)
+    expect(flags.minDisplayMs).toBe(333)
+    expect(flags.statusUpdateMs).toBe(77)
+    expect(flags.thinkingMaxChars).toBe(1234)
+    expect(flags.thinkingMaxLines).toBe(9)
+    expect(flags.adaptiveMarkdownMinChunkChars).toBe(5)
+    expect(flags.adaptiveMarkdownMinCoalesceMs).toBe(11)
+    expect(flags.adaptiveMarkdownBurstChars).toBe(42)
+  })
+
+  it("enforces legality matrix", () => {
+    expect(isLegalActivityTransition("run", "responding")).toBe(true)
+    expect(isLegalActivityTransition("permission_required", "completed")).toBe(true)
+    expect(isLegalActivityTransition("completed", "tool_call")).toBe(false)
+  })
+
+  it("suppresses lower-priority transitions inside hysteresis window", () => {
+    const flags = resolveRuntimeBehaviorFlags({
+      BREADBOARD_ACTIVITY_MIN_DISPLAY_MS: "500",
+      BREADBOARD_ACTIVITY_ENABLED: "1",
+    })
+    const base = createActivitySnapshot("responding", 1_000, 1)
+    const next = reduceActivityTransition(base, { to: "thinking", now: 1_100 }, flags)
+    expect(next.applied).toBe(false)
+    expect(next.reason).toBe("hysteresis")
+    expect(next.snapshot.primary).toBe("responding")
+  })
+
+  it("allows higher-priority transitions inside hysteresis window", () => {
+    const flags = resolveRuntimeBehaviorFlags({
+      BREADBOARD_ACTIVITY_MIN_DISPLAY_MS: "500",
+      BREADBOARD_ACTIVITY_ENABLED: "1",
+    })
+    const base = createActivitySnapshot("responding", 1_000, 1)
+    const next = reduceActivityTransition(base, { to: "error", now: 1_100 }, flags)
+    expect(activityPriority("error")).toBeGreaterThan(activityPriority("responding"))
+    expect(next.applied).toBe(true)
+    expect(next.reason).toBe("applied")
+    expect(next.snapshot.primary).toBe("error")
+    expect(next.snapshot.seq).toBe(2)
+  })
+
+  it("returns illegal for disallowed transitions", () => {
+    const flags = resolveRuntimeBehaviorFlags({
+      BREADBOARD_ACTIVITY_MIN_DISPLAY_MS: "0",
+      BREADBOARD_ACTIVITY_ENABLED: "1",
+    })
+    const base = createActivitySnapshot("completed", 1_000, 10)
+    const next = reduceActivityTransition(base, { to: "tool_call", now: 1_050 }, flags)
+    expect(next.applied).toBe(false)
+    expect(next.reason).toBe("illegal")
+    expect(next.snapshot).toBe(base)
+  })
+
+  it("suppresses transitions when activity runtime is disabled", () => {
+    const flags = resolveRuntimeBehaviorFlags({
+      BREADBOARD_ACTIVITY_ENABLED: "0",
+    })
+    const base = createActivitySnapshot("run", 1_000, 1)
+    const next = reduceActivityTransition(base, { to: "responding", now: 1_050 }, flags)
+    expect(next.applied).toBe(false)
+    expect(next.reason).toBe("disabled")
+    expect(next.snapshot).toBe(base)
+  })
+
+  it("normalizes reasoning/thought-summary deltas", () => {
+    const reasoning = normalizeThinkingSignal("assistant.reasoning.delta", { delta: "Analyzing..." })
+    const summary = normalizeThinkingSignal("assistant.thought_summary.delta", { text: "Plan ready." })
+    expect(reasoning?.kind).toBe("delta")
+    expect(summary?.kind).toBe("summary")
+    expect(reasoning?.text).toContain("Analyzing")
+    expect(summary?.text).toContain("Plan")
+  })
+
+  it("builds and finalizes bounded thinking artifacts", () => {
+    const flags = resolveRuntimeBehaviorFlags({
+      BREADBOARD_THINKING_MAX_CHARS: "20",
+      BREADBOARD_THINKING_MAX_LINES: "2",
+    })
+    let artifact = createThinkingArtifact("summary", 1000, "thinking-test")
+    const signal1 = normalizeThinkingSignal("assistant.reasoning.delta", { delta: "line1" })
+    const signal2 = normalizeThinkingSignal("assistant.reasoning.delta", { delta: "line2\nline3" })
+    expect(signal1).toBeTruthy()
+    expect(signal2).toBeTruthy()
+    artifact = appendThinkingArtifact(artifact, signal1!, flags, 1100)
+    artifact = appendThinkingArtifact(artifact, signal2!, flags, 1200)
+    expect(artifact.summary.length).toBeLessThanOrEqual(flags.thinkingMaxChars)
+    expect((artifact.summary.match(/\n/g) ?? []).length).toBeLessThanOrEqual(1)
+    const done = finalizeThinkingArtifact(artifact, 1300)
+    expect(done.finalizedAt).toBe(1300)
+  })
+
+  it("initializes telemetry counters at zero", () => {
+    const telemetry = createRuntimeTelemetry()
+    expect(telemetry.statusTransitions).toBe(0)
+    expect(telemetry.suppressedTransitions).toBe(0)
+    expect(telemetry.illegalTransitions).toBe(0)
+    expect(telemetry.markdownFlushes).toBe(0)
+    expect(telemetry.thinkingUpdates).toBe(0)
+    expect(telemetry.adaptiveCadenceAdjustments).toBe(0)
+  })
+})

--- a/tui_skeleton/src/commands/repl/__tests__/controllerActivitySequence.test.ts
+++ b/tui_skeleton/src/commands/repl/__tests__/controllerActivitySequence.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from "vitest"
+import { ReplSessionController } from "../controller.js"
+
+const event = (seq: number, type: string, payload: Record<string, unknown> = {}) => ({
+  id: String(seq),
+  seq,
+  turn: 1,
+  type,
+  payload,
+})
+
+describe("ReplSessionController activity sequencing", () => {
+  it("tracks core lifecycle transitions for run -> tool -> permission -> completion", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+    }
+
+    controller.applyEvent(event(1, "run.start"))
+    controller.applyEvent(event(2, "turn_start"))
+    controller.applyEvent(event(3, "assistant.message.start"))
+    controller.applyEvent(event(4, "tool_call", { call_id: "c1", tool: "Write", tool_name: "Write" }))
+    controller.applyEvent(event(5, "permission.request", { request_id: "p1", tool: "Write" }))
+    controller.applyEvent(event(6, "permission.decision", { decision: "allow-once" }))
+    controller.applyEvent(event(7, "completion", { completed: true }))
+
+    const state = controller.getState()
+    expect(state.activity?.primary).toBe("completed")
+    expect(state.runtimeTelemetry?.statusTransitions).toBeGreaterThan(0)
+    expect(state.runtimeTelemetry?.illegalTransitions).toBe(0)
+  })
+
+  it("coalesces duplicate status updates inside update window", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+      runtimeFlags: Record<string, unknown>
+    }
+
+    controller.runtimeFlags = { ...controller.runtimeFlags, statusUpdateMs: 10_000 }
+    controller.applyEvent(event(1, "run.start"))
+    controller.applyEvent(event(2, "run.start"))
+
+    const state = controller.getState()
+    expect(state.activity?.primary).toBe("thinking")
+    expect(state.runtimeTelemetry?.statusTransitions).toBe(1)
+    expect(state.runtimeTelemetry?.suppressedTransitions).toBe(0)
+  })
+
+  it("applies hysteresis in event path and suppresses low-priority churn", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+      runtimeFlags: Record<string, unknown>
+    }
+
+    controller.runtimeFlags = {
+      ...controller.runtimeFlags,
+      minDisplayMs: 10_000,
+      statusUpdateMs: 0,
+    }
+    controller.applyEvent(event(1, "run.start"))
+    controller.applyEvent(event(2, "assistant.message.start"))
+    controller.applyEvent(event(3, "turn_start"))
+
+    const state = controller.getState()
+    expect(state.activity?.primary).toBe("responding")
+    expect(state.runtimeTelemetry?.suppressedTransitions).toBeGreaterThan(0)
+  })
+
+  it("keeps first active state deterministic as thinking across run.start + turn_start bursts", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+      runtimeFlags: Record<string, unknown>
+    }
+
+    controller.runtimeFlags = { ...controller.runtimeFlags, statusUpdateMs: 10_000 }
+    controller.applyEvent(event(1, "run.start"))
+    controller.applyEvent(event(2, "turn_start"))
+
+    const state = controller.getState()
+    expect(state.activity?.primary).toBe("thinking")
+    expect(state.runtimeTelemetry?.statusTransitions).toBe(1)
+  })
+
+  it("transitions to responding only once for an assistant delta burst", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+      runtimeFlags: Record<string, unknown>
+    }
+
+    controller.runtimeFlags = { ...controller.runtimeFlags, statusUpdateMs: 10_000 }
+    controller.applyEvent(event(1, "run.start"))
+    controller.applyEvent(event(2, "assistant.message.start"))
+    controller.applyEvent(event(3, "assistant.message.delta", { delta: "a" }))
+    controller.applyEvent(event(4, "assistant.message.delta", { delta: "b" }))
+    controller.applyEvent(event(5, "assistant_delta", { text: "c" }))
+
+    const state = controller.getState()
+    expect(state.activity?.primary).toBe("responding")
+    expect(state.runtimeTelemetry?.statusTransitions).toBe(2)
+  })
+
+  it("maps permission allow/deny/timeout branches deterministically", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+    }
+
+    controller.applyEvent(event(1, "run.start"))
+    controller.applyEvent(event(2, "permission.request", { request_id: "perm-1", tool: "Write" }))
+    controller.applyEvent(event(3, "permission.decision", { decision: "allow-once" }))
+    controller.applyEvent(event(4, "assistant.message.start"))
+    let state = controller.getState()
+    expect(state.activity?.primary).toBe("responding")
+
+    controller.applyEvent(event(5, "permission.request", { request_id: "perm-2", tool: "Write" }))
+    controller.applyEvent(event(6, "permission.decision", { decision: "deny" }))
+    state = controller.getState()
+    expect(state.activity?.primary).toBe("halted")
+
+    controller.applyEvent(event(7, "permission.request", { request_id: "perm-3", tool: "Write" }))
+    controller.applyEvent(event(8, "permission.timeout", { request_id: "perm-3" }))
+    state = controller.getState()
+    expect(state.activity?.primary).toBe("halted")
+  })
+
+  it("surfaces reconnecting and compacting states, then clears them deterministically", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+    }
+
+    controller.applyEvent(event(1, "stream.gap"))
+    let state = controller.getState()
+    expect(state.activity?.primary).toBe("reconnecting")
+    expect(state.hints.some((hint: string) => hint.includes("Stream gap detected"))).toBe(true)
+
+    controller.applyEvent(event(2, "run.start"))
+    state = controller.getState()
+    expect(state.activity?.primary).toBe("thinking")
+
+    controller.applyEvent(event(3, "conversation.compaction.start"))
+    state = controller.getState()
+    expect(state.activity?.primary).toBe("compacting")
+
+    controller.applyEvent(event(4, "conversation.compaction.end"))
+    state = controller.getState()
+    expect(state.activity?.primary).toBe("session")
+    expect(state.hints.some((hint: string) => hint.includes("Compaction started"))).toBe(true)
+    expect(state.hints.some((hint: string) => hint.includes("Compaction complete"))).toBe(true)
+  })
+
+  it("keeps transcript behavior stable when activity runtime is disabled", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+      runtimeFlags: Record<string, unknown>
+    }
+
+    controller.runtimeFlags = { ...controller.runtimeFlags, activityEnabled: false }
+    controller.applyEvent(event(1, "assistant.message.start"))
+    controller.applyEvent(event(2, "assistant.message.delta", { delta: "hello " }))
+    controller.applyEvent(event(3, "assistant.message.delta", { delta: "world" }))
+    controller.applyEvent(event(4, "assistant.message.end"))
+
+    const state = controller.getState()
+    const assistantText = state.conversation
+      .filter((entry: any) => entry.speaker === "assistant")
+      .map((entry: any) => entry.text)
+      .join("")
+
+    expect(state.activity?.primary).toBe("idle")
+    expect(state.runtimeTelemetry?.statusTransitions ?? 0).toBe(0)
+    expect(assistantText).toBe("hello world")
+  })
+
+  it("emits bounded lifecycle toast only when lifecycle-toasts flag is enabled", () => {
+    const enabled = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+      runtimeFlags: Record<string, unknown>
+    }
+    enabled.runtimeFlags = { ...enabled.runtimeFlags, lifecycleToastsEnabled: true }
+    enabled.applyEvent(event(1, "run.start"))
+    enabled.applyEvent(event(2, "stream.gap"))
+    enabled.applyEvent(event(3, "conversation.compaction.start"))
+    let state = enabled.getState()
+    expect(state.liveSlots.some((slot: any) => String(slot.text).includes("[lifecycle]"))).toBe(true)
+
+    const disabled = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+      runtimeFlags: Record<string, unknown>
+    }
+    disabled.runtimeFlags = { ...disabled.runtimeFlags, lifecycleToastsEnabled: false }
+    disabled.applyEvent(event(1, "run.start"))
+    disabled.applyEvent(event(2, "stream.gap"))
+    disabled.applyEvent(event(3, "conversation.compaction.start"))
+    state = disabled.getState()
+    expect(state.liveSlots.some((slot: any) => String(slot.text).includes("[lifecycle]"))).toBe(false)
+  })
+
+  it("suppresses status churn during repeated permission/tool bursts", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+      runtimeFlags: Record<string, unknown>
+    }
+    controller.runtimeFlags = {
+      ...controller.runtimeFlags,
+      statusUpdateMs: 10_000,
+      minDisplayMs: 2_000,
+    }
+    controller.applyEvent(event(1, "run.start"))
+    for (let i = 0; i < 3; i += 1) {
+      const base = i * 10
+      controller.applyEvent(event(base + 2, "permission.request", { request_id: `perm-${i}`, tool: "Write" }))
+      controller.applyEvent(event(base + 3, "permission.decision", { decision: "allow-once" }))
+      controller.applyEvent(event(base + 4, "tool_call", { call_id: `call-${i}`, tool_name: "Write" }))
+      controller.applyEvent(event(base + 5, "tool.result", { call_id: `call-${i}`, tool_name: "Write" }))
+    }
+    controller.applyEvent(event(40, "completion", { completed: true }))
+
+    const state = controller.getState()
+    expect(state.activity?.primary).toBe("completed")
+    expect(state.runtimeTelemetry?.suppressedTransitions).toBeGreaterThan(0)
+    expect(state.runtimeTelemetry?.statusTransitions ?? 0).toBeLessThanOrEqual(12)
+  })
+
+  it("keeps inline thinking block disabled by default and avoids transcript leakage", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+      runtimeFlags: Record<string, unknown>
+    }
+    controller.runtimeFlags = {
+      ...controller.runtimeFlags,
+      inlineThinkingBlockEnabled: false,
+      thinkingEnabled: true,
+      allowFullThinking: false,
+      allowRawThinkingPeek: false,
+    }
+    controller.applyEvent(event(1, "turn_start"))
+    controller.applyEvent(event(2, "assistant.thought_summary.delta", { delta: "plan draft" }))
+    controller.applyEvent(event(3, "assistant.reasoning.delta", { delta: "raw hidden" }))
+
+    const state = controller.getState()
+    const transcript = state.conversation.map((entry: any) => String(entry.text ?? "")).join("\n")
+    expect(transcript.includes("[thinking-inline]")).toBe(false)
+    expect(transcript.includes("raw hidden")).toBe(false)
+  })
+
+  it("emits inline thinking summary block only when explicitly enabled", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      workspace: ".",
+    }) as unknown as {
+      applyEvent: (evt: any) => void
+      getState: () => any
+      runtimeFlags: Record<string, unknown>
+      providerCapabilities: Record<string, unknown>
+      viewPrefs: Record<string, unknown>
+    }
+    controller.runtimeFlags = {
+      ...controller.runtimeFlags,
+      inlineThinkingBlockEnabled: true,
+      thinkingEnabled: true,
+      allowFullThinking: false,
+      allowRawThinkingPeek: false,
+    }
+    controller.providerCapabilities = {
+      ...controller.providerCapabilities,
+      inlineThinkingBlock: true,
+      thoughtSummaryEvents: true,
+      reasoningEvents: true,
+    }
+    controller.viewPrefs = { ...controller.viewPrefs, showReasoning: false }
+    controller.applyEvent(event(1, "turn_start"))
+    controller.applyEvent(event(2, "assistant.thought_summary.delta", { delta: "plan draft" }))
+    controller.applyEvent(event(3, "assistant.reasoning.delta", { delta: "raw hidden" }))
+
+    const state = controller.getState()
+    const thinkingEntry = state.conversation.find((entry: any) =>
+      String(entry.text ?? "").startsWith("[thinking-inline]"),
+    )
+    expect(thinkingEntry).toBeTruthy()
+    expect(String(thinkingEntry.text)).toContain("summary: plan draft")
+    expect(String(thinkingEntry.text)).not.toContain("raw hidden")
+  })
+})

--- a/tui_skeleton/src/commands/repl/__tests__/controllerStateRenderMarkdown.test.ts
+++ b/tui_skeleton/src/commands/repl/__tests__/controllerStateRenderMarkdown.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  appendMarkdownDelta,
+  applyMarkdownBlocks,
+  ensureMarkdownStreamer,
+  shouldStreamMarkdown,
+} from "../controllerStateRender.js"
+
+describe("controllerStateRender markdown cadence + fallback", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("flushes short deltas according to cadence policy", () => {
+    vi.useFakeTimers()
+    const appendSpy = vi.fn()
+    const telemetrySpy = vi.fn()
+    const markStreamingSpy = vi.fn()
+    const controller: any = {
+      runtimeFlags: { markdownCoalescingEnabled: true, statusUpdateMs: 10 },
+      viewPrefs: { richMarkdown: true },
+      streamingEntryId: "entry-1",
+      markdownStreams: new Map([
+        [
+          "entry-1",
+          {
+            streamer: { append: appendSpy },
+            lastText: "",
+          },
+        ],
+      ]),
+      markdownStableState: new Map(),
+      markdownPendingDeltas: new Map(),
+      bumpRuntimeTelemetry: telemetrySpy,
+      markEntryMarkdownStreaming: markStreamingSpy,
+      shouldStreamMarkdown() {
+        return shouldStreamMarkdown.call(this)
+      },
+      ensureMarkdownStreamer(entryId: string) {
+        return ensureMarkdownStreamer.call(this, entryId)
+      },
+    }
+
+    appendMarkdownDelta.call(controller, "abc\n")
+    const immediateCalls = appendSpy.mock.calls.length
+    expect(immediateCalls).toBeLessThanOrEqual(1)
+    expect(markStreamingSpy).toHaveBeenCalledWith("entry-1", true)
+
+    if (immediateCalls === 0) {
+      vi.advanceTimersByTime(11)
+    }
+
+    expect(appendSpy).toHaveBeenCalledTimes(1)
+    expect(appendSpy).toHaveBeenCalledWith("abc\n")
+    expect(telemetrySpy).toHaveBeenCalledWith("markdownFlushes")
+  })
+
+  it("flushes immediately when chunk threshold is reached", () => {
+    const appendSpy = vi.fn()
+    const telemetrySpy = vi.fn()
+    const controller: any = {
+      runtimeFlags: { markdownCoalescingEnabled: true, statusUpdateMs: 50 },
+      viewPrefs: { richMarkdown: true },
+      streamingEntryId: "entry-2",
+      markdownStreams: new Map([
+        [
+          "entry-2",
+          {
+            streamer: { append: appendSpy },
+            lastText: "",
+          },
+        ],
+      ]),
+      markdownStableState: new Map(),
+      markdownPendingDeltas: new Map(),
+      bumpRuntimeTelemetry: telemetrySpy,
+      markEntryMarkdownStreaming: vi.fn(),
+      shouldStreamMarkdown() {
+        return shouldStreamMarkdown.call(this)
+      },
+      ensureMarkdownStreamer(entryId: string) {
+        return ensureMarkdownStreamer.call(this, entryId)
+      },
+    }
+
+    appendMarkdownDelta.call(controller, `${"x".repeat(48)}\n`)
+
+    expect(appendSpy).toHaveBeenCalledTimes(1)
+    expect(telemetrySpy).toHaveBeenCalledWith("markdownFlushes")
+  })
+
+  it("adapts cadence at markdown boundaries when adaptive mode is enabled", () => {
+    vi.useFakeTimers()
+    const appendSpy = vi.fn()
+    const telemetrySpy = vi.fn()
+    const controller: any = {
+      runtimeFlags: {
+        markdownCoalescingEnabled: true,
+        statusUpdateMs: 60,
+        adaptiveMarkdownCadenceEnabled: true,
+        adaptiveMarkdownMinChunkChars: 4,
+        adaptiveMarkdownMinCoalesceMs: 5,
+        adaptiveMarkdownBurstChars: 20,
+      },
+      viewPrefs: { richMarkdown: true },
+      streamingEntryId: "entry-adaptive",
+      markdownStreams: new Map([
+        [
+          "entry-adaptive",
+          {
+            streamer: { append: appendSpy },
+            lastText: "",
+          },
+        ],
+      ]),
+      markdownStableState: new Map(),
+      markdownPendingDeltas: new Map(),
+      bumpRuntimeTelemetry: telemetrySpy,
+      markEntryMarkdownStreaming: vi.fn(),
+      shouldStreamMarkdown() {
+        return shouldStreamMarkdown.call(this)
+      },
+      ensureMarkdownStreamer(entryId: string) {
+        return ensureMarkdownStreamer.call(this, entryId)
+      },
+    }
+
+    appendMarkdownDelta.call(controller, "abc\n")
+    if (appendSpy.mock.calls.length === 0) {
+      vi.advanceTimersByTime(6)
+    }
+    expect(appendSpy).toHaveBeenCalledTimes(1)
+    expect(appendSpy).toHaveBeenCalledWith("abc\n")
+    expect(telemetrySpy).toHaveBeenCalledWith("markdownFlushes")
+  })
+
+  it("applies adaptive burst threshold and flushes immediately when burst cap is reached", () => {
+    const appendSpy = vi.fn()
+    const telemetrySpy = vi.fn()
+    const controller: any = {
+      runtimeFlags: {
+        markdownCoalescingEnabled: true,
+        statusUpdateMs: 80,
+        adaptiveMarkdownCadenceEnabled: true,
+        adaptiveMarkdownMinChunkChars: 8,
+        adaptiveMarkdownMinCoalesceMs: 10,
+        adaptiveMarkdownBurstChars: 10,
+      },
+      viewPrefs: { richMarkdown: true },
+      streamingEntryId: "entry-burst",
+      markdownStreams: new Map([
+        [
+          "entry-burst",
+          {
+            streamer: { append: appendSpy },
+            lastText: "",
+          },
+        ],
+      ]),
+      markdownStableState: new Map(),
+      markdownPendingDeltas: new Map(),
+      bumpRuntimeTelemetry: telemetrySpy,
+      markEntryMarkdownStreaming: vi.fn(),
+      shouldStreamMarkdown() {
+        return shouldStreamMarkdown.call(this)
+      },
+      ensureMarkdownStreamer(entryId: string) {
+        return ensureMarkdownStreamer.call(this, entryId)
+      },
+    }
+
+    appendMarkdownDelta.call(controller, "abcdefghijkl\n")
+    expect(appendSpy).toHaveBeenCalledTimes(1)
+    expect(telemetrySpy).toHaveBeenCalledWith("markdownFlushes")
+  })
+
+  it("degrades one markdown entry on parser error without global disable side effect", () => {
+    const hintSpy = vi.fn()
+    const emitSpy = vi.fn()
+    const controller: any = {
+      markdownGloballyDisabled: false,
+      conversation: [
+        {
+          id: "assistant-1",
+          speaker: "assistant",
+          text: "raw text",
+          phase: "streaming",
+          createdAt: 0,
+        },
+      ],
+      pushHint: hintSpy,
+      eventsScheduled: false,
+      emitChange: emitSpy,
+    }
+
+    applyMarkdownBlocks.call(controller, "assistant-1", [], "worker failed", false)
+
+    expect(controller.markdownGloballyDisabled).toBe(false)
+    expect(controller.conversation[0]?.markdownError).toBe("worker failed")
+    expect(hintSpy).toHaveBeenCalledWith(expect.stringContaining("Rich markdown fallback on one entry"))
+    expect(emitSpy).toHaveBeenCalled()
+  })
+
+  it("emits only stable markdown boundaries during streaming deltas", () => {
+    const appendSpy = vi.fn()
+    const telemetrySpy = vi.fn()
+    const controller: any = {
+      runtimeFlags: { markdownCoalescingEnabled: true, statusUpdateMs: 0 },
+      viewPrefs: { richMarkdown: true },
+      streamingEntryId: "entry-3",
+      markdownStreams: new Map([
+        [
+          "entry-3",
+          {
+            streamer: { append: appendSpy },
+            lastText: "",
+          },
+        ],
+      ]),
+      markdownStableState: new Map(),
+      markdownPendingDeltas: new Map(),
+      bumpRuntimeTelemetry: telemetrySpy,
+      markEntryMarkdownStreaming: vi.fn(),
+      shouldStreamMarkdown() {
+        return shouldStreamMarkdown.call(this)
+      },
+      ensureMarkdownStreamer(entryId: string) {
+        return ensureMarkdownStreamer.call(this, entryId)
+      },
+    }
+
+    appendMarkdownDelta.call(controller, "list item")
+    expect(appendSpy).not.toHaveBeenCalled()
+
+    appendMarkdownDelta.call(controller, "\n")
+    expect(appendSpy).toHaveBeenCalledTimes(1)
+    expect(appendSpy).toHaveBeenCalledWith("list item\n")
+    expect(telemetrySpy).toHaveBeenCalledWith("markdownFlushes")
+  })
+})

--- a/tui_skeleton/src/commands/repl/__tests__/fixtures/inline_thinking_permission_tool_answer.jsonl
+++ b/tui_skeleton/src/commands/repl/__tests__/fixtures/inline_thinking_permission_tool_answer.jsonl
@@ -1,0 +1,10 @@
+{"type":"turn_start","seq":1,"id":"1","turn":1,"payload":{}}
+{"type":"assistant.thought_summary.delta","seq":2,"id":"2","turn":1,"payload":{"delta":"drafting plan"}}
+{"type":"permission.request","seq":3,"id":"3","turn":1,"payload":{"request_id":"perm-1","tool":"Write"}}
+{"type":"permission.decision","seq":4,"id":"4","turn":1,"payload":{"decision":"allow-once"}}
+{"type":"tool_call","seq":5,"id":"5","turn":1,"payload":{"call_id":"call-1","tool_name":"Write","args":{"path":"notes.txt"}}}
+{"type":"tool.result","seq":6,"id":"6","turn":1,"payload":{"call_id":"call-1","tool_name":"Write","ok":true}}
+{"type":"assistant.message.start","seq":7,"id":"7","turn":1,"payload":{}}
+{"type":"assistant.message.delta","seq":8,"id":"8","turn":1,"payload":{"delta":"Done. Applied the update."}}
+{"type":"assistant.message.end","seq":9,"id":"9","turn":1,"payload":{}}
+{"type":"completion","seq":10,"id":"10","turn":1,"payload":{"completed":true}}

--- a/tui_skeleton/src/commands/repl/__tests__/providerCapabilityResolution.test.ts
+++ b/tui_skeleton/src/commands/repl/__tests__/providerCapabilityResolution.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest"
+import { resolveProviderCapabilities } from "../providerCapabilityResolution.js"
+
+describe("provider capability resolution", () => {
+  it("applies deterministic layering default -> preset -> provider -> model -> runtime", () => {
+    const result = resolveProviderCapabilities({
+      modelId: "openai/gpt-5-mini",
+      preset: "claude_like",
+      overrideSchema: {
+        defaults: { reasoningEvents: true, rawThinkingPeek: false, inlineThinkingBlock: false },
+        presets: { claude_like: { contextUsage: false } },
+        providers: { openai: { reasoningEvents: false, inlineThinkingBlock: true } },
+        models: { "openai/gpt-5-mini": { reasoningEvents: true, inlineThinkingBlock: true } },
+      },
+      runtimeOverrides: { rawThinkingPeek: true },
+    })
+
+    expect(result.provider).toBe("openai")
+    expect(result.model).toBe("openai/gpt-5-mini")
+    expect(result.capabilities.reasoningEvents).toBe(true)
+    expect(result.capabilities.contextUsage).toBe(false)
+    expect(result.capabilities.rawThinkingPeek).toBe(true)
+    expect(result.capabilities.inlineThinkingBlock).toBe(true)
+  })
+
+  it("degrades safely and emits warnings for malformed schema values", () => {
+    const result = resolveProviderCapabilities({
+      modelId: "anthropic/claude-sonnet",
+      overrideSchema: {
+        defaults: { unknownFlag: true, reasoningEvents: "yes" },
+        providers: "invalid",
+      },
+    })
+
+    expect(result.capabilities.reasoningEvents).toBe(false)
+    expect(result.warnings.length).toBeGreaterThan(0)
+    expect(result.warnings.join(" ")).toContain("defaults")
+    expect(result.warnings.join(" ")).toContain("providers")
+  })
+
+  it("falls back to unknown provider defaults when model identity is missing provider prefix", () => {
+    const result = resolveProviderCapabilities({
+      modelId: "gpt-5-no-provider-prefix",
+      overrideSchema: {
+        models: {
+          "gpt-5-no-provider-prefix": { thoughtSummaryEvents: false },
+        },
+      },
+    })
+
+    expect(result.provider).toBe("unknown")
+    expect(result.model).toBe("gpt-5-no-provider-prefix")
+    expect(result.capabilities.thoughtSummaryEvents).toBe(false)
+  })
+
+  it("keeps layering deterministic when provider defaults conflict with preset defaults", () => {
+    const anthropicResult = resolveProviderCapabilities({
+      modelId: "anthropic/claude-sonnet",
+      preset: "codex_like",
+    })
+    expect(anthropicResult.capabilities.reasoningEvents).toBe(false)
+    expect(anthropicResult.capabilities.thoughtSummaryEvents).toBe(true)
+
+    const openaiResult = resolveProviderCapabilities({
+      modelId: "openai/gpt-5-mini",
+      preset: "claude_like",
+    })
+    expect(openaiResult.capabilities.reasoningEvents).toBe(true)
+    expect(openaiResult.capabilities.thoughtSummaryEvents).toBe(true)
+  })
+
+  it("warns when an unknown preset is requested without a custom override", () => {
+    const result = resolveProviderCapabilities({
+      modelId: "openai/gpt-5-mini",
+      preset: "not_a_real_preset",
+      overrideSchema: {},
+    })
+
+    expect(result.warnings.some((warning) => warning.includes("unknown"))).toBe(true)
+  })
+
+  it("covers provider matrix for openai/anthropic/openrouter/unknown identities", () => {
+    const openai = resolveProviderCapabilities({ modelId: "openai/gpt-5-mini", preset: "codex_like" })
+    const anthropic = resolveProviderCapabilities({ modelId: "anthropic/claude-sonnet", preset: "codex_like" })
+    const openrouter = resolveProviderCapabilities({ modelId: "openrouter/kimi", preset: "codex_like" })
+    const unknown = resolveProviderCapabilities({ modelId: "plain-model-without-provider", preset: "codex_like" })
+
+    expect(openai.provider).toBe("openai")
+    expect(anthropic.provider).toBe("anthropic")
+    expect(openrouter.provider).toBe("openrouter")
+    expect(unknown.provider).toBe("unknown")
+
+    expect(openai.capabilities.reasoningEvents).toBe(true)
+    expect(anthropic.capabilities.reasoningEvents).toBe(false)
+    expect(openrouter.capabilities.reasoningEvents).toBe(true)
+    expect(unknown.capabilities.reasoningEvents).toBe(true)
+    expect(openai.capabilities.inlineThinkingBlock).toBe(true)
+    expect(anthropic.capabilities.inlineThinkingBlock).toBe(false)
+  })
+
+  it("emits deterministic warnings for malformed nested override keys and value types", () => {
+    const result = resolveProviderCapabilities({
+      modelId: "openai/gpt-5-mini",
+      preset: "unknown_custom",
+      overrideSchema: {
+        presets: {
+          unknown_custom: {
+            badNested: { x: 1 },
+            reasoningEvents: "not-bool",
+          },
+        },
+        providers: {
+          openai: {
+            thoughtSummaryEvents: "bad",
+            extraToggle: true,
+          },
+        },
+      },
+    })
+
+    const warningText = result.warnings.join(" | ")
+    expect(warningText).toContain("unknown")
+    expect(warningText).toContain("must be boolean")
+    expect(warningText).toContain("unknown; ignoring key")
+    expect(result.capabilities.reasoningEvents).toBe(true)
+    expect(result.capabilities.thoughtSummaryEvents).toBe(true)
+  })
+})

--- a/tui_skeleton/src/commands/repl/controllerActivityRuntime.ts
+++ b/tui_skeleton/src/commands/repl/controllerActivityRuntime.ts
@@ -1,0 +1,406 @@
+import type {
+  ActivityDetail,
+  ActivityPrimary,
+  ActivitySnapshot,
+  RuntimeBehaviorFlags,
+  RuntimeTelemetry,
+  ThinkingArtifact,
+  ThinkingMode,
+} from "../../repl/types.js"
+import { extractRawString, isRecord, parseNumberish } from "./controllerUtils.js"
+
+const DEFAULT_MIN_DISPLAY_MS = 200
+const DEFAULT_STATUS_UPDATE_MS = 120
+const DEFAULT_THINKING_MAX_CHARS = 600
+const DEFAULT_THINKING_MAX_LINES = 6
+const DEFAULT_ADAPTIVE_MIN_CHUNK_CHARS = 8
+const DEFAULT_ADAPTIVE_MIN_COALESCE_MS = 12
+const DEFAULT_ADAPTIVE_BURST_CHARS = 48
+
+const PRIMARY_LABELS: Record<ActivityPrimary, string> = {
+  idle: "Ready",
+  session: "Session active",
+  run: "Run started",
+  thinking: "Assistant thinking…",
+  responding: "Assistant responding…",
+  tool_call: "Tool call in progress…",
+  tool_result: "Tool result received",
+  permission_required: "Permission required",
+  permission_resolved: "Permission response received",
+  reconnecting: "Reconnecting",
+  compacting: "Compacting conversation…",
+  completed: "Finished",
+  halted: "Halted",
+  cancelled: "Cancelled",
+  error: "Error received",
+}
+
+const PRIMARY_PRIORITY: Record<ActivityPrimary, number> = {
+  idle: 10,
+  session: 20,
+  run: 30,
+  thinking: 40,
+  responding: 50,
+  tool_call: 55,
+  tool_result: 45,
+  permission_required: 80,
+  permission_resolved: 82,
+  reconnecting: 85,
+  compacting: 75,
+  completed: 95,
+  halted: 95,
+  cancelled: 95,
+  error: 100,
+}
+
+const LEGAL_TRANSITIONS: Record<ActivityPrimary, ReadonlyArray<ActivityPrimary>> = {
+  idle: ["idle", "session", "run", "thinking", "reconnecting", "compacting", "error"],
+  session: [
+    "session",
+    "run",
+    "thinking",
+    "responding",
+    "permission_required",
+    "reconnecting",
+    "completed",
+    "halted",
+    "cancelled",
+    "idle",
+    "error",
+  ],
+  run: [
+    "run",
+    "thinking",
+    "responding",
+    "tool_call",
+    "permission_required",
+    "reconnecting",
+    "compacting",
+    "completed",
+    "halted",
+    "cancelled",
+    "error",
+    "idle",
+  ],
+  thinking: [
+    "thinking",
+    "responding",
+    "tool_call",
+    "permission_required",
+    "compacting",
+    "completed",
+    "halted",
+    "cancelled",
+    "error",
+    "reconnecting",
+  ],
+  responding: [
+    "responding",
+    "thinking",
+    "tool_call",
+    "tool_result",
+    "permission_required",
+    "compacting",
+    "completed",
+    "halted",
+    "cancelled",
+    "error",
+    "reconnecting",
+  ],
+  tool_call: [
+    "tool_call",
+    "tool_result",
+    "responding",
+    "permission_required",
+    "completed",
+    "halted",
+    "error",
+    "cancelled",
+    "reconnecting",
+  ],
+  tool_result: ["tool_result", "responding", "thinking", "completed", "halted", "cancelled", "error", "reconnecting"],
+  permission_required: [
+    "permission_required",
+    "permission_resolved",
+    "completed",
+    "halted",
+    "cancelled",
+    "error",
+    "reconnecting",
+  ],
+  permission_resolved: ["permission_resolved", "thinking", "responding", "tool_call", "completed", "halted", "cancelled", "error", "reconnecting"],
+  reconnecting: ["reconnecting", "run", "thinking", "responding", "idle", "error", "cancelled", "halted"],
+  compacting: [
+    "compacting",
+    "session",
+    "run",
+    "thinking",
+    "responding",
+    "completed",
+    "halted",
+    "error",
+    "idle",
+    "reconnecting",
+  ],
+  completed: ["completed", "idle", "session", "run", "thinking", "responding", "reconnecting"],
+  halted: ["halted", "idle", "session", "run", "thinking", "responding", "reconnecting"],
+  cancelled: ["cancelled", "idle", "session", "run", "thinking", "responding", "reconnecting"],
+  error: ["error", "idle", "session", "run", "thinking", "responding", "reconnecting"],
+}
+
+const parseBoolEnv = (value: string | undefined, fallback: boolean): boolean => {
+  if (value == null) return fallback
+  const normalized = value.trim().toLowerCase()
+  if (!normalized) return fallback
+  if (["1", "true", "yes", "on"].includes(normalized)) return true
+  if (["0", "false", "no", "off"].includes(normalized)) return false
+  return fallback
+}
+
+const parseBoundedIntEnv = (
+  value: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number => {
+  const parsed = parseNumberish(value)
+  if (parsed == null || !Number.isFinite(parsed)) return fallback
+  const rounded = Math.round(parsed)
+  if (rounded < min) return min
+  if (rounded > max) return max
+  return rounded
+}
+
+export interface ActivityTransitionInput {
+  readonly to: ActivityPrimary
+  readonly label?: string | null
+  readonly detail?: ActivityDetail | null
+  readonly source?: ActivityDetail["source"]
+  readonly eventType?: string | null
+  readonly now?: number
+}
+
+export interface ActivityTransitionResult {
+  readonly snapshot: ActivitySnapshot
+  readonly applied: boolean
+  readonly reason: "applied" | "disabled" | "same" | "hysteresis" | "illegal"
+}
+
+export interface ThinkingSignal {
+  readonly kind: "delta" | "summary"
+  readonly text: string
+  readonly eventType: string
+}
+
+export const resolveRuntimeBehaviorFlags = (env: NodeJS.ProcessEnv): RuntimeBehaviorFlags => ({
+  activityEnabled: parseBoolEnv(env.BREADBOARD_ACTIVITY_ENABLED, true),
+  lifecycleToastsEnabled: parseBoolEnv(env.BREADBOARD_ACTIVITY_LIFECYCLE_TOASTS, false),
+  thinkingEnabled: parseBoolEnv(env.BREADBOARD_THINKING_ENABLED, true),
+  allowFullThinking: parseBoolEnv(env.BREADBOARD_THINKING_FULL_OPT_IN, false),
+  allowRawThinkingPeek: parseBoolEnv(env.BREADBOARD_THINKING_PEEK_RAW_ALLOWED, false),
+  inlineThinkingBlockEnabled: parseBoolEnv(env.BREADBOARD_THINKING_INLINE_COLLAPSIBLE, false),
+  markdownCoalescingEnabled: parseBoolEnv(env.BREADBOARD_MARKDOWN_COALESCING_ENABLED, true),
+  adaptiveMarkdownCadenceEnabled: parseBoolEnv(env.BREADBOARD_MARKDOWN_ADAPTIVE_CADENCE, false),
+  transitionDebug: parseBoolEnv(env.BREADBOARD_ACTIVITY_TRANSITION_DEBUG, false),
+  minDisplayMs: parseBoundedIntEnv(env.BREADBOARD_ACTIVITY_MIN_DISPLAY_MS, DEFAULT_MIN_DISPLAY_MS, 0, 60_000),
+  statusUpdateMs: parseBoundedIntEnv(env.BREADBOARD_STATUS_UPDATE_MS, DEFAULT_STATUS_UPDATE_MS, 0, 10_000),
+  thinkingMaxChars: parseBoundedIntEnv(env.BREADBOARD_THINKING_MAX_CHARS, DEFAULT_THINKING_MAX_CHARS, 16, 20_000),
+  thinkingMaxLines: parseBoundedIntEnv(env.BREADBOARD_THINKING_MAX_LINES, DEFAULT_THINKING_MAX_LINES, 1, 200),
+  adaptiveMarkdownMinChunkChars: parseBoundedIntEnv(
+    env.BREADBOARD_MARKDOWN_ADAPTIVE_MIN_CHUNK_CHARS,
+    DEFAULT_ADAPTIVE_MIN_CHUNK_CHARS,
+    1,
+    200,
+  ),
+  adaptiveMarkdownMinCoalesceMs: parseBoundedIntEnv(
+    env.BREADBOARD_MARKDOWN_ADAPTIVE_MIN_COALESCE_MS,
+    DEFAULT_ADAPTIVE_MIN_COALESCE_MS,
+    0,
+    5000,
+  ),
+  adaptiveMarkdownBurstChars: parseBoundedIntEnv(
+    env.BREADBOARD_MARKDOWN_ADAPTIVE_BURST_CHARS,
+    DEFAULT_ADAPTIVE_BURST_CHARS,
+    1,
+    10_000,
+  ),
+})
+
+export const createRuntimeTelemetry = (): RuntimeTelemetry => ({
+  statusTransitions: 0,
+  suppressedTransitions: 0,
+  illegalTransitions: 0,
+  markdownFlushes: 0,
+  thinkingUpdates: 0,
+  adaptiveCadenceAdjustments: 0,
+})
+
+export const bumpTelemetry = (
+  telemetry: RuntimeTelemetry,
+  key: keyof RuntimeTelemetry,
+  by = 1,
+): RuntimeTelemetry => ({ ...telemetry, [key]: telemetry[key] + by })
+
+export const defaultActivityLabel = (primary: ActivityPrimary): string => PRIMARY_LABELS[primary]
+
+export const isLegalActivityTransition = (from: ActivityPrimary, to: ActivityPrimary): boolean =>
+  LEGAL_TRANSITIONS[from].includes(to)
+
+export const activityPriority = (primary: ActivityPrimary): number => PRIMARY_PRIORITY[primary]
+
+export const createActivitySnapshot = (
+  primary: ActivityPrimary,
+  now = Date.now(),
+  seq = 0,
+): ActivitySnapshot => ({
+  primary,
+  label: defaultActivityLabel(primary),
+  detail: null,
+  updatedAt: now,
+  displayedAt: now,
+  seq,
+})
+
+const detailsEqual = (a?: ActivityDetail | null, b?: ActivityDetail | null): boolean =>
+  (a?.message ?? null) === (b?.message ?? null) &&
+  (a?.eventType ?? null) === (b?.eventType ?? null) &&
+  (a?.source ?? null) === (b?.source ?? null)
+
+export const reduceActivityTransition = (
+  current: ActivitySnapshot,
+  input: ActivityTransitionInput,
+  flags: RuntimeBehaviorFlags,
+): ActivityTransitionResult => {
+  if (!flags.activityEnabled) {
+    return { snapshot: current, applied: false, reason: "disabled" }
+  }
+  const now = typeof input.now === "number" && Number.isFinite(input.now) ? input.now : Date.now()
+  const detail: ActivityDetail | null =
+    input.detail ?? input.source ?? input.eventType
+      ? {
+          ...(input.detail ?? {}),
+          ...(input.source ? { source: input.source } : {}),
+          ...(input.eventType ? { eventType: input.eventType } : {}),
+        }
+      : null
+  const nextLabel = input.label?.trim() || defaultActivityLabel(input.to)
+  if (current.primary === input.to && current.label === nextLabel && detailsEqual(current.detail, detail)) {
+    return { snapshot: current, applied: false, reason: "same" }
+  }
+  if (!isLegalActivityTransition(current.primary, input.to)) {
+    return { snapshot: current, applied: false, reason: "illegal" }
+  }
+  const elapsed = Math.max(0, now - current.displayedAt)
+  const incomingPriority = activityPriority(input.to)
+  const currentPriority = activityPriority(current.primary)
+  const terminalStates: ActivityPrimary[] = ["completed", "halted", "cancelled", "error"]
+  const leavingTerminal = terminalStates.includes(current.primary) && !terminalStates.includes(input.to)
+  const resumingAfterPermission =
+    current.primary === "permission_resolved" &&
+    (input.to === "thinking" || input.to === "responding" || input.to === "tool_call")
+  const resumingAfterReconnect =
+    current.primary === "reconnecting" &&
+    (input.to === "thinking" || input.to === "responding" || input.to === "run")
+  const resumingAfterCompaction =
+    current.primary === "compacting" &&
+    (input.to === "session" || input.to === "run" || input.to === "thinking" || input.to === "responding")
+  if (
+    !leavingTerminal &&
+    !resumingAfterPermission &&
+    !resumingAfterReconnect &&
+    !resumingAfterCompaction &&
+    elapsed < flags.minDisplayMs &&
+    incomingPriority <= currentPriority
+  ) {
+    return { snapshot: current, applied: false, reason: "hysteresis" }
+  }
+  return {
+    snapshot: {
+      primary: input.to,
+      label: nextLabel,
+      detail,
+      updatedAt: now,
+      displayedAt: now,
+      seq: current.seq + 1,
+    },
+    applied: true,
+    reason: "applied",
+  }
+}
+
+const truncateByLines = (text: string, maxLines: number): { text: string; truncated: boolean } => {
+  const lines = text.split(/\r?\n/)
+  if (lines.length <= maxLines) return { text, truncated: false }
+  return { text: lines.slice(0, maxLines).join("\n"), truncated: true }
+}
+
+const truncateByChars = (text: string, maxChars: number): { text: string; truncated: boolean } => {
+  if (text.length <= maxChars) return { text, truncated: false }
+  return { text: `${text.slice(0, Math.max(0, maxChars - 1))}…`, truncated: true }
+}
+
+export const createThinkingArtifact = (
+  mode: ThinkingMode,
+  now = Date.now(),
+  id?: string,
+): ThinkingArtifact => ({
+  id: id ?? `thinking-${now.toString(36)}`,
+  mode,
+  startedAt: now,
+  updatedAt: now,
+  finalizedAt: null,
+  summary: "",
+  rawText: mode === "full" ? "" : null,
+  summaryTruncated: false,
+  rawTruncated: false,
+  sourceEventTypes: [],
+})
+
+export const appendThinkingArtifact = (
+  artifact: ThinkingArtifact,
+  signal: ThinkingSignal,
+  flags: RuntimeBehaviorFlags,
+  now = Date.now(),
+): ThinkingArtifact => {
+  const baseSummary = artifact.summary ? `${artifact.summary}\n${signal.text}` : signal.text
+  const lineSummary = truncateByLines(baseSummary, flags.thinkingMaxLines)
+  const charSummary = truncateByChars(lineSummary.text, flags.thinkingMaxChars)
+  const nextSummary = charSummary.text
+  const nextRaw =
+    artifact.mode === "full"
+      ? (() => {
+          const rawBase = `${artifact.rawText ?? ""}${signal.text}`
+          const rawTrim = truncateByChars(rawBase, flags.thinkingMaxChars * 4)
+          return { text: rawTrim.text, truncated: rawTrim.truncated }
+        })()
+      : { text: null as string | null, truncated: false }
+  return {
+    ...artifact,
+    updatedAt: now,
+    summary: nextSummary,
+    summaryTruncated: Boolean(artifact.summaryTruncated || lineSummary.truncated || charSummary.truncated),
+    rawText: nextRaw.text,
+    rawTruncated: Boolean(artifact.rawTruncated || nextRaw.truncated),
+    sourceEventTypes: [...(artifact.sourceEventTypes ?? []), signal.eventType].slice(-20),
+  }
+}
+
+export const finalizeThinkingArtifact = (artifact: ThinkingArtifact, now = Date.now()): ThinkingArtifact => ({
+  ...artifact,
+  updatedAt: now,
+  finalizedAt: now,
+})
+
+export const normalizeThinkingSignal = (eventType: string, payload: unknown): ThinkingSignal | null => {
+  const obj = isRecord(payload) ? payload : {}
+  const delta =
+    extractRawString(obj, ["delta", "text", "summary", "thought_summary"]) ??
+    (typeof obj.reasoning === "string" ? obj.reasoning : undefined)
+  if (!delta || !delta.trim()) return null
+  const kind = eventType.includes("thought_summary") ? "summary" : "delta"
+  return {
+    kind,
+    text: delta,
+    eventType,
+  }
+}

--- a/tui_skeleton/src/commands/repl/controllerStateMethods.ts
+++ b/tui_skeleton/src/commands/repl/controllerStateMethods.ts
@@ -1,3 +1,65 @@
+import { ApiError } from "../../api/client.js"
+import type { SessionEvent } from "../../api/types.js"
+import type { SessionFileInfo } from "../../api/types.js"
+import { BRAND_COLORS, resolveIcons } from "../../repl/designSystem.js"
+import { SLASH_COMMANDS } from "../../repl/slashCommands.js"
+import { computeDiffPreview } from "../../repl/transcriptUtils.js"
+import type {
+  CheckpointSummary,
+  ConversationEntry,
+  CTreeSnapshot,
+  LiveSlotStatus,
+  PermissionDecision,
+  PermissionRequest,
+  PermissionRuleScope,
+  TaskEntry,
+  TodoItem,
+  ToolDisplayPayload,
+  ToolLogEntry,
+  ToolLogKind,
+} from "../../repl/types.js"
+import {
+  MAX_HINTS,
+  MAX_RAW_EVENTS,
+  MAX_RAW_EVENT_CHARS,
+  MAX_TOOL_EXEC_OUTPUT,
+  MAX_TOOL_HISTORY,
+  createSlotId,
+  extractProgress,
+  extractString,
+  extractUsageMetrics,
+  isRecord,
+  numberOrUndefined,
+  parseTodoEntry,
+  parseTodoList,
+  tryParseJsonTodos,
+} from "./controllerUtils.js"
+import { formatActivityTransitionTimeline } from "./controllerTransitionTimeline.js"
+
+type SlashHandler = (args: string[]) => Promise<void>
+
+const normalizeTaskStatus = (rawStatus?: string | null, rawKind?: string | null): string | null => {
+  const seed = (rawStatus ?? rawKind ?? "").toLowerCase()
+  if (!seed) return rawStatus ?? rawKind ?? null
+  if (seed.includes("complete") || seed.includes("done") || seed.includes("success")) return "completed"
+  if (seed.includes("error") || seed.includes("fail")) return "failed"
+  if (seed.includes("cancel") || seed.includes("stop")) return "stopped"
+  if (seed.includes("start") || seed.includes("run") || seed.includes("progress")) return "running"
+  return rawStatus ?? rawKind ?? null
+}
+
+const clampLines = (text: string, maxLines: number): string => {
+  const lines = text.split(/\r?\n/)
+  if (lines.length <= maxLines) return text
+  return `${lines.slice(0, maxLines).join("\n")}…`
+}
+
+const clampChars = (text: string, maxChars: number): string =>
+  text.length <= maxChars ? text : `${text.slice(0, Math.max(0, maxChars - 1))}…`
+
+const formatThinkingPreview = (raw: string, maxLines: number, maxChars: number): string =>
+  clampChars(clampLines(raw, maxLines), maxChars)
+
 export function slashHandlers(this: any): Record<string, SlashHandler> {
   return {
     quit: async () => {
@@ -249,17 +311,87 @@ export function slashHandlers(this: any): Record<string, SlashHandler> {
           return
         }
         const enabled = value === "on"
+        const fullAllowed = this.runtimeFlags?.allowFullThinking === true
+        if (enabled && !fullAllowed) {
+          this.updateViewPrefs(
+            { showReasoning: enabled },
+            "Reasoning set to summary mode. Enable BREADBOARD_THINKING_FULL_OPT_IN=1 to allow full reasoning output.",
+          )
+          return
+        }
         this.updateViewPrefs({ showReasoning: enabled }, `Reasoning stream ${enabled ? "enabled" : "disabled"}.`)
         return
       }
       this.pushHint("Usage: /view collapse <auto|all|none>, /view scroll <auto|compact>, /view markdown <on|off>, /view raw <on|off>, /view tools <rail|inline|both|off>, /view reasoning <on|off>.")
+    },
+    thinking: async (args) => {
+      const mode = args[0]?.toLowerCase()
+      if (mode && !["summary", "raw"].includes(mode)) {
+        this.pushHint("Usage: /thinking [summary|raw].")
+        return
+      }
+      const artifact = this.thinkingArtifact
+      if (!artifact) {
+        this.pushHint("No thinking artifact available yet.")
+        return
+      }
+      const maxLines = Math.max(1, Number(this.runtimeFlags?.thinkingMaxLines ?? 6))
+      const maxChars = Math.max(32, Number(this.runtimeFlags?.thinkingMaxChars ?? 600))
+      const lines: string[] = []
+      lines.push(
+        `[thinking] mode=${artifact.mode} finalized=${artifact.finalizedAt ? "yes" : "no"} updates=${artifact.sourceEventTypes?.length ?? 0}`,
+      )
+      const summary = artifact.summary?.trim().length > 0 ? artifact.summary : "(empty summary)"
+      lines.push(formatThinkingPreview(summary, maxLines, maxChars))
+      if (mode === "raw") {
+        const rawAllowed =
+          artifact.mode === "full" &&
+          this.runtimeFlags?.allowFullThinking === true &&
+          this.runtimeFlags?.allowRawThinkingPeek === true
+        const rawText = typeof artifact.rawText === "string" ? artifact.rawText.trim() : ""
+        if (rawAllowed && rawText.length > 0) {
+          lines.push("[raw]")
+          lines.push(formatThinkingPreview(rawText, maxLines * 2, maxChars))
+        } else {
+          this.pushHint(
+            "Raw thinking unavailable (requires full mode + BREADBOARD_THINKING_FULL_OPT_IN=1 + BREADBOARD_THINKING_PEEK_RAW_ALLOWED=1).",
+          )
+        }
+      }
+      this.addTool("status", lines.join("\n"), "success")
+      this.pushHint("Thinking artifact shown.")
+    },
+    runtime: async (args) => {
+      const mode = (args[0] ?? "telemetry").toLowerCase()
+      if (!["telemetry", "status"].includes(mode)) {
+        this.pushHint("Usage: /runtime [telemetry].")
+        return
+      }
+      const telemetry = this.runtimeTelemetry ?? {}
+      const activity = this.activity?.primary ?? "idle"
+      const thinkingMode =
+        this.runtimeFlags?.thinkingEnabled === false
+          ? "off"
+          : this.thinkingArtifact?.mode ??
+            (this.viewPrefs?.showReasoning && this.runtimeFlags?.allowFullThinking === true ? "full" : "summary")
+      const timeline = formatActivityTransitionTimeline(this.activityTransitionTrace ?? [], 10)
+      const lines = [
+        `[runtime] activity=${activity} thinking=${thinkingMode}`,
+        `flags inlineThinkingBlock=${this.runtimeFlags?.inlineThinkingBlockEnabled === true ? "on" : "off"} adaptiveCadence=${this.runtimeFlags?.adaptiveMarkdownCadenceEnabled === true ? "on" : "off"}`,
+        `statusTransitions=${telemetry.statusTransitions ?? 0} suppressedTransitions=${telemetry.suppressedTransitions ?? 0} illegalTransitions=${telemetry.illegalTransitions ?? 0}`,
+        `markdownFlushes=${telemetry.markdownFlushes ?? 0} thinkingUpdates=${telemetry.thinkingUpdates ?? 0} adaptiveCadenceAdjustments=${telemetry.adaptiveCadenceAdjustments ?? 0}`,
+        "[timeline]",
+        timeline,
+      ]
+      this.addTool("status", lines.join("\n"), "success")
+      this.pushHint("Runtime telemetry shown.")
     },
     files: async (args) => {
       const scope = args[0] ?? "."
       try {
         const files = await this.api().listSessionFiles(this.sessionId, scope === "." ? undefined : scope)
         const output = files
-          .map((file) => `${file.type.padEnd(4, " ")} ${file.path}${file.size != null ? ` ${file.size}` : ""}`)
+          .map((file: SessionFileInfo) => `${file.type.padEnd(4, " ")} ${file.path}${file.size != null ? ` ${file.size}` : ""}`)
           .join("\n")
         this.pushHint(`Files listed for ${scope === "." ? "(root)" : scope}.`)
         this.addTool("status", `[files]\n${output}`)
@@ -472,6 +604,10 @@ export function addConversation(this: any,
   text: string,
   phase: ConversationEntry["phase"] = "final",
 ): void {
+  const resolveEventTimestamp = (ctx: any): number => {
+    const seq = ctx.currentEventSeq
+    return typeof seq === "number" && Number.isFinite(seq) ? seq : Date.now()
+  }
   if (phase === "streaming") {
     this.setStreamingConversation(speaker, text)
     return
@@ -482,14 +618,18 @@ export function addConversation(this: any,
     speaker,
     text,
     phase: "final",
-    createdAt: Date.now(),
+    createdAt: resolveEventTimestamp(this),
   }
   this.conversation.push(entry)
 }
 
 export function setStreamingConversation(this: any, speaker: ConversationEntry["speaker"], text: string): void {
+  const resolveEventTimestamp = (ctx: any): number => {
+    const seq = ctx.currentEventSeq
+    return typeof seq === "number" && Number.isFinite(seq) ? seq : Date.now()
+  }
   if (this.streamingEntryId) {
-    const index = this.conversation.findIndex((entry) => entry.id === this.streamingEntryId)
+    const index = this.conversation.findIndex((entry: ConversationEntry) => entry.id === this.streamingEntryId)
     if (index >= 0) {
       const existing = this.conversation[index]
       this.conversation[index] = { ...existing, speaker, text, phase: "streaming" }
@@ -501,7 +641,7 @@ export function setStreamingConversation(this: any, speaker: ConversationEntry["
     speaker,
     text,
     phase: "streaming",
-    createdAt: Date.now(),
+    createdAt: resolveEventTimestamp(this),
   }
   this.conversation.push(entry)
   this.streamingEntryId = entry.id
@@ -510,7 +650,7 @@ export function setStreamingConversation(this: any, speaker: ConversationEntry["
 export function finalizeStreamingEntry(this: any): void {
   if (!this.streamingEntryId) return
   this.finalizeMarkdown(this.streamingEntryId)
-  const index = this.conversation.findIndex((entry) => entry.id === this.streamingEntryId)
+  const index = this.conversation.findIndex((entry: ConversationEntry) => entry.id === this.streamingEntryId)
   if (index >= 0) {
     const existing = this.conversation[index]
     if (existing.phase !== "final") {
@@ -533,7 +673,8 @@ export function upsertTask(this: any, entry: TaskEntry): void {
     updatedAt: entry.updatedAt || existing?.updatedAt || Date.now(),
   }
   this.taskMap.set(merged.id, merged)
-  this.tasks = Array.from(this.taskMap.values()).sort((a, b) => b.updatedAt - a.updatedAt)
+  const taskEntries = Array.from(this.taskMap.values()) as TaskEntry[]
+  this.tasks = taskEntries.sort((a, b) => b.updatedAt - a.updatedAt)
 }
 
 export function handleTaskEvent(this: any, payload: Record<string, unknown>): void {
@@ -591,23 +732,53 @@ export function trimToolHistory(this: any): void {
   }
 }
 
-export function addTool(this: any, 
+export function addTool(this: any,
   kind: ToolLogKind,
   text: string,
   status?: LiveSlotStatus,
-  options?: { callId?: string | null; insertAfterId?: string | null },
+  options?: { callId?: string | null; insertAfterId?: string | null; display?: ToolDisplayPayload | null },
 ): ToolLogEntry {
+  const resolveEventTimestamp = (ctx: any): number => {
+    const seq = ctx.currentEventSeq
+    return typeof seq === "number" && Number.isFinite(seq) ? seq : Date.now()
+  }
+  const insertAfterId = options?.insertAfterId ?? null
+  if (!insertAfterId && this.toolEvents.length > 0) {
+    const last = this.toolEvents[this.toolEvents.length - 1] as ToolLogEntry
+    const mergeableKind = kind === "call" || kind === "result"
+    const lastMergeable = last.kind === "call" || last.kind === "result"
+    const sameText = last.text === text
+    const nextHeader = text.split(/\r?\n/)[0]?.trim()
+    const lastHeader = last.text.split(/\r?\n/)[0]?.trim()
+    const sameHeader = Boolean(nextHeader && lastHeader && nextHeader === lastHeader)
+    const callId = options?.callId ?? null
+    const display = options?.display ?? null
+    const sameCall = callId && last.callId ? callId === last.callId : true
+    if (mergeableKind && lastMergeable && (sameText || sameHeader) && sameCall) {
+      const nextKind = kind === "result" || last.kind === "result" ? "result" : last.kind
+      const merged: ToolLogEntry = {
+        ...last,
+        kind: nextKind,
+        text,
+        status: status ?? last.status,
+        callId: last.callId ?? callId,
+        display: display ?? last.display ?? null,
+      }
+      this.toolEvents[this.toolEvents.length - 1] = merged
+      return merged
+    }
+  }
   const entry: ToolLogEntry = {
     id: createSlotId(),
     kind,
     text,
     status,
     callId: options?.callId ?? null,
-    createdAt: Date.now(),
+    display: options?.display ?? null,
+    createdAt: resolveEventTimestamp(this),
   }
-  const insertAfterId = options?.insertAfterId ?? null
   if (insertAfterId) {
-    const index = this.toolEvents.findIndex((item) => item.id === insertAfterId)
+    const index = this.toolEvents.findIndex((item: ToolLogEntry) => item.id === insertAfterId)
     if (index >= 0) {
       this.toolEvents.splice(index + 1, 0, entry)
     } else {
@@ -620,6 +791,24 @@ export function addTool(this: any,
   return entry
 }
 
+export function updateToolEntry(
+  this: any,
+  entryId: string,
+  patch: Partial<Omit<ToolLogEntry, "id" | "createdAt">>,
+): ToolLogEntry | null {
+  const index = this.toolEvents.findIndex((item: ToolLogEntry) => item.id === entryId)
+  if (index < 0) return null
+  const current = this.toolEvents[index] as ToolLogEntry
+  const next: ToolLogEntry = {
+    ...current,
+    ...patch,
+    id: current.id,
+    createdAt: current.createdAt,
+  }
+  this.toolEvents[index] = next
+  return next
+}
+
 export function formatToolSlot(this: any, payload: unknown): { text: string; color?: string; summary?: string } {
   const data = isRecord(payload) ? payload : {}
   const toolName = extractString(data, ["tool", "name", "command"]) ?? "Tool"
@@ -629,13 +818,168 @@ export function formatToolSlot(this: any, payload: unknown): { text: string; col
   return { text: `${toolName}: ${action}${progressText}`, color: BRAND_COLORS.duneOrange, summary: this.extractDiffSummary(payload) }
 }
 
+const normalizeDisplayLines = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value
+      .map((line) => (typeof line === "string" ? line.trimEnd() : ""))
+      .filter((line) => line.trim().length > 0)
+  }
+  if (typeof value === "string") {
+    return value
+      .split(/\r?\n/)
+      .map((line) => line.trimEnd())
+      .filter((line) => line.trim().length > 0)
+  }
+  return []
+}
+
+const TOOL_PREVIEW_MAX_LINES = 24
+
+const normalizeToolArgs = (
+  payload: Record<string, unknown>,
+): { name: string | null; args: Record<string, unknown> | null } => {
+  const toolRecord = isRecord(payload.tool) ? payload.tool : isRecord(payload.tool_call) ? payload.tool_call : null
+  const name =
+    extractString((toolRecord ?? {}) as Record<string, unknown>, ["name", "tool", "command"]) ??
+    extractString(payload, ["tool_name", "tool", "name", "command"]) ??
+    null
+  const args = isRecord(toolRecord?.args) ? toolRecord?.args : isRecord(payload.args) ? payload.args : null
+  return { name, args }
+}
+
+const normalizePreviewLines = (value: string): string[] => {
+  const normalized = value.replace(/\r\n?/g, "\n")
+  const lines = normalized.split("\n")
+  while (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop()
+  }
+  return lines
+}
+
+const truncatePreviewLines = (lines: string[], maxLines: number) => {
+  if (lines.length <= maxLines) return { lines, hidden: 0 }
+  return { lines: lines.slice(0, maxLines), hidden: lines.length - maxLines }
+}
+
+export function resolveToolDisplayPayload(this: any, payload: Record<string, unknown>): Record<string, unknown> | null {
+  const base = isRecord(payload.display) ? { ...payload.display } : {}
+  const { name, args } = normalizeToolArgs(payload)
+  const normalizedName = (name ?? "").toLowerCase()
+  const pathValue = typeof args?.path === "string" ? args.path.trim() : null
+
+  const ensureTitle = (prefix: string) => {
+    if (!base.title && pathValue) {
+      base.title = `${prefix}(${pathValue})`
+    }
+  }
+
+  const isWrite =
+    normalizedName === "write_file" ||
+    normalizedName === "write" ||
+    normalizedName === "write-file"
+  const isPatch =
+    normalizedName === "apply_patch" ||
+    normalizedName === "patch"
+
+  if (isWrite) {
+    ensureTitle("Write")
+    const content = typeof args?.content === "string" ? args.content : null
+    if (!base.detail && content) {
+      const rawLines = normalizePreviewLines(content)
+      const { lines, hidden } = truncatePreviewLines(rawLines, TOOL_PREVIEW_MAX_LINES)
+      base.detail = lines
+      if (hidden > 0 && !isRecord(base.detail_truncated)) {
+        base.detail_truncated = { hidden }
+      }
+      if (!base.summary) {
+        base.summary = `Wrote ${rawLines.length} ${rawLines.length === 1 ? "line" : "lines"}`
+      }
+    }
+  }
+
+  if (isPatch) {
+    ensureTitle("Patch")
+    const diff =
+      typeof args?.diff === "string"
+        ? args?.diff
+        : typeof args?.patch === "string"
+          ? args?.patch
+          : typeof args?.unified_diff === "string"
+            ? args?.unified_diff
+            : typeof args?.unified === "string"
+              ? args?.unified
+              : null
+    if (!Array.isArray(base.diff_blocks) || base.diff_blocks.length === 0) {
+      if (diff) {
+        const normalized = diff.replace(/(?:\r?\n)+$/, "")
+        base.diff_blocks = [
+          {
+            kind: "diff",
+            filePath: pathValue,
+            unified: normalized,
+          },
+        ]
+      }
+    }
+  }
+
+  return Object.keys(base).length > 0 ? base : null
+}
+
+export function formatToolDisplayText(this: any, payload: Record<string, unknown>): string {
+  const icons = resolveIcons()
+  const display = isRecord(payload.display) ? payload.display : null
+  const title =
+    extractString(display ?? {}, ["title"]) ??
+    extractString(payload, ["tool_name", "tool", "name"]) ??
+    "Tool"
+  const debugRule = extractString(display ?? {}, ["debug_rule_id"])
+  const titleWithDebug = debugRule ? `${title} ⟪${debugRule}⟫` : title
+  const summaryLines = normalizeDisplayLines(display ? display.summary : undefined)
+  const detailLines = normalizeDisplayLines(display ? display.detail : undefined)
+  const lines: string[] = [titleWithDebug]
+  const truncated = isRecord(display?.detail_truncated) ? display?.detail_truncated : null
+  const hiddenCount = truncated && typeof truncated.hidden === "number" ? truncated.hidden : null
+  const hint = truncated && typeof truncated.hint === "string" ? truncated.hint : null
+  const mode = truncated && typeof truncated.mode === "string" ? truncated.mode : null
+  const tailCount = truncated && typeof truncated.tail === "number" ? truncated.tail : null
+
+  const contentLines = detailLines.length > 0 ? detailLines.slice() : summaryLines.slice()
+  if (detailLines.length > 0 && hiddenCount && hiddenCount > 0) {
+    const summaryLine = `${icons.ellipsis} ${hiddenCount} lines hidden${hint ? ` — ${hint}` : ""}`
+    if (mode === "head_tail" && tailCount && tailCount > 0 && tailCount < contentLines.length) {
+      const head = contentLines.slice(0, contentLines.length - tailCount)
+      const tail = contentLines.slice(-tailCount)
+      contentLines.length = 0
+      contentLines.push(...head, summaryLine, ...tail)
+    } else {
+      contentLines.push(summaryLine)
+    }
+  }
+  if (contentLines.length > 0) {
+    contentLines.forEach((line, index) => {
+      const prefix = index === contentLines.length - 1 ? icons.treeBranch : icons.verticalLine
+      lines.push(`${prefix} ${line}`)
+    })
+  }
+  return lines.join("\n")
+}
+
 export function resolveToolCallId(this: any, payload: Record<string, unknown>): string | null {
-  return (
+  const direct =
     extractString(payload, ["tool_call_id", "toolCallId"]) ??
     extractString(payload, ["call_id", "callId"]) ??
-    extractString(payload, ["id"]) ??
-    null
-  )
+    extractString(payload, ["id"])
+  if (direct) return direct
+  const nestedToolCall = isRecord(payload.tool_call) ? payload.tool_call : isRecord(payload.toolCall) ? payload.toolCall : null
+  if (nestedToolCall) {
+    return (
+      extractString(nestedToolCall, ["tool_call_id", "toolCallId"]) ??
+      extractString(nestedToolCall, ["call_id", "callId", "id"]) ??
+      null
+    )
+  }
+  return null
 }
 
 export function appendToolCallArgs(this: any, callId: string, delta: string): string {

--- a/tui_skeleton/src/commands/repl/controllerStateRender.ts
+++ b/tui_skeleton/src/commands/repl/controllerStateRender.ts
@@ -1,15 +1,131 @@
 import type { Block } from "@stream-mdx/core/types"
 import { MarkdownStreamer } from "../../markdown/streamer.js"
+import { scanStableBoundary } from "../../repl/markdown/stableBoundaryScanner.js"
 import type {
   ConversationEntry,
   LiveSlotEntry,
   LiveSlotStatus,
   TranscriptPreferences,
 } from "../../repl/types.js"
-import type { ReplSessionController } from "./controller.js"
+
+const parseBoolEnv = (value: string | undefined, fallback: boolean): boolean => {
+  if (value == null) return fallback
+  const normalized = value.trim().toLowerCase()
+  if (!normalized) return fallback
+  if (["1", "true", "yes", "on"].includes(normalized)) return true
+  if (["0", "false", "no", "off"].includes(normalized)) return false
+  return fallback
+}
+
+const STREAM_MARKDOWN = parseBoolEnv(process.env.BREADBOARD_MARKDOWN_STREAM, true)
+const DEFAULT_MARKDOWN_MIN_CHUNK_CHARS = 24
+const ENV_MARKDOWN_COALESCE_MS = Number(process.env.BREADBOARD_MARKDOWN_COALESCE_MS ?? "")
+const ENV_MARKDOWN_MIN_CHUNK = Number(process.env.BREADBOARD_MARKDOWN_MIN_CHUNK_CHARS ?? "")
 
 export function shouldStreamMarkdown(this: any): boolean {
-  return this.viewPrefs.richMarkdown && !this.markdownGloballyDisabled
+  const coalescingEnabled =
+    this.runtimeFlags?.markdownCoalescingEnabled === undefined
+      ? true
+      : Boolean(this.runtimeFlags?.markdownCoalescingEnabled)
+  return STREAM_MARKDOWN && coalescingEnabled && this.viewPrefs.richMarkdown
+}
+
+const LIVE_TOKENIZATION = process.env.BREADBOARD_STREAM_MDX_LIVE_TOKENS === "1"
+
+const resolveCadence = (controller: any): { coalesceMs: number; minChunkChars: number } => {
+  const fromFlags = Number(controller.runtimeFlags?.statusUpdateMs ?? 120)
+  const coalesceMs = Number.isFinite(ENV_MARKDOWN_COALESCE_MS)
+    ? Math.max(0, Math.round(ENV_MARKDOWN_COALESCE_MS))
+    : Math.max(0, Math.round(fromFlags))
+  const minChunkChars = Number.isFinite(ENV_MARKDOWN_MIN_CHUNK)
+    ? Math.max(1, Math.round(ENV_MARKDOWN_MIN_CHUNK))
+    : DEFAULT_MARKDOWN_MIN_CHUNK_CHARS
+  return { coalesceMs, minChunkChars }
+}
+
+const hasMarkdownBoundary = (delta: string): boolean => {
+  if (!delta) return false
+  if (delta.includes("\n")) return true
+  if (delta.includes("```") || delta.includes("~~~")) return true
+  if (/\|\s*[-:]/.test(delta)) return true
+  if (/^\s*[-*+]\s/m.test(delta)) return true
+  return false
+}
+
+const resolveAdaptiveCadence = (
+  controller: any,
+  base: { coalesceMs: number; minChunkChars: number },
+  delta: string,
+): { coalesceMs: number; minChunkChars: number; adjusted: boolean } => {
+  if (controller.runtimeFlags?.adaptiveMarkdownCadenceEnabled !== true) {
+    return { ...base, adjusted: false }
+  }
+  const minChunkFloor = Math.max(1, Number(controller.runtimeFlags?.adaptiveMarkdownMinChunkChars ?? 8))
+  const minCoalesceFloor = Math.max(0, Number(controller.runtimeFlags?.adaptiveMarkdownMinCoalesceMs ?? 12))
+  const burstChars = Math.max(1, Number(controller.runtimeFlags?.adaptiveMarkdownBurstChars ?? 48))
+  const boundaryBoost = hasMarkdownBoundary(delta)
+  const burstBoost = delta.length >= burstChars
+  let minChunkChars = base.minChunkChars
+  let coalesceMs = base.coalesceMs
+  if (boundaryBoost) {
+    minChunkChars = Math.min(minChunkChars, minChunkFloor)
+    coalesceMs = Math.min(coalesceMs, minCoalesceFloor)
+  }
+  if (burstBoost) {
+    minChunkChars = Math.min(minChunkChars, Math.max(minChunkFloor, Math.floor(base.minChunkChars / 2)))
+    coalesceMs = Math.min(coalesceMs, minCoalesceFloor)
+  }
+  const adjusted = minChunkChars !== base.minChunkChars || coalesceMs !== base.coalesceMs
+  return { coalesceMs, minChunkChars, adjusted }
+}
+
+const clearMarkdownQueueTimer = (controller: any, entryId: string): void => {
+  const state = controller.markdownPendingDeltas.get(entryId)
+  if (state?.timer) {
+    clearTimeout(state.timer)
+    state.timer = null
+  }
+}
+
+const flushMarkdownQueue = (controller: any, entryId: string): void => {
+  const pending = controller.markdownPendingDeltas.get(entryId)
+  if (!pending || !pending.buffer) return
+  const stream = controller.markdownStreams.get(entryId)
+  if (!stream) {
+    pending.buffer = ""
+    return
+  }
+  const chunk = pending.buffer
+  pending.buffer = ""
+  stream.streamer.append(chunk)
+  controller.bumpRuntimeTelemetry?.("markdownFlushes")
+}
+
+const queueMarkdownDelta = (controller: any, entryId: string, delta: string): void => {
+  const baseCadence = resolveCadence(controller)
+  const cadence = resolveAdaptiveCadence(controller, baseCadence, delta)
+  if (cadence.adjusted) {
+    controller.bumpRuntimeTelemetry?.("adaptiveCadenceAdjustments")
+  }
+  const pending =
+    controller.markdownPendingDeltas.get(entryId) ??
+    (() => {
+      const seed = { buffer: "", timer: null as NodeJS.Timeout | null }
+      controller.markdownPendingDeltas.set(entryId, seed)
+      return seed
+    })()
+  pending.buffer += delta
+  if (pending.buffer.length >= cadence.minChunkChars || cadence.coalesceMs <= 0) {
+    clearMarkdownQueueTimer(controller, entryId)
+    flushMarkdownQueue(controller, entryId)
+    return
+  }
+  if (!pending.timer) {
+    pending.timer = setTimeout(() => {
+      clearMarkdownQueueTimer(controller, entryId)
+      flushMarkdownQueue(controller, entryId)
+    }, cadence.coalesceMs)
+  }
 }
 
 export function ensureMarkdownStreamer(
@@ -19,7 +135,16 @@ export function ensureMarkdownStreamer(
   if (!this.shouldStreamMarkdown()) return null
   const existing = this.markdownStreams.get(entryId)
   if (existing) return existing
-  const streamer = new MarkdownStreamer()
+  const streamer = new MarkdownStreamer({
+    docPlugins: {
+      codeHighlighting: LIVE_TOKENIZATION ? "incremental" : "final",
+      outputMode: "tokens",
+      emitHighlightTokens: true,
+      emitDiffBlocks: true,
+      liveTokenization: LIVE_TOKENIZATION,
+      liveCodeHighlighting: false,
+    },
+  })
   streamer.subscribe((blocks, meta) => this.applyMarkdownBlocks(entryId, blocks, meta?.error ?? null, meta?.finalized ?? false))
   streamer.initialize()
   const state = { streamer, lastText: "" }
@@ -34,9 +159,7 @@ export function appendMarkdownChunk(this: any, text: string): void {
   if (!state) return
   const previous = state.lastText
   const delta = text.startsWith(previous) ? text.slice(previous.length) : text
-  state.lastText = previous + delta
-  state.streamer.append(delta)
-  this.markEntryMarkdownStreaming(entryId, true)
+  this.appendMarkdownDelta(delta)
 }
 
 export function appendMarkdownDelta(this: any, delta: string): void {
@@ -45,24 +168,75 @@ export function appendMarkdownDelta(this: any, delta: string): void {
   const entryId = this.streamingEntryId
   const state = this.ensureMarkdownStreamer(entryId)
   if (!state) return
-  state.lastText += delta
-  state.streamer.append(delta)
+  const stableSeed =
+    this.markdownStableState.get(entryId) ??
+    ({
+      fullText: state.lastText ?? "",
+      emittedLen: (state.lastText ?? "").length,
+      stableBoundaryLen: (state.lastText ?? "").length,
+      state: { inFence: false, fenceMarker: null, inList: false, inTable: false },
+    } as const)
+  const fullText = `${stableSeed.fullText}${delta}`
+  const scan = scanStableBoundary(fullText, stableSeed.state)
+  const emitTarget = Math.max(stableSeed.emittedLen, scan.stableBoundaryLen)
+  const stableDelta = emitTarget > stableSeed.emittedLen ? fullText.slice(stableSeed.emittedLen, emitTarget) : ""
+  this.markdownStableState.set(entryId, {
+    fullText,
+    emittedLen: emitTarget,
+    stableBoundaryLen: scan.stableBoundaryLen,
+    state: scan.state,
+  })
+  state.lastText = fullText.slice(0, emitTarget)
+  if (stableDelta) queueMarkdownDelta(this, entryId, stableDelta)
   this.markEntryMarkdownStreaming(entryId, true)
 }
 
 export function finalizeMarkdown(this: any, entryId: string | null): void {
   if (!entryId) return
+  const stable = this.markdownStableState.get(entryId)
+  if (stable && stable.fullText.length > stable.emittedLen) {
+    const tailDelta = stable.fullText.slice(stable.emittedLen)
+    if (tailDelta) queueMarkdownDelta(this, entryId, tailDelta)
+  }
+  clearMarkdownQueueTimer(this, entryId)
+  flushMarkdownQueue(this, entryId)
+  this.markdownPendingDeltas.delete(entryId)
+  this.markdownStableState.delete(entryId)
   const state = this.markdownStreams.get(entryId)
   if (!state) return
   state.streamer.finalize()
-  const blocks = [...state.streamer.getBlocks()]
-  const error = state.streamer.getError()
-  state.streamer.dispose()
-  this.markdownStreams.delete(entryId)
-  this.applyMarkdownBlocks(entryId, blocks, error ?? null, true)
+  const start = Date.now()
+  const maxWaitMs = 1500
+  const poll = () => {
+    const active = this.markdownStreams.get(entryId)
+    if (!active || active !== state) return
+    const blocks = [...active.streamer.getBlocks()]
+    const error = active.streamer.getError()
+    const allFinal = blocks.length > 0 && blocks.every((block) => block.isFinalized)
+    if (error || allFinal || Date.now() - start >= maxWaitMs) {
+      active.streamer.dispose()
+      this.markdownStreams.delete(entryId)
+      this.applyMarkdownBlocks(entryId, blocks, error ?? null, true)
+      return
+    }
+    setTimeout(poll, 50)
+  }
+  setTimeout(poll, 50)
 }
 
 export function disposeAllMarkdown(this: any): void {
+  for (const [entryId, stable] of this.markdownStableState.entries()) {
+    if (stable.fullText.length > stable.emittedLen) {
+      const tailDelta = stable.fullText.slice(stable.emittedLen)
+      if (tailDelta) queueMarkdownDelta(this, entryId, tailDelta)
+    }
+  }
+  for (const [entryId] of this.markdownPendingDeltas.entries()) {
+    clearMarkdownQueueTimer(this, entryId)
+    flushMarkdownQueue(this, entryId)
+  }
+  this.markdownPendingDeltas.clear()
+  this.markdownStableState.clear()
   for (const [entryId, state] of this.markdownStreams.entries()) {
     const blocks = [...state.streamer.getBlocks()]
     const error = state.streamer.getError()
@@ -79,7 +253,7 @@ export function applyMarkdownBlocks(
   error: string | null,
   finalized: boolean,
 ): void {
-  const index = this.conversation.findIndex((entry) => entry.id === entryId)
+  const index = this.conversation.findIndex((entry: ConversationEntry) => entry.id === entryId)
   if (index === -1) return
   const existing = this.conversation[index]
   const next: ConversationEntry = {
@@ -90,14 +264,13 @@ export function applyMarkdownBlocks(
   }
   this.conversation[index] = next
   if (error) {
-    this.markdownGloballyDisabled = true
-    this.pushHint(`Rich markdown disabled: ${error}`)
+    this.pushHint(`Rich markdown fallback on one entry: ${error}`)
   }
   if (!this.eventsScheduled) this.emitChange()
 }
 
 export function markEntryMarkdownStreaming(this: any, entryId: string, streaming: boolean): void {
-  const index = this.conversation.findIndex((entry) => entry.id === entryId)
+  const index = this.conversation.findIndex((entry: ConversationEntry) => entry.id === entryId)
   if (index === -1) return
   const existing = this.conversation[index]
   if (existing.markdownStreaming === streaming) return

--- a/tui_skeleton/src/commands/repl/providerCapabilityResolution.ts
+++ b/tui_skeleton/src/commands/repl/providerCapabilityResolution.ts
@@ -1,0 +1,186 @@
+export interface ReplProviderCapabilities {
+  reasoningEvents: boolean
+  thoughtSummaryEvents: boolean
+  contextUsage: boolean
+  activitySurface: boolean
+  rawThinkingPeek: boolean
+  inlineThinkingBlock: boolean
+}
+
+export interface ReplCapabilityOverrideSchema {
+  defaults?: Record<string, unknown>
+  presets?: Record<string, unknown>
+  providers?: Record<string, unknown>
+  models?: Record<string, unknown>
+}
+
+export interface CapabilityResolutionInput {
+  readonly modelId?: string | null
+  readonly preset?: string | null
+  readonly overrideSchema?: unknown
+  readonly runtimeOverrides?: Partial<ReplProviderCapabilities> | null
+}
+
+export interface CapabilityResolutionResult {
+  readonly provider: string
+  readonly model: string | null
+  readonly capabilities: ReplProviderCapabilities
+  readonly warnings: string[]
+}
+
+const KNOWN_CAPABILITY_KEYS = new Set<keyof ReplProviderCapabilities>([
+  "reasoningEvents",
+  "thoughtSummaryEvents",
+  "contextUsage",
+  "activitySurface",
+  "rawThinkingPeek",
+  "inlineThinkingBlock",
+])
+
+const BASE_CAPABILITIES: ReplProviderCapabilities = {
+  reasoningEvents: true,
+  thoughtSummaryEvents: true,
+  contextUsage: true,
+  activitySurface: true,
+  rawThinkingPeek: false,
+  inlineThinkingBlock: false,
+}
+
+const PRESET_CAPABILITIES: Record<string, Partial<ReplProviderCapabilities>> = {
+  claude_like: {
+    reasoningEvents: false,
+    thoughtSummaryEvents: true,
+    contextUsage: true,
+    activitySurface: true,
+    rawThinkingPeek: false,
+    inlineThinkingBlock: false,
+  },
+  codex_like: {
+    reasoningEvents: true,
+    thoughtSummaryEvents: true,
+    contextUsage: true,
+    activitySurface: true,
+    rawThinkingPeek: false,
+    inlineThinkingBlock: true,
+  },
+}
+
+const PROVIDER_CAPABILITIES: Record<string, Partial<ReplProviderCapabilities>> = {
+  anthropic: {
+    reasoningEvents: false,
+    thoughtSummaryEvents: true,
+    inlineThinkingBlock: false,
+  },
+  openai: {
+    reasoningEvents: true,
+    thoughtSummaryEvents: true,
+    inlineThinkingBlock: true,
+  },
+  openrouter: {
+    reasoningEvents: true,
+    thoughtSummaryEvents: true,
+    inlineThinkingBlock: true,
+  },
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value != null && typeof value === "object" && !Array.isArray(value)
+
+const sanitizePatch = (
+  patch: unknown,
+  path: string,
+  warnings: string[],
+): Partial<ReplProviderCapabilities> => {
+  if (!isRecord(patch)) {
+    if (patch != null) warnings.push(`${path} must be an object; ignoring invalid override.`)
+    return {}
+  }
+  const next: Partial<ReplProviderCapabilities> = {}
+  for (const [key, value] of Object.entries(patch)) {
+    if (!KNOWN_CAPABILITY_KEYS.has(key as keyof ReplProviderCapabilities)) {
+      warnings.push(`${path}.${key} is unknown; ignoring key.`)
+      continue
+    }
+    if (typeof value !== "boolean") {
+      warnings.push(`${path}.${key} must be boolean; ignoring invalid value.`)
+      continue
+    }
+    next[key as keyof ReplProviderCapabilities] = value
+  }
+  return next
+}
+
+const parseSchema = (
+  input: unknown,
+): { schema: ReplCapabilityOverrideSchema; warnings: string[] } => {
+  const warnings: string[] = []
+  if (!isRecord(input)) {
+    if (input != null) warnings.push("overrideSchema must be an object; ignoring invalid schema.")
+    return { schema: {}, warnings }
+  }
+  const schema: ReplCapabilityOverrideSchema = {}
+  if (isRecord(input.defaults)) schema.defaults = input.defaults
+  else if (input.defaults != null) warnings.push("overrideSchema.defaults must be an object.")
+  if (isRecord(input.presets)) schema.presets = input.presets
+  else if (input.presets != null) warnings.push("overrideSchema.presets must be an object.")
+  if (isRecord(input.providers)) schema.providers = input.providers
+  else if (input.providers != null) warnings.push("overrideSchema.providers must be an object.")
+  if (isRecord(input.models)) schema.models = input.models
+  else if (input.models != null) warnings.push("overrideSchema.models must be an object.")
+  return { schema, warnings }
+}
+
+const parseModelIdentity = (modelId?: string | null): { provider: string; model: string | null } => {
+  const trimmed = (modelId ?? "").trim()
+  if (!trimmed) return { provider: "unknown", model: null }
+  const slash = trimmed.indexOf("/")
+  if (slash <= 0) return { provider: "unknown", model: trimmed }
+  return {
+    provider: trimmed.slice(0, slash).trim().toLowerCase() || "unknown",
+    model: trimmed,
+  }
+}
+
+export const resolveProviderCapabilities = (input: CapabilityResolutionInput): CapabilityResolutionResult => {
+  const identity = parseModelIdentity(input.modelId)
+  const presetName = (input.preset ?? "").trim().toLowerCase()
+  const { schema, warnings } = parseSchema(input.overrideSchema)
+
+  const defaultsPatch = sanitizePatch(schema.defaults, "defaults", warnings)
+  const presetBuiltIn = presetName ? PRESET_CAPABILITIES[presetName] ?? {} : {}
+  const presetCustom = presetName && schema.presets ? sanitizePatch(schema.presets[presetName], `presets.${presetName}`, warnings) : {}
+  if (
+    presetName &&
+    PRESET_CAPABILITIES[presetName] == null &&
+    !(schema.presets && isRecord(schema.presets[presetName]))
+  ) {
+    warnings.push(`preset "${presetName}" is unknown; using default/provider/model/runtime layers.`)
+  }
+  const providerBuiltIn = PROVIDER_CAPABILITIES[identity.provider] ?? {}
+  const providerCustom = schema.providers
+    ? sanitizePatch(schema.providers[identity.provider], `providers.${identity.provider}`, warnings)
+    : {}
+  const modelCustom =
+    identity.model && schema.models
+      ? sanitizePatch(schema.models[identity.model], `models.${identity.model}`, warnings)
+      : {}
+  const runtimePatch = sanitizePatch(input.runtimeOverrides ?? {}, "runtimeOverrides", warnings)
+
+  const capabilities: ReplProviderCapabilities = {
+    ...BASE_CAPABILITIES,
+    ...defaultsPatch,
+    ...presetBuiltIn,
+    ...presetCustom,
+    ...providerBuiltIn,
+    ...providerCustom,
+    ...modelCustom,
+    ...runtimePatch,
+  }
+
+  return {
+    provider: identity.provider,
+    model: identity.model,
+    capabilities,
+    warnings,
+  }
+}

--- a/tui_skeleton/src/repl/__tests__/transcriptUtils.test.ts
+++ b/tui_skeleton/src/repl/__tests__/transcriptUtils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import {
+  INLINE_THINKING_MARKER,
+  isInlineThinkingBlockText,
+  shouldAutoCollapseEntry,
+  stripInlineThinkingMarker,
+} from "../transcriptUtils.js"
+
+describe("transcriptUtils inline thinking marker", () => {
+  it("detects and strips inline thinking marker payload", () => {
+    const text = `${INLINE_THINKING_MARKER}\nsummary: plan\nsummary: refine`
+    expect(isInlineThinkingBlockText(text)).toBe(true)
+    expect(stripInlineThinkingMarker(text)).toBe("summary: plan\nsummary: refine")
+  })
+
+  it("forces auto-collapse for inline thinking entries", () => {
+    const collapsible = shouldAutoCollapseEntry({
+      id: "conv-1",
+      speaker: "assistant",
+      text: `${INLINE_THINKING_MARKER}\nsummary: plan`,
+      phase: "final",
+      createdAt: 1,
+    })
+    expect(collapsible).toBe(true)
+  })
+})

--- a/tui_skeleton/src/repl/components/replView/controller/useReplViewScrollback.tsx
+++ b/tui_skeleton/src/repl/components/replView/controller/useReplViewScrollback.tsx
@@ -8,6 +8,7 @@ import { useToolRenderer } from "../renderers/toolRenderer.js"
 import { resolveDiffRenderStyle } from "../renderers/diffStyles.js"
 import { useConversationMeasure, useConversationRenderer } from "../renderers/conversationRenderer.js"
 import { sliceTailByLineBudget, trimTailByLineCount } from "../layout/windowing.js"
+import { isInlineThinkingBlockText } from "../../../transcriptUtils.js"
 import { CHALK, COLORS } from "../theme.js"
 import { formatCostUsd, formatLatency } from "../utils/format.js"
 import { useReplViewRenderNodes } from "./useReplViewRenderNodes.js"
@@ -487,7 +488,17 @@ export const useReplViewScrollback = (context: ScrollbackContext) => {
       }
     }
     if (viewPrefs.collapseMode === "none") {
-      for (const id of activeIds) {
+      for (const entry of collapsibleEntries as any[]) {
+        const id = String(entry.id ?? "")
+        if (!id) continue
+        const forcedCollapsed = typeof entry.text === "string" && isInlineThinkingBlockText(entry.text)
+        if (forcedCollapsed) {
+          if (!map.has(id)) {
+            map.set(id, true)
+            changed = true
+          }
+          continue
+        }
         if (map.get(id) !== false) {
           map.set(id, false)
           changed = true

--- a/tui_skeleton/src/repl/components/replView/renderers/conversationRenderer.tsx
+++ b/tui_skeleton/src/repl/components/replView/renderers/conversationRenderer.tsx
@@ -6,6 +6,7 @@ import {
   computeDiffPreview,
   ENTRY_COLLAPSE_HEAD,
   ENTRY_COLLAPSE_TAIL,
+  stripInlineThinkingMarker,
   shouldAutoCollapseEntry,
 } from "../../../transcriptUtils.js"
 import { blocksToLines, renderMarkdownFallbackLines } from "./markdown/streamMdxAdapter.js"
@@ -126,9 +127,10 @@ export const useConversationMeasure = (options: ConversationMeasureOptions) => {
     (entry: ConversationEntry): number => {
       const hasRichBlocks = Boolean(entry.richBlocks && entry.richBlocks.length > 0)
       const useRich = viewPrefs.richMarkdown && hasRichBlocks && !entry.markdownError
+      const normalizedText = stripInlineThinkingMarker(entry.text)
       const fallback = viewPrefs.richMarkdown
-        ? renderMarkdownFallbackLines(entry.text, { ...markdownRenderOptions, width: markdownWidth })
-        : entry.text.split(/\r?\n/)
+        ? renderMarkdownFallbackLines(normalizedText, { ...markdownRenderOptions, width: markdownWidth })
+        : normalizedText.split(/\r?\n/)
       const lines = (useRich
         ? blocksToLines(entry.richBlocks, { ...markdownRenderOptions, width: markdownWidth })
         : fallback) as string[]
@@ -212,7 +214,8 @@ export const useConversationRenderer = (options: ConversationRenderOptions) => {
     (entry: ConversationEntry, key?: string) => {
       const hasRichBlocks = Boolean(entry.richBlocks && entry.richBlocks.length > 0)
       const useRich = viewPrefs.richMarkdown && hasRichBlocks && !entry.markdownError
-      const rawText = entry.text.trim()
+      const normalizedText = stripInlineThinkingMarker(entry.text)
+      const rawText = normalizedText.trim()
       if (!hasRichBlocks && !entry.markdownError && (!rawText || rawText.toLowerCase() === "none")) {
         return null
       }
@@ -249,8 +252,8 @@ export const useConversationRenderer = (options: ConversationRenderOptions) => {
         </Text>
       )
       const fallback = viewPrefs.richMarkdown
-        ? renderMarkdownFallbackLines(entry.text, { ...markdownRenderOptions, width: markdownWidth })
-        : entry.text.split(/\r?\n/)
+        ? renderMarkdownFallbackLines(normalizedText, { ...markdownRenderOptions, width: markdownWidth })
+        : normalizedText.split(/\r?\n/)
       const lines = (useRich
         ? blocksToLines(entry.richBlocks, { ...markdownRenderOptions, width: markdownWidth })
         : fallback) as string[]

--- a/tui_skeleton/src/repl/markdown/__tests__/runtimeGateDashboardCli.test.ts
+++ b/tui_skeleton/src/repl/markdown/__tests__/runtimeGateDashboardCli.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, writeFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { spawnSync } from "node:child_process"
+import { describe, expect, it } from "vitest"
+
+const writeJson = (dir: string, name: string, value: unknown): string => {
+  const target = path.join(dir, name)
+  writeFileSync(target, `${JSON.stringify(value, null, 2)}\n`, "utf8")
+  return target
+}
+
+describe("runtime_gate_dashboard CLI", () => {
+  it("returns non-zero in strict mode when required artifacts are missing", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "bb-runtime-dashboard-"))
+    const result = spawnSync(
+      "node",
+      [
+        "--import",
+        "tsx",
+        "scripts/runtime_gate_dashboard.ts",
+        "--artifacts",
+        tmp,
+        "--strict",
+      ],
+      { cwd: path.resolve("."), encoding: "utf8" },
+    )
+    expect(result.status).toBe(1)
+  })
+
+  it("returns zero in strict mode when strict suite is confirmed and artifacts pass", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "bb-runtime-dashboard-"))
+    writeJson(tmp, "jitter_gate.json", {
+      ok: true,
+      summary: "ok",
+      comparison: { deltaPrefixChurn: 0, deltaReflowCount: 0 },
+      thresholds: { maxPrefixChurnDelta: 0, maxReflowDelta: 0 },
+    })
+    writeJson(tmp, "noise_gate.json", {
+      ok: true,
+      summary: "ok",
+      threshold: 0.8,
+      metrics: { ratio: 0.2, canonicalChars: 100, noiseChars: 20 },
+    })
+    writeJson(tmp, "noise_matrix.json", {
+      ok: true,
+      failCount: 0,
+      total: 2,
+      results: [],
+    })
+    const outJson = path.join(tmp, "dashboard.json")
+    const outMd = path.join(tmp, "dashboard.md")
+    const result = spawnSync(
+      "node",
+      [
+        "--import",
+        "tsx",
+        "scripts/runtime_gate_dashboard.ts",
+        "--artifacts",
+        tmp,
+        "--strict-tests-ok",
+        "--strict",
+        "--out",
+        outJson,
+        "--markdown-out",
+        outMd,
+      ],
+      { cwd: path.resolve("."), encoding: "utf8" },
+    )
+    expect(result.status).toBe(0)
+  })
+})

--- a/tui_skeleton/src/repl/markdown/__tests__/runtimeQuickTriageCli.test.ts
+++ b/tui_skeleton/src/repl/markdown/__tests__/runtimeQuickTriageCli.test.ts
@@ -1,0 +1,31 @@
+import { existsSync, mkdtempSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { spawnSync } from "node:child_process"
+import { describe, expect, it } from "vitest"
+
+describe("runtime_quick_triage_snapshots CLI", () => {
+  it("generates triage pack artifacts for fixture scenarios", () => {
+    const outDir = mkdtempSync(path.join(os.tmpdir(), "bb-runtime-triage-"))
+    const fixtures = [
+      "src/commands/repl/__tests__/fixtures/tool_call_result.jsonl",
+      "src/commands/repl/__tests__/fixtures/multi_turn_interleave.jsonl",
+    ].join(",")
+    const result = spawnSync(
+      "node",
+      [
+        "--import",
+        "tsx",
+        "scripts/runtime_quick_triage_snapshots.ts",
+        "--out-dir",
+        outDir,
+        "--fixtures",
+        fixtures,
+      ],
+      { cwd: path.resolve("."), encoding: "utf8" },
+    )
+    expect(result.status).toBe(0)
+    expect(existsSync(path.join(outDir, "index.json"))).toBe(true)
+    expect(existsSync(path.join(outDir, "_diffs", "index.json"))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- finalize optional thinking/streaming runtime improvements behind default-off flags
- add runtime gate dashboard JSON/Markdown generation and CI step summary wiring
- add runtime quick triage snapshot pack script and nightly artifact workflow
- add/update tests and docs for provider capability/runtime flag surface and gate CLI tools

## Verification
- npm run typecheck
- npm run runtime:gates:strict
- npm run runtime:gate:jitter -- --baseline ../artifacts/runtime_gates/jitter_baseline.json --candidate ../artifacts/runtime_gates/jitter_candidate.json --strict --out ../artifacts/runtime_gates/jitter_gate.json
- npm run runtime:gate:noise -- --fixture src/commands/repl/__tests__/fixtures/multi_turn_interleave.jsonl --threshold 2 --strict --out ../artifacts/runtime_gates/noise_gate.json
- npm run runtime:gate:noise:matrix -- --fixtures src/commands/repl/__tests__/fixtures/tool_call_result.jsonl,src/commands/repl/__tests__/fixtures/multi_turn_interleave.jsonl --threshold 100 --strict --out ../artifacts/runtime_gates/noise_matrix.json
- npm run runtime:gate:dashboard -- --artifacts ../artifacts/runtime_gates --strict-tests-ok --strict --out ../artifacts/runtime_gates/dashboard.json --markdown-out ../artifacts/runtime_gates/dashboard.md
- npm run runtime:triage:quick -- --out-dir ../artifacts/runtime_triage
