### PR TITLE
tui: show live todo preview above input

### DIFF
--- a/tui_skeleton/src/repl/components/replView/composer/ComposerPanel.tsx
+++ b/tui_skeleton/src/repl/components/replView/composer/ComposerPanel.tsx
@@ -5,6 +5,7 @@ import { SelectPanel, type SelectPanelLine, type SelectPanelRow } from "../../Se
 import { CHALK, COLORS, GLYPHS, uiText, ASCII_ONLY, DASH_GLYPH } from "../theme.js"
 import { formatBytes, formatCell } from "../utils/format.js"
 import { highlightFuzzyLabel } from "../utils/text.js"
+import type { TodoPreviewModel } from "./todoPreview.js"
 
 // Intentionally broad while the controller continues to own most state.
 type ComposerPanelContext = Record<string, any>
@@ -14,6 +15,7 @@ export const ComposerPanel: React.FC<{ context: ComposerPanelContext }> = ({ con
     claudeChrome,
     modelMenu,
     pendingClaudeStatus,
+    todoPreviewModel,
     promptRule,
     composerPromptPrefix,
     composerPlaceholderClassic,
@@ -57,6 +59,24 @@ export const ComposerPanel: React.FC<{ context: ComposerPanelContext }> = ({ con
 
   if (claudeChrome && modelMenu.status !== "hidden") return null
 
+  const previewModel = todoPreviewModel as TodoPreviewModel | null
+  const previewItems = previewModel?.items ?? []
+  const previewHeader = previewModel?.header ?? ""
+  const previewColorForStatus = (status: string): string => {
+    switch (status) {
+      case "done":
+        return "dim"
+      case "blocked":
+        return COLORS.error
+      case "in_progress":
+        return COLORS.warning
+      case "canceled":
+        return COLORS.textMuted
+      default:
+        return COLORS.textBright
+    }
+  }
+
   const ruleWidth = Number.isFinite(columnWidth)
     ? Math.max(1, Math.floor(columnWidth) - (claudeChrome ? 0 : 1))
     : Math.max(1, promptRule.length - (claudeChrome ? 0 : 1))
@@ -69,6 +89,16 @@ export const ComposerPanel: React.FC<{ context: ComposerPanelContext }> = ({ con
   return (
     <Box marginTop={claudeChrome ? 0 : 1} flexDirection="column" width={ruleWidth}>
       {claudeChrome && pendingClaudeStatus && <Text color="dim">{pendingClaudeStatus}</Text>}
+      {claudeChrome && !overlayActive && previewItems.length > 0 && (
+        <Box flexDirection="column">
+          {previewHeader ? <Text color={COLORS.textMuted} wrap="truncate">{uiText(previewHeader)}</Text> : null}
+          {previewItems.map((item) => (
+            <Text key={item.id} color={previewColorForStatus(item.status)} wrap="truncate">
+              {uiText(item.label)}
+            </Text>
+          ))}
+        </Box>
+      )}
       {!overlayActive && claudeChrome && hintNodes.length > 0 && (
         <Box flexDirection="column">
           {hintNodes}

--- a/tui_skeleton/src/repl/components/replView/composer/__tests__/ComposerPanel.todoPreview.test.tsx
+++ b/tui_skeleton/src/repl/components/replView/composer/__tests__/ComposerPanel.todoPreview.test.tsx
@@ -1,0 +1,68 @@
+import React from "react"
+import { describe, expect, it, vi } from "vitest"
+import { render } from "ink-testing-library"
+import { ComposerPanel } from "../ComposerPanel.js"
+import { buildTodoPreviewModel } from "../todoPreview.js"
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe("ComposerPanel todo preview", () => {
+  it("renders todo preview above the input when enabled (claudeChrome)", async () => {
+    const preview = buildTodoPreviewModel([{ id: "t1", title: "Write tests", status: "todo" }], { maxItems: 7 })
+    const { lastFrame } = render(
+      <ComposerPanel
+        context={{
+          claudeChrome: true,
+          modelMenu: { status: "hidden" },
+          pendingClaudeStatus: null,
+          todoPreviewModel: preview,
+          promptRule: "----------------------------------------",
+          composerPromptPrefix: ">",
+          composerPlaceholderClassic: "",
+          composerPlaceholderClaude: "",
+          composerShowTopRule: false,
+          composerShowBottomRule: false,
+          input: "",
+          cursor: 0,
+          inputLocked: false,
+          attachments: [],
+          fileMentions: [],
+          inputMaxVisibleLines: 6,
+          handleLineEditGuarded: vi.fn(),
+          handleLineSubmit: vi.fn(),
+          handleAttachment: vi.fn(),
+          overlayActive: false,
+          filePickerActive: false,
+          fileIndexMeta: { fileCount: 0, dirCount: 0, scannedDirs: 0, queuedDirs: 0, status: "idle", truncated: false },
+          fileMenuMode: "fuzzy",
+          filePicker: { status: "hidden" },
+          fileMenuRows: [],
+          fileMenuHasLarge: false,
+          fileMenuWindow: { start: 0, end: 0, lineCount: 0, hiddenAbove: 0, hiddenBelow: 0, items: [] },
+          fileMenuIndex: 0,
+          fileMenuNeedlePending: false,
+          filePickerQueryParts: { cwd: ".", raw: "" },
+          filePickerConfig: { mode: "fuzzy", maxResults: 20, maxQueryParts: 4 },
+          fileMentionConfig: { maxInlineBytesPerFile: 64_000, maxTotalInlineBytes: 1_000_000, mode: "inline" },
+          selectedFileIsLarge: false,
+          columnWidth: 80,
+          suggestions: [],
+          suggestionWindow: { start: 0, end: 0, lineCount: 0, hiddenAbove: 0, hiddenBelow: 0 },
+          suggestionPrefix: "",
+          suggestionLayout: { commandWidth: 20, totalWidth: 80, labelWidth: 60 },
+          buildSuggestionLines: vi.fn(() => []),
+          suggestIndex: 0,
+          activeSlashQuery: null,
+          hintNodes: [],
+          shortcutHintNodes: [],
+        }}
+      />,
+    )
+    await flush()
+
+    const frame = lastFrame() ?? ""
+    expect(frame).toContain("TODOs: 0/1")
+    expect(frame).toContain("[ ] Write tests")
+  })
+})
+

--- a/tui_skeleton/src/repl/components/replView/composer/__tests__/todoPreview.test.ts
+++ b/tui_skeleton/src/repl/components/replView/composer/__tests__/todoPreview.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { buildTodoPreviewModel, DEFAULT_TODO_PREVIEW_MAX_ITEMS, getTodoPreviewRowCount } from "../todoPreview.js"
+
+describe("buildTodoPreviewModel", () => {
+  it("returns null for empty input", () => {
+    expect(buildTodoPreviewModel([])).toBeNull()
+  })
+
+  it("builds header and item labels with progress", () => {
+    const model = buildTodoPreviewModel([
+      { id: "1", title: "First", status: "todo" },
+      { id: "2", title: "Second", status: "done" },
+      { id: "3", title: "Third", status: "in_progress" },
+    ])
+    expect(model?.header).toBe("TODOs: 1/3")
+    expect(model?.items.map((item) => item.label)).toEqual(["[ ] First", "[x] Second", "[~] Third"])
+    expect(getTodoPreviewRowCount(model)).toBe(1 + 3)
+  })
+
+  it("truncates to maxItems and preserves order", () => {
+    const todos = Array.from({ length: DEFAULT_TODO_PREVIEW_MAX_ITEMS + 4 }).map((_, idx) => ({
+      id: String(idx + 1),
+      title: `Item ${idx + 1}`,
+      status: idx % 2 === 0 ? "todo" : "done",
+    }))
+    const model = buildTodoPreviewModel(todos, { maxItems: DEFAULT_TODO_PREVIEW_MAX_ITEMS })
+    expect(model?.items).toHaveLength(DEFAULT_TODO_PREVIEW_MAX_ITEMS)
+    expect(model?.items[0]?.label).toBe("[ ] Item 1")
+    expect(model?.items[DEFAULT_TODO_PREVIEW_MAX_ITEMS - 1]?.label).toBe(`[ ] Item ${DEFAULT_TODO_PREVIEW_MAX_ITEMS}`)
+  })
+
+  it("omits header when disabled", () => {
+    const model = buildTodoPreviewModel([{ id: "1", title: "Only", status: "todo" }], { showHeader: false })
+    expect(model?.header).toBe("")
+    expect(getTodoPreviewRowCount(model)).toBe(1)
+  })
+})

--- a/tui_skeleton/src/repl/components/replView/composer/todoPreview.ts
+++ b/tui_skeleton/src/repl/components/replView/composer/todoPreview.ts
@@ -1,0 +1,68 @@
+import type { TodoItem } from "../../../types.js"
+
+export type TodoPreviewItem = {
+  readonly id: string
+  readonly label: string
+  readonly status: string
+}
+
+export type TodoPreviewModel = {
+  readonly header: string
+  readonly doneCount: number
+  readonly totalCount: number
+  readonly items: readonly TodoPreviewItem[]
+}
+
+export const DEFAULT_TODO_PREVIEW_MAX_ITEMS = 7
+
+type BuildTodoPreviewOptions = {
+  readonly maxItems?: number
+  readonly showHeader?: boolean
+}
+
+const statusMark = (status: string): string => {
+  switch (status) {
+    case "done":
+      return "x"
+    case "in_progress":
+      return "~"
+    case "blocked":
+      return "!"
+    case "canceled":
+      return "-"
+    default:
+      return " "
+  }
+}
+
+export const buildTodoPreviewModel = (
+  todos: readonly TodoItem[],
+  options: BuildTodoPreviewOptions = {},
+): TodoPreviewModel | null => {
+  if (!todos || todos.length === 0) return null
+  const maxItems = options.maxItems ?? DEFAULT_TODO_PREVIEW_MAX_ITEMS
+  const showHeader = options.showHeader ?? true
+
+  const totalCount = todos.length
+  let doneCount = 0
+  for (const todo of todos) {
+    if (todo.status === "done") doneCount += 1
+  }
+
+  const visible = todos.slice(0, Math.max(0, maxItems))
+  const items: TodoPreviewItem[] = visible.map((todo) => ({
+    id: todo.id,
+    status: todo.status,
+    label: `[${statusMark(todo.status)}] ${todo.title}`,
+  }))
+
+  const header = showHeader ? `TODOs: ${doneCount}/${totalCount}` : ""
+  return { header, doneCount, totalCount, items }
+}
+
+export const getTodoPreviewRowCount = (model: TodoPreviewModel | null): number => {
+  if (!model || model.items.length === 0) return 0
+  const headerRows = model.header ? 1 : 0
+  return headerRows + model.items.length
+}
+

--- a/tui_skeleton/src/repl/components/replView/controller/useReplViewController.tsx
+++ b/tui_skeleton/src/repl/components/replView/controller/useReplViewController.tsx
@@ -93,6 +93,7 @@ import {
 } from "./replViewControllerUtils.js"
 import { useReplViewModalStack } from "./useReplViewModalStack.js"
 import { ReplViewBaseContent } from "./ReplViewBaseContent.js"
+import { buildTodoPreviewModel } from "../composer/todoPreview.js"
 import { useTuiConfig } from "../../../../tui_config/context.js"
 import { formatConfiguredCompletionLine } from "../../../../tui_config/load.js"
 import {
@@ -576,6 +577,14 @@ export const useReplViewController = ({
     formatCTreeNodeFlags,
     requestTaskTail,
   } = panels
+
+  const todoPreviewModel = useMemo(() => {
+    if (!claudeChrome) return null
+    if (overlayActive) return null
+    if (!tuiConfig.composer.todoPreviewAboveInput) return null
+    return buildTodoPreviewModel(todos, { maxItems: tuiConfig.composer.todoPreviewMaxItems })
+  }, [claudeChrome, overlayActive, tuiConfig.composer.todoPreviewAboveInput, tuiConfig.composer.todoPreviewMaxItems, todos])
+
   useEffect(() => {
     const liveKeys = new Set(
       Array.isArray(taskGroups)
@@ -1045,6 +1054,7 @@ export const useReplViewController = ({
     suggestions,
     suggestionWindow,
     hints,
+    todoPreviewModel,
     attachments,
     fileMentions,
     workGraph,
@@ -1158,7 +1168,7 @@ export const useReplViewController = ({
     toolEvents.length === 0
 
   const composerPanelContext = {
-    claudeChrome, modelMenu, pendingClaudeStatus, promptRule, input, cursor, inputLocked,
+    claudeChrome, modelMenu, pendingClaudeStatus, todoPreviewModel, promptRule, input, cursor, inputLocked,
     attachments, fileMentions, inputMaxVisibleLines, handleLineEditGuarded, handleLineSubmit, handleAttachment,
     overlayActive, filePickerActive, fileIndexMeta, fileMenuMode, filePicker, fileMenuRows, fileMenuHasLarge,
     fileMenuWindow, fileMenuIndex, fileMenuNeedlePending, filePickerQueryParts, filePickerConfig, fileMentionConfig,

--- a/tui_skeleton/src/repl/components/replView/controller/useReplViewScrollback.tsx
+++ b/tui_skeleton/src/repl/components/replView/controller/useReplViewScrollback.tsx
@@ -11,6 +11,7 @@ import { sliceTailByLineBudget, trimTailByLineCount } from "../layout/windowing.
 import { isInlineThinkingBlockText } from "../../../transcriptUtils.js"
 import { CHALK, COLORS } from "../theme.js"
 import { formatCostUsd, formatLatency } from "../utils/format.js"
+import { getTodoPreviewRowCount, type TodoPreviewModel } from "../composer/todoPreview.js"
 import { useReplViewRenderNodes } from "./useReplViewRenderNodes.js"
 import { buildLandingContext, buildScrollbackLanding } from "../landing/scrollbackLanding.js"
 import {
@@ -76,6 +77,7 @@ export const useReplViewScrollback = (context: ScrollbackContext) => {
     suggestions,
     suggestionWindow,
     hints,
+    todoPreviewModel,
     attachments,
     fileMentions,
     workGraph,
@@ -280,11 +282,14 @@ export const useReplViewScrollback = (context: ScrollbackContext) => {
         : hintCount > 0
           ? 1 + hintCount
           : 0
+    const todoPreviewRows =
+      overlayActive ? 0 : getTodoPreviewRowCount(todoPreviewModel as TodoPreviewModel | null)
     const attachmentRows = overlayActive ? 0 : attachments.length > 0 ? attachments.length + 3 : 0
     const fileMentionRows = overlayActive ? 0 : fileMentions.length > 0 ? fileMentions.length + 3 : 0
     return (
       outerMargin +
       pendingStatusRows +
+      todoPreviewRows +
       promptRuleRows +
       promptLine +
       suggestionRows +
@@ -307,6 +312,7 @@ export const useReplViewScrollback = (context: ScrollbackContext) => {
     filePicker.status,
     filePickerActive,
     hints.length,
+    todoPreviewModel,
     overlayActive,
     pendingClaudeStatus,
     suggestions.length,

--- a/tui_skeleton/src/tui_config/load.ts
+++ b/tui_skeleton/src/tui_config/load.ts
@@ -282,6 +282,10 @@ export const resolveTuiConfig = async (options: ResolvedTuiConfigOptions): Promi
       ruleCharacter: normalizeRuleCharacter(merged.composer?.ruleCharacter, displayAsciiOnly),
       showTopRule: merged.composer?.showTopRule ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.showTopRule,
       showBottomRule: merged.composer?.showBottomRule ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.showBottomRule,
+      todoPreviewAboveInput:
+        merged.composer?.todoPreviewAboveInput ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.todoPreviewAboveInput,
+      todoPreviewMaxItems:
+        merged.composer?.todoPreviewMaxItems ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.todoPreviewMaxItems,
     },
     statusLine: {
       position: merged.statusLine?.position ?? DEFAULT_RESOLVED_TUI_CONFIG.statusLine.position,

--- a/tui_skeleton/src/tui_config/presets.ts
+++ b/tui_skeleton/src/tui_config/presets.ts
@@ -37,6 +37,8 @@ export const BUILTIN_TUI_PRESETS: Record<TuiPresetId, TuiConfigInput> = {
       ruleCharacter: "─",
       showTopRule: true,
       showBottomRule: true,
+      todoPreviewAboveInput: true,
+      todoPreviewMaxItems: 7,
     },
     statusLine: {
       position: "above_input",
@@ -228,6 +230,8 @@ export const DEFAULT_RESOLVED_TUI_CONFIG: ResolvedTuiConfig = {
     ruleCharacter: "─",
     showTopRule: true,
     showBottomRule: true,
+    todoPreviewAboveInput: false,
+    todoPreviewMaxItems: 7,
   },
   statusLine: {
     position: "above_input",

--- a/tui_skeleton/src/tui_config/schema.ts
+++ b/tui_skeleton/src/tui_config/schema.ts
@@ -251,7 +251,16 @@ export const validateTuiConfigInput = (input: unknown, options: ValidationOption
   if (composerRaw) {
     detectUnknownKeys(
       composerRaw,
-      ["promptPrefix", "placeholderClassic", "placeholderClaude", "ruleCharacter", "showTopRule", "showBottomRule"],
+      [
+        "promptPrefix",
+        "placeholderClassic",
+        "placeholderClaude",
+        "ruleCharacter",
+        "showTopRule",
+        "showBottomRule",
+        "todoPreviewAboveInput",
+        "todoPreviewMaxItems",
+      ],
       ["composer"],
       issues,
       options.strictUnknownKeys,
@@ -269,6 +278,10 @@ export const validateTuiConfigInput = (input: unknown, options: ValidationOption
     if (showTopRule != null) composer.showTopRule = showTopRule
     const showBottomRule = readBoolean(composerRaw, "showBottomRule", ["composer"], issues)
     if (showBottomRule != null) composer.showBottomRule = showBottomRule
+    const todoPreviewAboveInput = readBoolean(composerRaw, "todoPreviewAboveInput", ["composer"], issues)
+    if (todoPreviewAboveInput != null) composer.todoPreviewAboveInput = todoPreviewAboveInput
+    const todoPreviewMaxItems = readPositiveInt(composerRaw, "todoPreviewMaxItems", ["composer"], issues)
+    if (todoPreviewMaxItems != null) composer.todoPreviewMaxItems = todoPreviewMaxItems
     config.composer = composer
   }
 

--- a/tui_skeleton/src/tui_config/types.ts
+++ b/tui_skeleton/src/tui_config/types.ts
@@ -44,6 +44,8 @@ export type TuiConfigInput = {
     ruleCharacter?: string
     showTopRule?: boolean
     showBottomRule?: boolean
+    todoPreviewAboveInput?: boolean
+    todoPreviewMaxItems?: number
   }
   statusLine?: {
     position?: StatusLinePosition
@@ -92,6 +94,8 @@ export type ResolvedTuiConfig = {
     readonly ruleCharacter: string
     readonly showTopRule: boolean
     readonly showBottomRule: boolean
+    readonly todoPreviewAboveInput: boolean
+    readonly todoPreviewMaxItems: number
   }
   readonly statusLine: {
     readonly position: StatusLinePosition


### PR DESCRIPTION
Adds a Claude Code-like live TODO preview above the composer input.

Key points:
- Uses existing controller `state.todos` (no new todo store/protocol for MVP)
- Gated by TUI config: `composer.todoPreviewAboveInput` (enabled by default in `claude_code_like` preset)
- One-line-per-item, `wrap="truncate"` to avoid layout jitter
- Updates scrollback layout budgeting to reserve the new rows

Tests:
- `npm -C tui_skeleton run typecheck`
- `npm -C tui_skeleton test`