### PR TITLE
E2E Phase4: Tier-1 UI baselines strict canary + runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,8 +632,8 @@ jobs:
         working-directory: tui_skeleton
         run: npm run tui:goldens:report
 
-      - name: TUI goldens (report-only) summary
-        if: always()
+      - name: TUI goldens (report-only) summary (ubuntu only)
+        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
         run: |
           python - <<'PY'
           import glob, json, os

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -700,32 +700,44 @@ jobs:
               print("\n".join(lines))
 
           def summarize_lane(lane: str):
-              paths = sorted(glob.glob(f"tui_skeleton/ui_baselines/{lane}/_runs/run-*/_diffs/index.json"))
-              if not paths:
-                  append([f"### Tier-1 {lane} strict", "", f"- missing `tui_skeleton/ui_baselines/{lane}/_runs/run-*/_diffs/index.json`", ""])
-                  return
-              p = paths[-1]
-              with open(p, "r", encoding="utf-8") as f:
-                  data = json.load(f)
-              total = int(data.get(\"okCount\", 0)) + int(data.get(\"failCount\", 0))
-              append(
-                  [
-                      f\"### Tier-1 {lane} strict\",
-                      \"\",
-                      f\"- run: `{p.split('/_diffs/')[0]}`\",
-                      f\"- scenarios: `{total}`\",
-                      f\"- ok: `{data.get('okCount', 0)}`\",
-                      f\"- fail: `{data.get('failCount', 0)}`\",
-                      f\"- missing_blessed: `{data.get('missingBlessed', 0)}`\",
-                      f\"- missing_candidate: `{data.get('missingCandidate', 0)}`\",
-                      f\"- diff index: `{p}`\",
-                      \"\",
-                  ]
-              )
+              try:
+                  paths = sorted(glob.glob(f"tui_skeleton/ui_baselines/{lane}/_runs/run-*/_diffs/index.json"))
+                  if not paths:
+                      append(
+                          [
+                              f"### Tier-1 {lane} strict",
+                              "",
+                              f"- missing `tui_skeleton/ui_baselines/{lane}/_runs/run-*/_diffs/index.json`",
+                              "",
+                          ]
+                      )
+                      return
 
-          summarize_lane(\"u1\")
-          summarize_lane(\"u2\")
-          summarize_lane(\"u3\")
+                  p = paths[-1]
+                  with open(p, "r", encoding="utf-8") as f:
+                      data = json.load(f)
+
+                  total = int(data.get("okCount", 0)) + int(data.get("failCount", 0))
+                  append(
+                      [
+                          f"### Tier-1 {lane} strict",
+                          "",
+                          f"- run: `{p.split('/_diffs/')[0]}`",
+                          f"- scenarios: `{total}`",
+                          f"- ok: `{data.get('okCount', 0)}`",
+                          f"- fail: `{data.get('failCount', 0)}`",
+                          f"- missing_blessed: `{data.get('missingBlessed', 0)}`",
+                          f"- missing_candidate: `{data.get('missingCandidate', 0)}`",
+                          f"- diff index: `{p}`",
+                          "",
+                      ]
+                  )
+              except Exception as e:
+                  append([f"### Tier-1 {lane} strict", "", f"- summary error: `{type(e).__name__}: {e}`", ""])
+
+          summarize_lane("u1")
+          summarize_lane("u2")
+          summarize_lane("u3")
           PY
 
       - name: Upload TUI golden artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,19 +632,101 @@ jobs:
         working-directory: tui_skeleton
         run: npm run tui:goldens:report
 
+      - name: TUI goldens (report-only) summary
+        if: always()
+        run: |
+          python - <<'PY'
+          import glob, json, os
+
+          def append(lines):
+              summary = os.environ.get("GITHUB_STEP_SUMMARY")
+              if summary:
+                  with open(summary, "a", encoding="utf-8") as out:
+                      out.write("\n".join(lines) + "\n")
+              print("\n".join(lines))
+
+          paths = sorted(glob.glob("misc/tui_goldens/artifacts/run-*/_diffs/index.json"))
+          if not paths:
+              append(["### TUI goldens report-only", "", "- missing `misc/tui_goldens/artifacts/run-*/_diffs/index.json`", ""])
+              raise SystemExit(0)
+
+          p = paths[-1]
+          with open(p, "r", encoding="utf-8") as f:
+              data = json.load(f)
+
+          total = int(data.get("okCount", 0)) + int(data.get("failCount", 0))
+          append(
+              [
+                  "### TUI goldens report-only",
+                  "",
+                  f"- run: `{p.split('/_diffs/')[0]}`",
+                  f"- scenarios: `{total}`",
+                  f"- ok: `{data.get('okCount', 0)}`",
+                  f"- fail: `{data.get('failCount', 0)}`",
+                  f"- missing_blessed: `{data.get('missingBlessed', 0)}`",
+                  f"- missing_candidate: `{data.get('missingCandidate', 0)}`",
+                  f"- diff index: `{p}`",
+                  "",
+              ]
+          )
+          PY
+
       - name: Claude alignment (report-only)
         working-directory: tui_skeleton
         run: npm run claude:compare:report
 
-      - name: TUI goldens (strict gate, ubuntu only)
+      - name: Tier-1 UI baselines (strict gate, ubuntu only)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         working-directory: tui_skeleton
         run: |
-          if [ -f ../misc/tui_goldens/manifests/tui_goldens.yaml ]; then
-            npm run tui:goldens:strict
-          else
-            echo "Skipping strict TUI goldens gate: missing misc/tui_goldens/manifests/tui_goldens.yaml"
-          fi
+          unset NO_COLOR || true
+          export BREADBOARD_ASCII=0
+          export BREADBOARD_TUI_PRESET=breadboard_default
+          node --import tsx scripts/tui_u1_goldens_strict.ts
+          node --import tsx scripts/tui_u2_goldens_strict.ts
+          node --import tsx scripts/tui_u3_goldens_strict.ts
+
+      - name: Tier-1 UI baselines summary (ubuntu only)
+        if: ${{ always() && matrix.os == 'ubuntu-latest' }}
+        run: |
+          python - <<'PY'
+          import glob, json, os
+
+          def append(lines):
+              summary = os.environ.get("GITHUB_STEP_SUMMARY")
+              if summary:
+                  with open(summary, "a", encoding="utf-8") as out:
+                      out.write("\n".join(lines) + "\n")
+              print("\n".join(lines))
+
+          def summarize_lane(lane: str):
+              paths = sorted(glob.glob(f"tui_skeleton/ui_baselines/{lane}/_runs/run-*/_diffs/index.json"))
+              if not paths:
+                  append([f"### Tier-1 {lane} strict", "", f"- missing `tui_skeleton/ui_baselines/{lane}/_runs/run-*/_diffs/index.json`", ""])
+                  return
+              p = paths[-1]
+              with open(p, "r", encoding="utf-8") as f:
+                  data = json.load(f)
+              total = int(data.get(\"okCount\", 0)) + int(data.get(\"failCount\", 0))
+              append(
+                  [
+                      f\"### Tier-1 {lane} strict\",
+                      \"\",
+                      f\"- run: `{p.split('/_diffs/')[0]}`\",
+                      f\"- scenarios: `{total}`\",
+                      f\"- ok: `{data.get('okCount', 0)}`\",
+                      f\"- fail: `{data.get('failCount', 0)}`\",
+                      f\"- missing_blessed: `{data.get('missingBlessed', 0)}`\",
+                      f\"- missing_candidate: `{data.get('missingCandidate', 0)}`\",
+                      f\"- diff index: `{p}`\",
+                      \"\",
+                  ]
+              )
+
+          summarize_lane(\"u1\")
+          summarize_lane(\"u2\")
+          summarize_lane(\"u3\")
+          PY
 
       - name: Upload TUI golden artifacts
         if: always()
@@ -653,6 +735,9 @@ jobs:
           name: tui-goldens-${{ matrix.os }}
           path: |
             misc/tui_goldens/artifacts/run-*/**
+            tui_skeleton/ui_baselines/u1/_runs/run-*/**
+            tui_skeleton/ui_baselines/u2/_runs/run-*/**
+            tui_skeleton/ui_baselines/u3/_runs/run-*/**
           if-no-files-found: ignore
 
       - name: Upload Claude alignment artifacts

--- a/docs/TUI_TIER1_GOLDENS_RUNBOOK.md
+++ b/docs/TUI_TIER1_GOLDENS_RUNBOOK.md
@@ -1,0 +1,161 @@
+# TUI Tier-1 Goldens Runbook (U1/U2/U3)
+
+This document defines the Tier-1 deterministic gates and the operator workflows for:
+1. report generation,
+2. strict gating, and
+3. explicit blessing.
+
+## Canary (What Must Be Green To Merge)
+
+Canonical strict canary for PR merges:
+1. Workflow: `.github/workflows/ci.yml`
+2. Job: `tui` (ubuntu)
+3. Required strict steps:
+   - `node --import tsx tui_skeleton/scripts/tui_u1_goldens_strict.ts`
+   - `node --import tsx tui_skeleton/scripts/tui_u2_goldens_strict.ts`
+   - `node --import tsx tui_skeleton/scripts/tui_u3_goldens_strict.ts`
+
+Notes:
+1. `tui:goldens:report` is report-only by design (it must not fail CI), and is intended to provide visibility for drift.
+2. Broad matrix coverage beyond the canary is handled by Tier-2 nightly/report workflows and by local scripts.
+
+## Tier-1 Scenario IDs and Acceptance Invariants
+
+## U1 (ASCII / structural)
+
+Manifest: `tui_skeleton/ui_baselines/u1/manifests/u1.yaml`
+
+Scenarios:
+1. `tool_call_result_collapsed`
+2. `streaming_pending_basic`
+3. `ascii_only_pending`
+
+Acceptance invariants:
+1. ASCII-safe rendering (`ascii_only: true`)
+2. Stable structural text with normalization of timestamps/tokens/paths/status
+3. Strict compare must pass on blessed `render.txt`
+
+## U2 (Unicode + color structural)
+
+Manifest: `tui_skeleton/ui_baselines/u2/manifests/u2.yaml`
+
+Scenarios:
+1. `tool_call_result_collapsed`
+2. `streaming_pending_basic`
+3. `pending_unicode_color`
+
+Acceptance invariants:
+1. Unicode + truecolor render path is exercised (`ascii_only: false`, `color_mode: truecolor`)
+2. ANSI output required (`style.require_ansi: true`)
+3. Structural compare and strict compare must pass on blessed snapshots
+
+## U3 (Diff/style invariants)
+
+Manifest: `tui_skeleton/ui_baselines/u3/manifests/u3.yaml`
+
+Scenarios:
+1. `diff_patch_preview`
+
+Acceptance invariants:
+1. ANSI output required
+2. Diff add background present (`style.diff_add_bg: true`)
+3. Diff delete background present (`style.diff_del_bg: true`)
+4. Tool dot marker present (`style.tool_dot: true`)
+5. Strict compare must pass on blessed snapshots
+
+## CI Workflows
+
+1. `/.github/workflows/ci.yml` (canonical strict canary)
+2. `/.github/workflows/tui-goldens-tier2-nightly.yml` (broad report-only coverage)
+
+Coverage policy:
+1. Canonical strict canary runs on `ci.yml` (ubuntu) using the default preset unless explicitly overridden.
+2. Tier-2 nightly/report workflow is the matrix coverage surface (preset/mode/width combinations) and is report-only by design.
+3. Local `./scripts/run_tui_tier1_local.sh` is the recommended operator entrypoint to rerun the preset/mode matrix and then enforce strict gates.
+
+## Local Commands
+
+## One-command Tier-1 rerun (report matrix + strict gates)
+
+```bash
+./scripts/run_tui_tier1_local.sh
+```
+
+## One-command Tier-2 rerun (report-only; broader matrix)
+
+```bash
+./scripts/run_tui_tier2_local_report.sh
+```
+
+## Per-lane report
+
+```bash
+cd tui_skeleton
+node --import tsx scripts/tui_u1_goldens_report.ts
+node --import tsx scripts/tui_u2_goldens_report.ts
+node --import tsx scripts/tui_u3_goldens_report.ts
+```
+
+## Per-lane strict gate
+
+```bash
+cd tui_skeleton
+node --import tsx scripts/tui_u1_goldens_strict.ts
+node --import tsx scripts/tui_u2_goldens_strict.ts
+node --import tsx scripts/tui_u3_goldens_strict.ts
+```
+
+## Blessing Workflow (explicit and separate from gates)
+
+Blessing is a manual operator action and must not be embedded into strict gate CI.
+
+1. Generate candidate run:
+
+```bash
+cd tui_skeleton
+node --import tsx scripts/run_tui_goldens.ts --manifest ui_baselines/u1/manifests/u1.yaml --out ui_baselines/u1/_runs
+```
+
+2. Select candidate run directory (`ui_baselines/u1/_runs/run-<timestamp>`).
+3. Bless selected candidate:
+
+```bash
+cd tui_skeleton
+node --import tsx scripts/bless_tui_goldens.ts \
+  --manifest ui_baselines/u1/manifests/u1.yaml \
+  --source ui_baselines/u1/_runs/run-<timestamp> \
+  --blessed-root ui_baselines/u1/scenarios
+```
+
+4. Re-run strict compare after blessing and confirm green before commit.
+
+## Notes
+
+1. Tier-1 is deterministic and intended to gate PRs.
+2. Tier-2 nightly is report/artifact oriented and broadens preset/width coverage.
+3. Keep `docs_tmp/` artifacts out of commits.
+
+## Promotion Rubric (Warn/Report-Only -> Strict)
+
+Policy:
+1. Strict gates must remain minimal and stable. Any new strict gate must have:
+   - deterministic output paths
+   - reproducible local command
+   - clear false-positive handling
+2. Report-only lanes are allowed to be noisy, but must be measurable and summarized.
+
+Promotion from report-only to strict requires:
+1. The lane is green for at least 10 consecutive CI runs on `main`.
+2. Any known "expected mismatch" cases are either resolved or explicitly excluded from the lane.
+3. The lane has an explicit owner and rollback switch (or can be reverted cleanly).
+
+## Expected Mismatches (Report-Only Policy)
+
+Report-only lanes may show failures that are acceptable as visibility signals, but only if:
+1. They are explicitly documented here, and
+2. They do not affect the canonical strict canary.
+
+Currently documented report-only mismatch class:
+1. `ascii-no-color` lanes can fail ANSI/style requirements for scenarios that require ANSI output.
+   - Why: some style assertions (`require_ansi`, diff backgrounds, etc.) are intentionally incompatible with `NO_COLOR=1`.
+   - Action: treat as visibility; do not promote to strict until the lane is made semantically meaningful (either adjust scenario style requirements or drop the incompatible combos).

--- a/scripts/run_tui_tier1_local.sh
+++ b/scripts/run_tui_tier1_local.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TUI_DIR="${ROOT_DIR}/tui_skeleton"
+
+run_report_combo() {
+  local preset="$1"
+  local ascii="$2"
+  local no_color="$3"
+  local label="$4"
+
+  if [[ "${no_color}" == "1" ]]; then
+    export NO_COLOR=1
+  else
+    unset NO_COLOR || true
+  fi
+  export BREADBOARD_ASCII="${ascii}"
+  export BREADBOARD_TUI_PRESET="${preset}"
+
+  echo "[tier1-local] report combo preset=${preset} mode=${label}"
+  (cd "${TUI_DIR}" && node --import tsx scripts/tui_u1_goldens_report.ts)
+  (cd "${TUI_DIR}" && node --import tsx scripts/tui_u2_goldens_report.ts)
+  (cd "${TUI_DIR}" && node --import tsx scripts/tui_u3_goldens_report.ts)
+}
+
+echo "[tier1-local] installing dependencies"
+(cd "${TUI_DIR}" && npm ci)
+
+run_report_combo "breadboard_default" "0" "0" "unicode-color"
+run_report_combo "claude_code_like" "0" "0" "unicode-color"
+run_report_combo "breadboard_default" "1" "1" "ascii-no-color"
+run_report_combo "claude_code_like" "1" "1" "ascii-no-color"
+
+unset NO_COLOR || true
+export BREADBOARD_ASCII=0
+export BREADBOARD_TUI_PRESET=breadboard_default
+
+echo "[tier1-local] strict gates"
+(cd "${TUI_DIR}" && node --import tsx scripts/tui_u1_goldens_strict.ts)
+(cd "${TUI_DIR}" && node --import tsx scripts/tui_u2_goldens_strict.ts)
+(cd "${TUI_DIR}" && node --import tsx scripts/tui_u3_goldens_strict.ts)
+
+echo "[tier1-local] completed"

--- a/scripts/run_tui_tier2_local_report.sh
+++ b/scripts/run_tui_tier2_local_report.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TUI_DIR="${ROOT_DIR}/tui_skeleton"
+
+run_lane() {
+  local lane="$1"
+  local preset="$2"
+  local width="$3"
+  local ascii="$4"
+  local no_color="$5"
+  local mode="$6"
+
+  local manifest="ui_baselines/${lane}/manifests/${lane}.yaml"
+  local runs_root="ui_baselines/${lane}/_runs_tier2_local"
+  local blessed_root="ui_baselines/${lane}/scenarios"
+
+  if [[ "${no_color}" == "1" ]]; then
+    export NO_COLOR=1
+  else
+    unset NO_COLOR || true
+  fi
+  export BREADBOARD_ASCII="${ascii}"
+  export BREADBOARD_TUI_PRESET="${preset}"
+
+  echo "[tier2-local] lane=${lane} preset=${preset} width=${width} mode=${mode}"
+  (
+    cd "${TUI_DIR}"
+    node --import tsx scripts/run_tui_goldens.ts \
+      --manifest "${manifest}" \
+      --out "${runs_root}" \
+      --config ../agent_configs/codex_cli_gpt51mini_e4_live.yaml \
+      --max-width "${width}"
+
+    local latest_run
+    latest_run="$(ls -td "${runs_root}"/run-* | head -n 1)"
+
+    node --import tsx scripts/compare_tui_goldens.ts \
+      --manifest "${manifest}" \
+      --candidate "${latest_run}" \
+      --blessed-root "${blessed_root}" \
+      --summary
+  )
+}
+
+echo "[tier2-local] installing dependencies"
+(cd "${TUI_DIR}" && npm ci)
+
+run_lane "u1" "breadboard_default" "120" "0" "0" "unicode-color"
+run_lane "u1" "claude_code_like" "120" "0" "0" "unicode-color"
+run_lane "u2" "breadboard_default" "100" "0" "0" "unicode-color"
+run_lane "u2" "codex_cli_like" "160" "0" "0" "unicode-color"
+run_lane "u3" "claude_code_like" "120" "0" "0" "unicode-color"
+run_lane "u3" "codex_cli_like" "160" "0" "0" "unicode-color"
+
+echo "[tier2-local] completed"


### PR DESCRIPTION
Closes remaining A-lane closeout gap by making Tier-1 UI baselines (U1/U2/U3) a real strict canary in CI, with step summaries + artifacts.

Adds:
- docs/TUI_TIER1_GOLDENS_RUNBOOK.md
- scripts/run_tui_tier1_local.sh
- scripts/run_tui_tier2_local_report.sh
- ci.yml: strict canary + summaries + ui_baselines artifacts

Issue: ray_SCE-7n6