### PR TITLE
engine: provider auth attach/detach + import IR converter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -985,9 +985,4 @@ jobs:
         run: python -m pip install pytest jsonschema requests
 
       - name: Contract schema smoke
-        run: |
-          python -m pytest -q \
-            tests/test_cli_bridge_contract_exports.py \
-            tests/test_import_and_profile_contracts.py \
-            tests/test_import_ir_converter.py \
-            tests/test_provider_auth_store.py
+        run: python -m pytest -q tests/test_cli_bridge_contract_exports.py tests/test_import_and_profile_contracts.py tests/test_import_ir_converter.py tests/test_provider_auth_store.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -982,7 +982,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install minimal test dependencies
-        run: python -m pip install pytest jsonschema
+        run: python -m pip install pytest jsonschema requests
 
       - name: Contract schema smoke
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -985,4 +985,9 @@ jobs:
         run: python -m pip install pytest jsonschema
 
       - name: Contract schema smoke
-        run: python -m pytest -q tests/test_cli_bridge_contract_exports.py
+        run: |
+          python -m pytest -q \
+            tests/test_cli_bridge_contract_exports.py \
+            tests/test_import_and_profile_contracts.py \
+            tests/test_import_ir_converter.py \
+            tests/test_provider_auth_store.py

--- a/agentic_coder_prototype/api/cli_bridge/events.py
+++ b/agentic_coder_prototype/api/cli_bridge/events.py
@@ -28,6 +28,7 @@ class EventType(str, enum.Enum):
     CTREE_SNAPSHOT = "ctree_snapshot"
     TASK_EVENT = "task_event"
     REWARD_UPDATE = "reward_update"
+    LIMITS_UPDATE = "limits_update"
     COMPLETION = "completion"
     LOG_LINK = "log_link"
     ERROR = "error"

--- a/agentic_coder_prototype/api/cli_bridge/session_runner.py
+++ b/agentic_coder_prototype/api/cli_bridge/session_runner.py
@@ -1295,6 +1295,7 @@ class SessionRunner:
             "ctree_snapshot": EventType.CTREE_SNAPSHOT,
             "task_event": EventType.TASK_EVENT,
             "reward_update": EventType.REWARD_UPDATE,
+            "limits_update": EventType.LIMITS_UPDATE,
             "completion": EventType.COMPLETION,
             "log_link": EventType.LOG_LINK,
             "error": EventType.ERROR,

--- a/agentic_coder_prototype/auth/__init__.py
+++ b/agentic_coder_prototype/auth/__init__.py
@@ -1,0 +1,17 @@
+"""In-engine provider auth material (in-memory only).
+
+This package is intentionally small and conservative:
+- Auth material is accepted from the CLI bridge and stored in-memory only.
+- No refresh tokens are persisted or handled here.
+"""
+
+from .material import EngineAuthMaterial, EmulationProfileRequirement
+from .store import ProviderAuthStore, DEFAULT_PROVIDER_AUTH_STORE
+
+__all__ = [
+    "EngineAuthMaterial",
+    "EmulationProfileRequirement",
+    "ProviderAuthStore",
+    "DEFAULT_PROVIDER_AUTH_STORE",
+]
+

--- a/agentic_coder_prototype/auth/enforcer.py
+++ b/agentic_coder_prototype/auth/enforcer.py
@@ -1,0 +1,172 @@
+"""Sealed-profile conformance enforcement.
+
+This is intentionally narrow: it computes a conformance hash over a subset of a
+resolved config, addressed via JSON Pointers, and can return a sanitized diff.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+_MISSING = {"__breadboard_missing__": True}
+
+
+def _decode_pointer_token(token: str) -> str:
+    return token.replace("~1", "/").replace("~0", "~")
+
+
+def _get_by_pointer(doc: Any, pointer: str) -> Any:
+    if pointer == "":
+        return doc
+    if not pointer.startswith("/"):
+        raise ValueError(f"invalid json pointer: {pointer!r}")
+    current = doc
+    for raw in pointer.lstrip("/").split("/"):
+        token = _decode_pointer_token(raw)
+        if isinstance(current, dict):
+            if token not in current:
+                return _MISSING
+            current = current[token]
+            continue
+        if isinstance(current, list):
+            if not token.isdigit():
+                return _MISSING
+            idx = int(token)
+            if idx < 0 or idx >= len(current):
+                return _MISSING
+            current = current[idx]
+            continue
+        return _MISSING
+    return current
+
+
+def _tokenize_dotted_path(path: str) -> List[Any]:
+    tokens: List[Any] = []
+    parts = path.split(".")
+    for part in parts:
+        cursor = part
+        while cursor:
+            if "[" in cursor:
+                name, rest = cursor.split("[", 1)
+                if name:
+                    tokens.append(name)
+                idx_str, _, remainder = rest.partition("]")
+                if idx_str.isdigit():
+                    tokens.append(int(idx_str))
+                cursor = remainder.lstrip(".") if remainder.startswith(".") else remainder
+            else:
+                tokens.append(cursor)
+                cursor = ""
+    return tokens
+
+
+def _set_nested(doc: Any, tokens: List[Any], value: Any) -> None:
+    current = doc
+    parent_stack: List[Tuple[Any, Any]] = []
+    for idx, token in enumerate(tokens):
+        is_last = idx == len(tokens) - 1
+        if isinstance(token, str):
+            if not isinstance(current, dict):
+                if not parent_stack:
+                    return
+                parent, parent_token = parent_stack[-1]
+                replacement: Dict[str, Any] = {}
+                if isinstance(parent, dict):
+                    parent[parent_token] = replacement
+                elif isinstance(parent, list) and isinstance(parent_token, int):
+                    parent[parent_token] = replacement
+                current = replacement
+            if is_last:
+                current[token] = value
+                return
+            next_token = tokens[idx + 1]
+            if token not in current or current[token] is None:
+                current[token] = [] if isinstance(next_token, int) else {}
+            parent_stack.append((current, token))
+            current = current[token]
+            continue
+        # list index token
+        if not isinstance(current, list):
+            replacement_list: List[Any] = []
+            if parent_stack:
+                parent, parent_token = parent_stack[-1]
+                if isinstance(parent, dict):
+                    parent[parent_token] = replacement_list
+                elif isinstance(parent, list) and isinstance(parent_token, int):
+                    parent[parent_token] = replacement_list
+            current = replacement_list
+        while len(current) <= token:
+            next_token = tokens[idx + 1] if not is_last else None
+            current.append([] if isinstance(next_token, int) else {})
+        if is_last:
+            current[token] = value
+            return
+        parent_stack.append((current, token))
+        current = current[token]
+
+
+def apply_dotted_overrides(config: Dict[str, Any], overrides: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return a copy of config with dotted-path overrides applied (best-effort)."""
+    if not overrides:
+        return config
+    mutated = copy.deepcopy(config)
+    if not isinstance(mutated, dict):
+        mutated = {}
+    for path, value in (overrides or {}).items():
+        if not isinstance(path, str) or not path:
+            continue
+        _set_nested(mutated, _tokenize_dotted_path(path), value)
+    return mutated
+
+
+def locked_view(config: Dict[str, Any], locked_json_pointers: Iterable[str]) -> Dict[str, Any]:
+    view: Dict[str, Any] = {}
+    for ptr in locked_json_pointers:
+        if not isinstance(ptr, str) or not ptr:
+            continue
+        try:
+            view[ptr] = _get_by_pointer(config, ptr)
+        except Exception:
+            view[ptr] = _MISSING
+    return view
+
+
+def compute_conformance_hash(config: Dict[str, Any], locked_json_pointers: Iterable[str]) -> str:
+    view = locked_view(config, locked_json_pointers)
+    payload = json.dumps(view, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+@dataclass(frozen=True)
+class ConformanceResult:
+    ok: bool
+    expected_hash: str
+    actual_hash: str
+    details: Dict[str, Any]
+
+
+def check_conformance(
+    *,
+    config: Dict[str, Any],
+    locked_json_pointers: Iterable[str],
+    expected_hash: str,
+) -> ConformanceResult:
+    view = locked_view(config, locked_json_pointers)
+    actual = compute_conformance_hash(config, locked_json_pointers)
+    ok = bool(expected_hash) and (expected_hash == actual)
+    # Keep diff payload conservative to avoid leaking secrets from locked pointers.
+    details = {
+        "locked_json_pointers": list(locked_json_pointers),
+        "locked_value_kinds": {
+            ptr: ("missing" if val is _MISSING else type(val).__name__)
+            for ptr, val in view.items()
+        },
+    }
+    return ConformanceResult(ok=ok, expected_hash=expected_hash, actual_hash=actual, details=details)
+

--- a/agentic_coder_prototype/auth/material.py
+++ b/agentic_coder_prototype/auth/material.py
@@ -1,0 +1,97 @@
+"""Auth material types for provider auth overlays.
+
+These objects represent short-lived credential material the Engine can apply to
+outgoing provider calls. The Engine must not persist this material to disk.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class EmulationProfileRequirement:
+    """Sealed-profile requirement for compliance-sensitive auth sources.
+
+    The Engine enforces this at attach-time by recomputing a conformance hash
+    over a locked subset of the resolved runtime config.
+    """
+
+    profile_id: str
+    conformance_hash: str
+    locked_json_pointers: Tuple[str, ...] = ()
+
+    @staticmethod
+    def from_raw(raw: Any) -> Optional["EmulationProfileRequirement"]:
+        if not isinstance(raw, dict):
+            return None
+        profile_id = str(raw.get("profile_id") or raw.get("profileId") or "").strip()
+        conformance_hash = str(raw.get("conformance_hash") or raw.get("conformanceHash") or "").strip()
+        locked = raw.get("locked_json_pointers") or raw.get("lockedJsonPointers") or []
+        pointers: Tuple[str, ...] = ()
+        if isinstance(locked, (list, tuple)):
+            pointers = tuple(str(p) for p in locked if isinstance(p, str) and p)
+        if not profile_id or not conformance_hash:
+            return None
+        return EmulationProfileRequirement(
+            profile_id=profile_id,
+            conformance_hash=conformance_hash,
+            locked_json_pointers=pointers,
+        )
+
+
+@dataclass
+class EngineAuthMaterial:
+    """Short-lived auth material applied to provider calls."""
+
+    provider_id: str
+    alias: str = ""
+    # For OpenAI/Anthropic/OpenRouter style SDKs this typically maps to the SDK's api_key.
+    api_key: Optional[str] = None
+    # Additional headers that should be applied to provider calls (redacted from logs).
+    headers: Dict[str, str] | None = None
+    # Optional base URL override (e.g. local bridge, proxy).
+    base_url: Optional[str] = None
+    # Optional extra routing metadata (provider-specific).
+    routing: Dict[str, Any] | None = None
+    issued_at_ms: Optional[int] = None
+    expires_at_ms: Optional[int] = None
+    # Marks that this material corresponds to a compliance-sensitive plan adapter.
+    is_subscription_plan: bool = False
+    required_profile: Optional[EmulationProfileRequirement] = None
+
+    def header_keys(self) -> Sequence[str]:
+        if not self.headers:
+            return []
+        return sorted(str(k) for k in self.headers.keys())
+
+    def to_sanitized_status(self, now_ms: int) -> Dict[str, Any]:
+        expires_in_ms: Optional[int] = None
+        if self.expires_at_ms is not None:
+            try:
+                expires_in_ms = max(0, int(self.expires_at_ms) - int(now_ms))
+            except Exception:
+                expires_in_ms = None
+        return {
+            "provider_id": self.provider_id,
+            "alias": self.alias or None,
+            "has_api_key": bool(self.api_key),
+            "header_keys": list(self.header_keys()),
+            "base_url": self.base_url,
+            "routing_keys": sorted(list((self.routing or {}).keys())),
+            "issued_at_ms": self.issued_at_ms,
+            "expires_at_ms": self.expires_at_ms,
+            "expires_in_ms": expires_in_ms,
+            "is_subscription_plan": bool(self.is_subscription_plan),
+            "required_profile": (
+                {
+                    "profile_id": self.required_profile.profile_id,
+                    "conformance_hash": self.required_profile.conformance_hash,
+                    "locked_json_pointers": list(self.required_profile.locked_json_pointers),
+                }
+                if self.required_profile
+                else None
+            ),
+        }
+

--- a/agentic_coder_prototype/auth/store.py
+++ b/agentic_coder_prototype/auth/store.py
@@ -1,0 +1,88 @@
+"""In-memory provider auth material store with TTL expiry."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import asdict
+from typing import Any, Dict, List, Optional, Tuple
+
+from .material import EngineAuthMaterial, EmulationProfileRequirement
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+class ProviderAuthStore:
+    """Stores short-lived auth material in-memory (never persisted)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._items: Dict[Tuple[str, str], EngineAuthMaterial] = {}
+
+    def _key(self, provider_id: str, alias: str) -> Tuple[str, str]:
+        return (str(provider_id or "").strip(), str(alias or "").strip())
+
+    def attach(
+        self,
+        material: EngineAuthMaterial,
+        *,
+        ttl_seconds: Optional[int] = None,
+        required_profile: Optional[EmulationProfileRequirement] = None,
+    ) -> EngineAuthMaterial:
+        now = _now_ms()
+        if material.issued_at_ms is None:
+            material.issued_at_ms = now
+        if required_profile is not None:
+            material.required_profile = required_profile
+        if ttl_seconds is not None and material.expires_at_ms is None:
+            try:
+                material.expires_at_ms = now + (max(0, int(ttl_seconds)) * 1000)
+            except Exception:
+                pass
+        key = self._key(material.provider_id, material.alias)
+        with self._lock:
+            self._items[key] = material
+        return material
+
+    def detach(self, provider_id: str, *, alias: str = "") -> bool:
+        key = self._key(provider_id, alias)
+        with self._lock:
+            return self._items.pop(key, None) is not None
+
+    def _is_expired(self, material: EngineAuthMaterial, now_ms: int) -> bool:
+        if material.expires_at_ms is None:
+            return False
+        try:
+            return int(material.expires_at_ms) <= int(now_ms)
+        except Exception:
+            return False
+
+    def get(self, provider_id: str, *, alias: str = "") -> Optional[EngineAuthMaterial]:
+        now = _now_ms()
+        key = self._key(provider_id, alias)
+        with self._lock:
+            material = self._items.get(key)
+            if material is None:
+                return None
+            if self._is_expired(material, now):
+                self._items.pop(key, None)
+                return None
+            return material
+
+    def status(self) -> List[Dict[str, Any]]:
+        now = _now_ms()
+        with self._lock:
+            items = list(self._items.values())
+        # Best-effort expiry cleanup without holding lock during status formatting.
+        for material in items:
+            if self._is_expired(material, now):
+                self.detach(material.provider_id, alias=material.alias)
+        with self._lock:
+            active = list(self._items.values())
+        return [m.to_sanitized_status(now) for m in active]
+
+
+DEFAULT_PROVIDER_AUTH_STORE = ProviderAuthStore()
+

--- a/agentic_coder_prototype/limits/__init__.py
+++ b/agentic_coder_prototype/limits/__init__.py
@@ -1,0 +1,6 @@
+"""Rate limit parsing helpers."""
+
+from .parse_headers import parse_rate_limit_headers
+
+__all__ = ["parse_rate_limit_headers"]
+

--- a/agentic_coder_prototype/limits/parse_headers.py
+++ b/agentic_coder_prototype/limits/parse_headers.py
@@ -1,0 +1,135 @@
+"""Parse rate limit headers into a normalized snapshot.
+
+This is best-effort: providers vary wildly. The output is shaped to feed the
+`limits_update` CLI bridge event payload.
+"""
+
+from __future__ import annotations
+
+import datetime
+import time
+from typing import Any, Dict, List, Optional
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _parse_number(value: Optional[str]) -> Optional[float]:
+    if value is None:
+        return None
+    v = str(value).strip()
+    if not v:
+        return None
+    try:
+        return float(v)
+    except Exception:
+        return None
+
+
+def _parse_retry_after_ms(value: Optional[str]) -> Optional[int]:
+    if not value:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    # Spec allows either delta-seconds or an HTTP-date.
+    try:
+        seconds = float(raw)
+        return max(0, int(seconds * 1000))
+    except Exception:
+        pass
+    try:
+        dt = datetime.datetime.strptime(raw, "%a, %d %b %Y %H:%M:%S %Z")
+        return max(0, int((dt.timestamp() - time.time()) * 1000))
+    except Exception:
+        return None
+
+
+def _parse_reset_ms(value: Optional[str]) -> Optional[int]:
+    if not value:
+        return None
+    raw = str(value).strip()
+    if not raw:
+        return None
+    # Common forms: seconds since epoch, ISO-8601, or seconds-until-reset.
+    num = _parse_number(raw)
+    if num is not None:
+        # Heuristic: values > 10^10 are probably ms epoch already.
+        if num > 10_000_000_000:
+            return int(num)
+        # values > 10^9 likely seconds epoch.
+        if num > 1_000_000_000:
+            return int(num * 1000)
+        # Otherwise treat as delta seconds.
+        return _now_ms() + int(num * 1000)
+    try:
+        clean = raw.rstrip("Z")
+        dt = datetime.datetime.fromisoformat(clean + ("+00:00" if "T" in clean and "+" not in clean else ""))
+        return int(dt.timestamp() * 1000)
+    except Exception:
+        return None
+
+
+def parse_rate_limit_headers(headers: Dict[str, str], *, provider: str) -> Dict[str, Any] | None:
+    if not headers:
+        return None
+    normalized = {str(k).lower(): str(v) for k, v in headers.items() if k}
+    observed_at_ms = _now_ms()
+
+    buckets: List[Dict[str, Any]] = []
+
+    def _maybe_add_bucket(name: str, limit: Optional[float], remaining: Optional[float], reset_ms: Optional[int]) -> None:
+        if limit is None and remaining is None and reset_ms is None:
+            return
+        buckets.append(
+            {
+                "name": name,
+                "limit": limit,
+                "remaining": remaining,
+                "reset_at_ms": reset_ms,
+            }
+        )
+
+    # Generic x-ratelimit-* patterns (common across OpenAI-like providers).
+    _maybe_add_bucket(
+        "requests",
+        _parse_number(normalized.get("x-ratelimit-limit-requests") or normalized.get("x-ratelimit-limit-request")),
+        _parse_number(normalized.get("x-ratelimit-remaining-requests") or normalized.get("x-ratelimit-remaining-request")),
+        _parse_reset_ms(normalized.get("x-ratelimit-reset-requests") or normalized.get("x-ratelimit-reset-request")),
+    )
+    _maybe_add_bucket(
+        "tokens",
+        _parse_number(normalized.get("x-ratelimit-limit-tokens") or normalized.get("x-ratelimit-limit-token")),
+        _parse_number(normalized.get("x-ratelimit-remaining-tokens") or normalized.get("x-ratelimit-remaining-token")),
+        _parse_reset_ms(normalized.get("x-ratelimit-reset-tokens") or normalized.get("x-ratelimit-reset-token")),
+    )
+
+    # Anthropic-specific headers.
+    _maybe_add_bucket(
+        "requests",
+        _parse_number(normalized.get("anthropic-ratelimit-requests-limit")),
+        _parse_number(normalized.get("anthropic-ratelimit-requests-remaining")),
+        _parse_reset_ms(normalized.get("anthropic-ratelimit-requests-reset")),
+    )
+    _maybe_add_bucket(
+        "tokens",
+        _parse_number(normalized.get("anthropic-ratelimit-tokens-limit")),
+        _parse_number(normalized.get("anthropic-ratelimit-tokens-remaining")),
+        _parse_reset_ms(normalized.get("anthropic-ratelimit-tokens-reset")),
+    )
+
+    retry_after_ms = _parse_retry_after_ms(normalized.get("retry-after"))
+
+    if not buckets and retry_after_ms is None:
+        return None
+
+    # raw_headers are included but should be sanitized by downstream log/event tooling.
+    return {
+        "provider": str(provider),
+        "observed_at_ms": observed_at_ms,
+        "buckets": buckets,
+        "retry_after_ms": retry_after_ms,
+        "raw_headers": {k: v for k, v in normalized.items() if k != "authorization"},
+    }
+

--- a/breadboard_sdk/__init__.py
+++ b/breadboard_sdk/__init__.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 from .client import ApiError, BreadboardClient
+from .import_ir import import_ir_to_cli_bridge_events, load_json, write_events_jsonl
 
-__all__ = ["ApiError", "BreadboardClient"]
-
+__all__ = [
+    "ApiError",
+    "BreadboardClient",
+    "import_ir_to_cli_bridge_events",
+    "load_json",
+    "write_events_jsonl",
+]

--- a/breadboard_sdk/client.py
+++ b/breadboard_sdk/client.py
@@ -234,3 +234,41 @@ class BreadboardClient:
             if line.startswith("data:"):
                 data_lines.append(line[len("data:") :].lstrip())
 
+    # --- Provider auth material (in-memory engine store) --------------------
+    def attach_provider_auth(
+        self,
+        *,
+        provider_id: str,
+        api_key: str | None = None,
+        headers: Dict[str, str] | None = None,
+        base_url: str | None = None,
+        routing: Dict[str, Any] | None = None,
+        ttl_seconds: int | None = None,
+        is_subscription_plan: bool = False,
+        required_profile: Dict[str, Any] | None = None,
+        config_path: str | None = None,
+        overrides: Dict[str, Any] | None = None,
+        alias: str | None = None,
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {
+            "material": {
+                "provider_id": provider_id,
+                "alias": alias,
+                "api_key": api_key,
+                "headers": headers or {},
+                "base_url": base_url,
+                "routing": routing,
+                "ttl_seconds": ttl_seconds,
+                "is_subscription_plan": bool(is_subscription_plan),
+            },
+            "required_profile": required_profile,
+            "config_path": config_path,
+            "overrides": overrides,
+        }
+        return self._request("POST", "/v1/provider-auth/attach", body=body)
+
+    def detach_provider_auth(self, *, provider_id: str, alias: str | None = None) -> Dict[str, Any]:
+        return self._request("POST", "/v1/provider-auth/detach", body={"provider_id": provider_id, "alias": alias})
+
+    def provider_auth_status(self) -> Dict[str, Any]:
+        return self._request("GET", "/v1/provider-auth/status")

--- a/breadboard_sdk/import_ir.py
+++ b/breadboard_sdk/import_ir.py
@@ -1,0 +1,112 @@
+"""Session import helpers: Import IR -> CLI bridge events JSONL."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+def _text_from_ir_message(msg: Dict[str, Any]) -> str:
+    parts = msg.get("parts") or []
+    if not isinstance(parts, list):
+        return ""
+    texts: List[str] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") == "text":
+            text = part.get("text")
+            if isinstance(text, str):
+                texts.append(text)
+    return "".join(texts)
+
+
+def _stable_event_id(session_id: str, seq: int, event_type: str, timestamp_ms: int) -> str:
+    payload = f"{session_id}:{seq}:{event_type}:{timestamp_ms}"
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"evt_{digest[:24]}"
+
+
+def import_ir_to_cli_bridge_events(
+    import_ir: Dict[str, Any],
+    *,
+    session_id: str,
+    protocol_version: str = "1.0",
+    base_timestamp_ms: int = 0,
+) -> List[Dict[str, Any]]:
+    """Convert Import IR v1 to a list of CLI bridge event envelope dicts."""
+    conv = import_ir.get("conversation") if isinstance(import_ir, dict) else None
+    if not isinstance(conv, dict):
+        raise ValueError("import_ir missing conversation")
+    messages = conv.get("messages") or []
+    if not isinstance(messages, list):
+        raise ValueError("conversation.messages must be a list")
+
+    out: List[Dict[str, Any]] = []
+    seq = 0
+    timestamp_ms = int(base_timestamp_ms)
+    turn: Optional[int] = None
+
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role") or "")
+        if role not in {"system", "user", "assistant", "tool"}:
+            continue
+
+        if role == "user":
+            turn = 0 if turn is None else (turn + 1)
+
+        if role == "system":
+            # System messages are not currently part of the CLI bridge stream contract.
+            continue
+
+        event_type = "assistant_message" if role == "assistant" else "user_message"
+        if role == "tool":
+            event_type = "tool_result"
+
+        seq += 1
+        timestamp_ms += 1
+        envelope: Dict[str, Any] = {
+            "id": _stable_event_id(session_id, seq, event_type, timestamp_ms),
+            "seq": seq,
+            "type": event_type,
+            "session_id": session_id,
+            "turn": turn,
+            "timestamp": timestamp_ms,
+            "timestamp_ms": timestamp_ms,
+            "protocol_version": protocol_version,
+        }
+
+        if event_type in {"assistant_message", "user_message"}:
+            envelope["payload"] = {
+                "text": _text_from_ir_message(msg),
+                "message": msg,
+                "source": "import_ir",
+            }
+        else:
+            envelope["payload"] = {
+                "status": "ok",
+                "error": False,
+                "result": msg,
+            }
+
+        out.append(envelope)
+
+    return out
+
+
+def write_events_jsonl(events: Iterable[Dict[str, Any]], output_path: str | Path) -> None:
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for event in events:
+            f.write(json.dumps(event, ensure_ascii=False))
+            f.write("\n")
+
+
+def load_json(path: str | Path) -> Dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+

--- a/docs/concepts/provider-plan-auth.md
+++ b/docs/concepts/provider-plan-auth.md
@@ -1,0 +1,61 @@
+# Provider Plan Auth (Engine: In-Memory Attach/Detach/Status)
+
+Some provider authentication sources are **compliance-sensitive** (for example, consumer subscription plans). BreadBoard’s engine treats these sources conservatively:
+
+- The engine only accepts **short-lived** auth material.
+- The engine stores auth material **in-memory only** (never persisted).
+- When an auth source is compliance-sensitive, the engine can require a **sealed profile** conformance check before accepting it.
+
+## Endpoints
+
+All endpoints are part of the CLI bridge FastAPI service.
+
+- `POST /v1/provider-auth/attach`
+- `POST /v1/provider-auth/detach`
+- `GET /v1/provider-auth/status`
+
+All endpoints are protected by the same `BREADBOARD_API_TOKEN` bearer middleware as the rest of the CLI bridge surface (when enabled).
+
+## Attach
+
+Attach stores an `EngineAuthMaterial` overlay keyed by `provider_id` (alias is reserved for later multi-account support).
+
+The engine will apply attached overlays to outgoing provider calls with the following precedence:
+
+1. Attached auth material (in-memory)
+2. Environment/config auth resolution (existing behavior)
+3. Provider defaults
+
+### Local-only gating (subscription-plan sources)
+
+If `material.is_subscription_plan=true`, the engine rejects non-loopback requests by default. This prevents accidental forwarding of compliance-sensitive tokens to a remote engine.
+
+### Sealed profile enforcement (scaffolding)
+
+If `required_profile` is provided, the request must also include `config_path`. The engine will:
+
+1. Load the resolved runtime config from `config_path`
+2. Apply optional dotted-key `overrides`
+3. Compute a conformance hash over `required_profile.locked_json_pointers`
+4. Reject the attach request if the hash differs
+
+## Detach
+
+Detach removes any stored material for `(provider_id, alias)`.
+
+## Status
+
+Status returns **sanitized** metadata only:
+
+- header key names (not values)
+- presence/absence of `api_key`
+- expiry timestamps
+- base URL and routing key names
+
+No secrets are returned.
+
+## Related Contract
+
+- `limits_update` event payload schema:
+  - `docs/contracts/cli_bridge/schemas/session_event_payload_limits_update.schema.json`
+

--- a/docs/concepts/session-import.md
+++ b/docs/concepts/session-import.md
@@ -1,0 +1,53 @@
+# Session Import (IR + Canonical Event Stream)
+
+BreadBoard supports importing external session transcripts (from harnesses or other tools) by converting them into the **canonical CLI bridge event stream** format used by the TUI/SDKs.
+
+The import pipeline is designed to be:
+
+- **Deterministic**: repeated conversions produce identical event envelopes.
+- **Contract-gated**: inputs/outputs are defined by JSON schemas under `docs/contracts/`.
+- **Safe by default**: the engine-side converter does not need to persist any secrets.
+
+## Contracts
+
+- Import IR schema:
+  - `docs/contracts/import/import_ir_v1.schema.json`
+- Import run manifest schema:
+  - `docs/contracts/import/import_run_manifest_v1.schema.json`
+- Output event envelope schema:
+  - `docs/contracts/cli_bridge/schemas/session_event_envelope.schema.json`
+
+## Import IR v1 (Input)
+
+`import_ir_v1` is a provider-agnostic JSON representation of a conversation:
+
+- A `conversation.messages[]` array with `role` and `parts`.
+- Optional tool call/result structures attached to messages.
+- Optional `finish` metadata.
+
+This format is intentionally permissive (additional metadata is allowed) so that different harnesses can carry their own extra fields while still conforming to a shared baseline contract.
+
+## Canonical Events JSONL (Output)
+
+The canonical output is a JSONL file where each line is a **CLI bridge event envelope**.
+
+Fields like `id` and `seq` are produced deterministically by the converter so that downstream tooling can do stable diffs and reproducible imports.
+
+## Converter Tool
+
+Engine-owned conversion script:
+
+```bash
+python scripts/import_ir_to_events_jsonl.py \
+  --input path/to/import_ir.json \
+  --output path/to/events.jsonl \
+  --session-id imported-session
+```
+
+By default, the script validates the input JSON against `import_ir_v1.schema.json`. Use `--no-validate` to skip validation (not recommended).
+
+## Notes / Scope
+
+- This is an **engine-assist** surface. The actual filesystem importer UX typically belongs in the TUI.
+- The initial converter focuses on mapping IR messages into `user_message` / `assistant_message` / `tool_result` events. It can be extended to emit richer event types as needed.
+

--- a/docs/contracts/cli_bridge/openapi.json
+++ b/docs/contracts/cli_bridge/openapi.json
@@ -146,6 +146,35 @@
         "title": "CTreeSnapshotResponse",
         "type": "object"
       },
+      "EmulationProfileRequirement": {
+        "description": "Sealed-profile requirement used to gate compliance-sensitive auth sources.",
+        "properties": {
+          "conformance_hash": {
+            "description": "sha256 hash over locked JSON pointers.",
+            "title": "Conformance Hash",
+            "type": "string"
+          },
+          "locked_json_pointers": {
+            "description": "RFC6901 JSON pointers used for the hash.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Locked Json Pointers",
+            "type": "array"
+          },
+          "profile_id": {
+            "description": "Stable sealed profile identifier.",
+            "title": "Profile Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "profile_id",
+          "conformance_hash"
+        ],
+        "title": "EmulationProfileRequirement",
+        "type": "object"
+      },
       "ErrorResponse": {
         "properties": {
           "detail": {
@@ -313,6 +342,340 @@
           "models"
         ],
         "title": "ModelCatalogResponse",
+        "type": "object"
+      },
+      "ProviderAuthAttachRequest": {
+        "properties": {
+          "config_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Config path used for sealed-profile enforcement.",
+            "title": "Config Path"
+          },
+          "material": {
+            "$ref": "#/components/schemas/ProviderAuthMaterial"
+          },
+          "overrides": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional dotted-key override map for hashing.",
+            "title": "Overrides"
+          },
+          "required_profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EmulationProfileRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "material"
+        ],
+        "title": "ProviderAuthAttachRequest",
+        "type": "object"
+      },
+      "ProviderAuthAttachResponse": {
+        "properties": {
+          "detail": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detail"
+          },
+          "ok": {
+            "default": true,
+            "title": "Ok",
+            "type": "boolean"
+          }
+        },
+        "title": "ProviderAuthAttachResponse",
+        "type": "object"
+      },
+      "ProviderAuthDetachRequest": {
+        "properties": {
+          "alias": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alias"
+          },
+          "provider_id": {
+            "title": "Provider Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider_id"
+        ],
+        "title": "ProviderAuthDetachRequest",
+        "type": "object"
+      },
+      "ProviderAuthDetachResponse": {
+        "properties": {
+          "ok": {
+            "default": true,
+            "title": "Ok",
+            "type": "boolean"
+          }
+        },
+        "title": "ProviderAuthDetachResponse",
+        "type": "object"
+      },
+      "ProviderAuthMaterial": {
+        "description": "Short-lived auth material that the Engine can apply to provider calls.",
+        "properties": {
+          "alias": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional alias for multi-account support (MVP: unused).",
+            "title": "Alias"
+          },
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Provider API key or bearer token material.",
+            "title": "Api Key"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional base URL override.",
+            "title": "Base Url"
+          },
+          "expires_at_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional expiry time in ms since epoch.",
+            "title": "Expires At Ms"
+          },
+          "headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Additional request headers (no refresh tokens).",
+            "title": "Headers",
+            "type": "object"
+          },
+          "is_subscription_plan": {
+            "default": false,
+            "description": "Marks compliance-sensitive plan auth (defaults to false).",
+            "title": "Is Subscription Plan",
+            "type": "boolean"
+          },
+          "issued_at_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional issue time in ms since epoch.",
+            "title": "Issued At Ms"
+          },
+          "provider_id": {
+            "description": "Provider id (e.g. openai, openrouter, anthropic).",
+            "title": "Provider Id",
+            "type": "string"
+          },
+          "routing": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional routing metadata (provider-specific).",
+            "title": "Routing"
+          },
+          "ttl_seconds": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional TTL applied if expires_at_ms is absent.",
+            "title": "Ttl Seconds"
+          }
+        },
+        "required": [
+          "provider_id"
+        ],
+        "title": "ProviderAuthMaterial",
+        "type": "object"
+      },
+      "ProviderAuthStatusItem": {
+        "properties": {
+          "alias": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alias"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url"
+          },
+          "expires_at_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires At Ms"
+          },
+          "expires_in_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expires In Ms"
+          },
+          "has_api_key": {
+            "default": false,
+            "title": "Has Api Key",
+            "type": "boolean"
+          },
+          "header_keys": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Header Keys",
+            "type": "array"
+          },
+          "is_subscription_plan": {
+            "default": false,
+            "title": "Is Subscription Plan",
+            "type": "boolean"
+          },
+          "issued_at_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Issued At Ms"
+          },
+          "provider_id": {
+            "title": "Provider Id",
+            "type": "string"
+          },
+          "required_profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EmulationProfileRequirement"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "routing_keys": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Routing Keys",
+            "type": "array"
+          }
+        },
+        "required": [
+          "provider_id"
+        ],
+        "title": "ProviderAuthStatusItem",
+        "type": "object"
+      },
+      "ProviderAuthStatusResponse": {
+        "properties": {
+          "attached": {
+            "items": {
+              "$ref": "#/components/schemas/ProviderAuthStatusItem"
+            },
+            "title": "Attached",
+            "type": "array"
+          }
+        },
+        "title": "ProviderAuthStatusResponse",
         "type": "object"
       },
       "SessionCommandRequest": {
@@ -1607,6 +1970,141 @@
           }
         },
         "summary": "Engine Status"
+      }
+    },
+    "/v1/provider-auth/attach": {
+      "post": {
+        "description": "Attach short-lived provider auth material to the in-memory engine store.",
+        "operationId": "attach_provider_auth_v1_provider_auth_attach_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProviderAuthAttachRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderAuthAttachResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Attach Provider Auth"
+      }
+    },
+    "/v1/provider-auth/detach": {
+      "post": {
+        "operationId": "detach_provider_auth_v1_provider_auth_detach_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProviderAuthDetachRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderAuthDetachResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Detach Provider Auth"
+      }
+    },
+    "/v1/provider-auth/status": {
+      "get": {
+        "operationId": "provider_auth_status_v1_provider_auth_status_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderAuthStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Provider Auth Status"
       }
     }
   }

--- a/docs/contracts/cli_bridge/schemas/provider_auth_attach_request.schema.json
+++ b/docs/contracts/cli_bridge/schemas/provider_auth_attach_request.schema.json
@@ -1,0 +1,202 @@
+{
+  "$defs": {
+    "EmulationProfileRequirement": {
+      "description": "Sealed-profile requirement used to gate compliance-sensitive auth sources.",
+      "properties": {
+        "conformance_hash": {
+          "description": "sha256 hash over locked JSON pointers.",
+          "title": "Conformance Hash",
+          "type": "string"
+        },
+        "locked_json_pointers": {
+          "description": "RFC6901 JSON pointers used for the hash.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Locked Json Pointers",
+          "type": "array"
+        },
+        "profile_id": {
+          "description": "Stable sealed profile identifier.",
+          "title": "Profile Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "profile_id",
+        "conformance_hash"
+      ],
+      "title": "EmulationProfileRequirement",
+      "type": "object"
+    },
+    "ProviderAuthMaterial": {
+      "description": "Short-lived auth material that the Engine can apply to provider calls.",
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional alias for multi-account support (MVP: unused).",
+          "title": "Alias"
+        },
+        "api_key": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Provider API key or bearer token material.",
+          "title": "Api Key"
+        },
+        "base_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional base URL override.",
+          "title": "Base Url"
+        },
+        "expires_at_ms": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional expiry time in ms since epoch.",
+          "title": "Expires At Ms"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Additional request headers (no refresh tokens).",
+          "title": "Headers",
+          "type": "object"
+        },
+        "is_subscription_plan": {
+          "default": false,
+          "description": "Marks compliance-sensitive plan auth (defaults to false).",
+          "title": "Is Subscription Plan",
+          "type": "boolean"
+        },
+        "issued_at_ms": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional issue time in ms since epoch.",
+          "title": "Issued At Ms"
+        },
+        "provider_id": {
+          "description": "Provider id (e.g. openai, openrouter, anthropic).",
+          "title": "Provider Id",
+          "type": "string"
+        },
+        "routing": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional routing metadata (provider-specific).",
+          "title": "Routing"
+        },
+        "ttl_seconds": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional TTL applied if expires_at_ms is absent.",
+          "title": "Ttl Seconds"
+        }
+      },
+      "required": [
+        "provider_id"
+      ],
+      "title": "ProviderAuthMaterial",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "config_path": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Config path used for sealed-profile enforcement.",
+      "title": "Config Path"
+    },
+    "material": {
+      "$ref": "#/$defs/ProviderAuthMaterial"
+    },
+    "overrides": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional dotted-key override map for hashing.",
+      "title": "Overrides"
+    },
+    "required_profile": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/EmulationProfileRequirement"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null
+    }
+  },
+  "required": [
+    "material"
+  ],
+  "title": "ProviderAuthAttachRequest",
+  "type": "object"
+}

--- a/docs/contracts/cli_bridge/schemas/provider_auth_attach_response.schema.json
+++ b/docs/contracts/cli_bridge/schemas/provider_auth_attach_response.schema.json
@@ -1,0 +1,24 @@
+{
+  "properties": {
+    "detail": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Detail"
+    },
+    "ok": {
+      "default": true,
+      "title": "Ok",
+      "type": "boolean"
+    }
+  },
+  "title": "ProviderAuthAttachResponse",
+  "type": "object"
+}

--- a/docs/contracts/cli_bridge/schemas/provider_auth_detach_request.schema.json
+++ b/docs/contracts/cli_bridge/schemas/provider_auth_detach_request.schema.json
@@ -1,0 +1,25 @@
+{
+  "properties": {
+    "alias": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Alias"
+    },
+    "provider_id": {
+      "title": "Provider Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "provider_id"
+  ],
+  "title": "ProviderAuthDetachRequest",
+  "type": "object"
+}

--- a/docs/contracts/cli_bridge/schemas/provider_auth_detach_response.schema.json
+++ b/docs/contracts/cli_bridge/schemas/provider_auth_detach_response.schema.json
@@ -1,0 +1,11 @@
+{
+  "properties": {
+    "ok": {
+      "default": true,
+      "title": "Ok",
+      "type": "boolean"
+    }
+  },
+  "title": "ProviderAuthDetachResponse",
+  "type": "object"
+}

--- a/docs/contracts/cli_bridge/schemas/provider_auth_status_response.schema.json
+++ b/docs/contracts/cli_bridge/schemas/provider_auth_status_response.schema.json
@@ -1,0 +1,152 @@
+{
+  "$defs": {
+    "EmulationProfileRequirement": {
+      "description": "Sealed-profile requirement used to gate compliance-sensitive auth sources.",
+      "properties": {
+        "conformance_hash": {
+          "description": "sha256 hash over locked JSON pointers.",
+          "title": "Conformance Hash",
+          "type": "string"
+        },
+        "locked_json_pointers": {
+          "description": "RFC6901 JSON pointers used for the hash.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Locked Json Pointers",
+          "type": "array"
+        },
+        "profile_id": {
+          "description": "Stable sealed profile identifier.",
+          "title": "Profile Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "profile_id",
+        "conformance_hash"
+      ],
+      "title": "EmulationProfileRequirement",
+      "type": "object"
+    },
+    "ProviderAuthStatusItem": {
+      "properties": {
+        "alias": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Alias"
+        },
+        "base_url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Base Url"
+        },
+        "expires_at_ms": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Expires At Ms"
+        },
+        "expires_in_ms": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Expires In Ms"
+        },
+        "has_api_key": {
+          "default": false,
+          "title": "Has Api Key",
+          "type": "boolean"
+        },
+        "header_keys": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Header Keys",
+          "type": "array"
+        },
+        "is_subscription_plan": {
+          "default": false,
+          "title": "Is Subscription Plan",
+          "type": "boolean"
+        },
+        "issued_at_ms": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Issued At Ms"
+        },
+        "provider_id": {
+          "title": "Provider Id",
+          "type": "string"
+        },
+        "required_profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EmulationProfileRequirement"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "routing_keys": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Routing Keys",
+          "type": "array"
+        }
+      },
+      "required": [
+        "provider_id"
+      ],
+      "title": "ProviderAuthStatusItem",
+      "type": "object"
+    }
+  },
+  "properties": {
+    "attached": {
+      "items": {
+        "$ref": "#/$defs/ProviderAuthStatusItem"
+      },
+      "title": "Attached",
+      "type": "array"
+    }
+  },
+  "title": "ProviderAuthStatusResponse",
+  "type": "object"
+}

--- a/docs/contracts/cli_bridge/schemas/session_event_envelope.schema.json
+++ b/docs/contracts/cli_bridge/schemas/session_event_envelope.schema.json
@@ -261,6 +261,22 @@
     {
       "properties": {
         "payload": {
+          "$ref": "session_event_payload_limits_update.schema.json"
+        },
+        "type": {
+          "const": "limits_update"
+        }
+      },
+      "required": [
+        "type",
+        "payload"
+      ],
+      "title": "limits_updateEvent",
+      "type": "object"
+    },
+    {
+      "properties": {
+        "payload": {
           "$ref": "session_event_payload_completion.schema.json"
         },
         "type": {

--- a/docs/contracts/cli_bridge/schemas/session_event_payload_limits_update.schema.json
+++ b/docs/contracts/cli_bridge/schemas/session_event_payload_limits_update.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "properties": {
+    "buckets": {
+      "items": {
+        "additionalProperties": true,
+        "properties": {
+          "limit": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "raw": {
+            "additionalProperties": true,
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "remaining": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "reset_at_ms": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "scope": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "window_seconds": {
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "observed_at_ms": {
+      "type": "integer"
+    },
+    "provider": {
+      "type": "string"
+    },
+    "raw_headers": {
+      "additionalProperties": true,
+      "type": [
+        "object",
+        "null"
+      ]
+    },
+    "retry_after_ms": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "provider",
+    "observed_at_ms",
+    "buckets"
+  ],
+  "title": "LimitsUpdatePayload",
+  "type": "object"
+}

--- a/docs/contracts/emulation_profile/emulation_profile_manifest_v1.schema.json
+++ b/docs/contracts/emulation_profile/emulation_profile_manifest_v1.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "breadboard.emulation_profile_manifest.v1",
+  "title": "EmulationProfileManifestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "profile_id",
+    "locked_json_pointers",
+    "conformance_hash"
+  ],
+  "properties": {
+    "schema": {
+      "const": "breadboard.emulation_profile_manifest.v1"
+    },
+    "profile_id": {
+      "type": "string"
+    },
+    "display_name": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "description": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "locked_json_pointers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1
+    },
+    "conformance_hash": {
+      "type": "string"
+    },
+    "compat": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
+    }
+  }
+}
+

--- a/docs/contracts/import/import_ir_v1.schema.json
+++ b/docs/contracts/import/import_ir_v1.schema.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "breadboard.import_ir.v1",
+  "title": "ImportIRv1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "conversation"
+  ],
+  "properties": {
+    "schema": {
+      "const": "breadboard.import_ir.v1"
+    },
+    "created_at_ms": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "meta": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
+    },
+    "conversation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "ir_version",
+        "messages"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "ir_version": {
+          "type": "string"
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "role"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "role": {
+                "enum": [
+                  "system",
+                  "user",
+                  "assistant",
+                  "tool"
+                ]
+              },
+              "parts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "type": {
+                      "enum": [
+                        "text",
+                        "json",
+                        "media"
+                      ]
+                    },
+                    "text": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "value": {},
+                    "kind": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "uri": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "mime": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "default": []
+              },
+              "tool_calls": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "required": [
+                    "id",
+                    "name",
+                    "args"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "args": {},
+                    "group": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "default": []
+              },
+              "tool_results": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "required": [
+                    "tool_call_id",
+                    "ok"
+                  ],
+                  "properties": {
+                    "tool_call_id": {
+                      "type": "string"
+                    },
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "result": {},
+                    "error": {
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "additionalProperties": true
+                    }
+                  }
+                },
+                "default": []
+              },
+              "corr_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": []
+              },
+              "time": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+              "cursor",
+              "type",
+              "payload"
+            ],
+            "properties": {
+              "cursor": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "text",
+                  "tool_call",
+                  "reasoning_meta",
+                  "logprob",
+                  "finish"
+                ]
+              },
+              "payload": {}
+            }
+          },
+          "default": []
+        },
+        "finish": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": true,
+          "required": [
+            "reason",
+            "usage"
+          ],
+          "properties": {
+            "reason": {
+              "enum": [
+                "stop",
+                "tool_call",
+                "length",
+                "error"
+              ]
+            },
+            "usage": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "provider_meta": {},
+            "agent_summary": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": true
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/docs/contracts/import/import_run_manifest_v1.schema.json
+++ b/docs/contracts/import/import_run_manifest_v1.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "breadboard.import_run_manifest.v1",
+  "title": "ImportRunManifestV1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "run_id",
+    "input_ir_path",
+    "output_events_path"
+  ],
+  "properties": {
+    "schema": {
+      "const": "breadboard.import_run_manifest.v1"
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "input_ir_path": {
+      "type": "string"
+    },
+    "output_events_path": {
+      "type": "string"
+    },
+    "created_at_ms": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "notes": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "meta": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": true
+    }
+  }
+}
+

--- a/docs/contracts/provider_plans/provider_policy_manifest_v1.schema.json
+++ b/docs/contracts/provider_plans/provider_policy_manifest_v1.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "breadboard.provider_policy_manifest.v1",
+  "title": "ProviderPolicyManifestV1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema",
+    "provider_id",
+    "plan_id",
+    "supported",
+    "support_mode",
+    "requires_explicit_enable",
+    "local_only",
+    "requires_sealed_profile",
+    "notes"
+  ],
+  "properties": {
+    "schema": {
+      "const": "breadboard.provider_policy_manifest.v1"
+    },
+    "provider_id": {
+      "type": "string"
+    },
+    "plan_id": {
+      "type": "string"
+    },
+    "supported": {
+      "type": "boolean"
+    },
+    "support_mode": {
+      "enum": [
+        "supported",
+        "harness_backed_only",
+        "unsupported"
+      ]
+    },
+    "requires_explicit_enable": {
+      "type": "boolean"
+    },
+    "local_only": {
+      "type": "boolean"
+    },
+    "requires_sealed_profile": {
+      "type": "boolean"
+    },
+    "notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}
+

--- a/docs/provider_plans/policy_manifests/anthropic_consumer_subscription.json
+++ b/docs/provider_plans/policy_manifests/anthropic_consumer_subscription.json
@@ -1,0 +1,15 @@
+{
+  "schema": "breadboard.provider_policy_manifest.v1",
+  "provider_id": "anthropic",
+  "plan_id": "consumer_subscription",
+  "supported": false,
+  "support_mode": "unsupported",
+  "requires_explicit_enable": true,
+  "local_only": true,
+  "requires_sealed_profile": false,
+  "notes": [
+    "Unsupported by default: consumer subscription tokens are compliance-sensitive.",
+    "Use API keys / enterprise auth instead."
+  ]
+}
+

--- a/docs/provider_plans/policy_manifests/openai_codex_chatgpt_plan.json
+++ b/docs/provider_plans/policy_manifests/openai_codex_chatgpt_plan.json
@@ -1,0 +1,15 @@
+{
+  "schema": "breadboard.provider_policy_manifest.v1",
+  "provider_id": "openai",
+  "plan_id": "codex_chatgpt_subscription",
+  "supported": false,
+  "support_mode": "harness_backed_only",
+  "requires_explicit_enable": true,
+  "local_only": true,
+  "requires_sealed_profile": true,
+  "notes": [
+    "Default-off: compliance-sensitive subscription plan auth.",
+    "Only support via documented harness-backed integration; no impersonation."
+  ]
+}
+

--- a/scripts/import_ir_to_events_jsonl.py
+++ b/scripts/import_ir_to_events_jsonl.py
@@ -1,0 +1,57 @@
+"""Convert Import IR JSON into CLI bridge event stream JSONL.
+
+This is intended as a deterministic, engine-owned conversion tool used by TUI-side
+importers (filesystem, harness export) to produce the canonical stream artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from jsonschema import Draft202012Validator
+
+from breadboard_sdk.import_ir import import_ir_to_cli_bridge_events, write_events_jsonl
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="Path to Import IR JSON")
+    parser.add_argument("--output", required=True, help="Path to output events JSONL")
+    parser.add_argument("--session-id", default="imported-session", help="Session id to embed in event envelopes")
+    parser.add_argument("--protocol-version", default="1.0", help="CLI bridge protocol_version to embed")
+    parser.add_argument("--no-validate", action="store_true", help="Skip jsonschema validation of the input IR")
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    import_ir = _load_json(input_path)
+    if not args.no_validate:
+        schema = _load_json(root / "docs" / "contracts" / "import" / "import_ir_v1.schema.json")
+        Draft202012Validator.check_schema(schema)
+        validator = Draft202012Validator(schema)
+        errors = list(validator.iter_errors(import_ir))
+        if errors:
+            raise SystemExit(f"Import IR failed schema validation: {errors}")
+
+    events = import_ir_to_cli_bridge_events(
+        import_ir,
+        session_id=str(args.session_id),
+        protocol_version=str(args.protocol_version),
+        base_timestamp_ms=int(import_ir.get("created_at_ms") or 0),
+    )
+    write_events_jsonl(events, output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/tests/fixtures/contracts/emulation_profile/sample_manifest_v1.json
+++ b/tests/fixtures/contracts/emulation_profile/sample_manifest_v1.json
@@ -1,0 +1,12 @@
+{
+  "schema": "breadboard.emulation_profile_manifest.v1",
+  "profile_id": "bbprof_fixture",
+  "display_name": "Fixture Profile",
+  "description": "Test-only profile manifest fixture.",
+  "locked_json_pointers": [
+    "/provider",
+    "/dialect"
+  ],
+  "conformance_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+}
+

--- a/tests/fixtures/contracts/import_ir/sample_import_ir_v1.json
+++ b/tests/fixtures/contracts/import_ir/sample_import_ir_v1.json
@@ -1,0 +1,42 @@
+{
+  "schema": "breadboard.import_ir.v1",
+  "created_at_ms": 0,
+  "meta": {
+    "source": "fixture"
+  },
+  "conversation": {
+    "id": "conv-1",
+    "ir_version": "1",
+    "messages": [
+      {
+        "id": "msg-1",
+        "role": "user",
+        "parts": [
+          {
+            "type": "text",
+            "text": "hello"
+          }
+        ]
+      },
+      {
+        "id": "msg-2",
+        "role": "assistant",
+        "parts": [
+          {
+            "type": "text",
+            "text": "hi"
+          }
+        ]
+      }
+    ],
+    "events": [],
+    "finish": {
+      "reason": "stop",
+      "usage": {
+        "input_tokens": 1,
+        "output_tokens": 1
+      }
+    }
+  }
+}
+

--- a/tests/fixtures/contracts/import_ir/sample_import_run_manifest_v1.json
+++ b/tests/fixtures/contracts/import_ir/sample_import_run_manifest_v1.json
@@ -1,0 +1,9 @@
+{
+  "schema": "breadboard.import_run_manifest.v1",
+  "run_id": "run-1",
+  "input_ir_path": "input.json",
+  "output_events_path": "events.jsonl",
+  "created_at_ms": 0,
+  "notes": "fixture"
+}
+

--- a/tests/test_cli_bridge_contract_exports.py
+++ b/tests/test_cli_bridge_contract_exports.py
@@ -34,10 +34,16 @@ def test_cli_bridge_contract_files_present() -> None:
         "session_event_payload_ctree_snapshot.schema.json",
         "session_event_payload_task_event.schema.json",
         "session_event_payload_reward_update.schema.json",
+        "session_event_payload_limits_update.schema.json",
         "session_event_payload_completion.schema.json",
         "session_event_payload_log_link.schema.json",
         "session_event_payload_error.schema.json",
         "session_event_payload_run_finished.schema.json",
+        "provider_auth_attach_request.schema.json",
+        "provider_auth_attach_response.schema.json",
+        "provider_auth_detach_request.schema.json",
+        "provider_auth_detach_response.schema.json",
+        "provider_auth_status_response.schema.json",
     ]
 
     missing = [name for name in expected_schemas if not (schema_dir / name).is_file()]
@@ -73,6 +79,7 @@ def test_session_event_schema_variants_cover_all_event_types() -> None:
         "ctree_snapshot",
         "task_event",
         "reward_update",
+        "limits_update",
         "completion",
         "log_link",
         "error",
@@ -108,6 +115,7 @@ def test_session_event_payloads_validate_minimal_samples() -> None:
         "ctree_snapshot": {},
         "task_event": {"kind": "step"},
         "reward_update": {"summary": {}},
+        "limits_update": {"provider": "openai", "observed_at_ms": 0, "buckets": []},
         "completion": {"summary": {}},
         "log_link": {"url": "https://example.com/log"},
         "error": {"message": "error"},

--- a/tests/test_import_and_profile_contracts.py
+++ b/tests/test_import_and_profile_contracts.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+
+@pytest.mark.parametrize(
+    "schema_path, fixture_paths",
+    [
+        (
+            "docs/contracts/import/import_ir_v1.schema.json",
+            ["tests/fixtures/contracts/import_ir/sample_import_ir_v1.json"],
+        ),
+        (
+            "docs/contracts/import/import_run_manifest_v1.schema.json",
+            ["tests/fixtures/contracts/import_ir/sample_import_run_manifest_v1.json"],
+        ),
+        (
+            "docs/contracts/emulation_profile/emulation_profile_manifest_v1.schema.json",
+            ["tests/fixtures/contracts/emulation_profile/sample_manifest_v1.json"],
+        ),
+        (
+            "docs/contracts/provider_plans/provider_policy_manifest_v1.schema.json",
+            [
+                "docs/provider_plans/policy_manifests/openai_codex_chatgpt_plan.json",
+                "docs/provider_plans/policy_manifests/anthropic_consumer_subscription.json",
+            ],
+        ),
+    ],
+)
+def test_schema_is_valid_and_fixture_conforms(schema_path: str, fixture_paths: list[str]) -> None:
+    root = Path(__file__).resolve().parents[1]
+    schema = json.loads((root / schema_path).read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    for rel in fixture_paths:
+        fixture = json.loads((root / rel).read_text(encoding="utf-8"))
+        errors = list(validator.iter_errors(fixture))
+        assert not errors, f"{rel} failed schema validation: {errors}"

--- a/tests/test_import_ir_converter.py
+++ b/tests/test_import_ir_converter.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from breadboard_sdk.import_ir import import_ir_to_cli_bridge_events
+from jsonschema import Draft202012Validator, RefResolver
+
+
+def test_import_ir_to_events_jsonl_matches_event_envelope_schema() -> None:
+    root = Path(__file__).resolve().parents[1]
+    import_ir = json.loads(
+        (root / "tests/fixtures/contracts/import_ir/sample_import_ir_v1.json").read_text(encoding="utf-8")
+    )
+    events = import_ir_to_cli_bridge_events(import_ir, session_id="sess-import", protocol_version="1.0")
+    assert events, "Expected at least one converted event"
+
+    schema_dir = root / "docs/contracts/cli_bridge/schemas"
+    envelope = json.loads((schema_dir / "session_event_envelope.schema.json").read_text(encoding="utf-8"))
+    resolver = RefResolver(base_uri=schema_dir.resolve().as_uri() + "/", referrer=envelope)
+    validator = Draft202012Validator(envelope, resolver=resolver)
+
+    for evt in events:
+        errors = list(validator.iter_errors(evt))
+        assert not errors, f"Converted event failed validation: {errors}"
+
+
+def test_import_ir_conversion_is_deterministic() -> None:
+    root = Path(__file__).resolve().parents[1]
+    import_ir = json.loads(
+        (root / "tests/fixtures/contracts/import_ir/sample_import_ir_v1.json").read_text(encoding="utf-8")
+    )
+    events_a = import_ir_to_cli_bridge_events(import_ir, session_id="sess-import", protocol_version="1.0")
+    events_b = import_ir_to_cli_bridge_events(import_ir, session_id="sess-import", protocol_version="1.0")
+    assert events_a == events_b
+

--- a/tests/test_provider_auth_store.py
+++ b/tests/test_provider_auth_store.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import time
+
+from agentic_coder_prototype.auth.material import EngineAuthMaterial, EmulationProfileRequirement
+from agentic_coder_prototype.auth.store import ProviderAuthStore
+from agentic_coder_prototype.auth.enforcer import compute_conformance_hash, check_conformance
+
+
+def test_provider_auth_store_attach_detach_and_status_sanitizes() -> None:
+    store = ProviderAuthStore()
+    mat = EngineAuthMaterial(
+        provider_id="openai",
+        alias="",
+        api_key="secret",
+        headers={"Authorization": "Bearer secret", "X-Other": "ok"},
+        base_url="https://example.com",
+        routing={"a": 1},
+        is_subscription_plan=True,
+    )
+    store.attach(mat, ttl_seconds=60)
+    status = store.status()
+    assert status
+    assert status[0]["provider_id"] == "openai"
+    assert status[0]["has_api_key"] is True
+    assert "Authorization" in status[0]["header_keys"]
+    # Values are never returned, only keys.
+    assert "secret" not in str(status)
+
+    got = store.get("openai")
+    assert got is not None
+    assert store.detach("openai") is True
+    assert store.get("openai") is None
+
+
+def test_provider_auth_store_ttl_expires() -> None:
+    store = ProviderAuthStore()
+    now_ms = int(time.time() * 1000)
+    mat = EngineAuthMaterial(provider_id="openai", expires_at_ms=now_ms - 1)
+    store.attach(mat)
+    assert store.get("openai") is None
+
+
+def test_sealed_profile_conformance_hash_and_mismatch() -> None:
+    cfg = {"provider": "openai", "dialect": "pythonic", "nested": {"x": 1}}
+    pointers = ["/provider", "/dialect"]
+    expected = compute_conformance_hash(cfg, pointers)
+    ok = check_conformance(config=cfg, locked_json_pointers=pointers, expected_hash=expected)
+    assert ok.ok is True
+
+    cfg2 = dict(cfg)
+    cfg2["dialect"] = "other"
+    bad = check_conformance(config=cfg2, locked_json_pointers=pointers, expected_hash=expected)
+    assert bad.ok is False
+


### PR DESCRIPTION
## Summary
- Add CLI bridge provider-auth attach/detach/status endpoints with in-memory TTL store and optional sealed-profile conformance enforcement.
- Add `limits_update` event contract + best-effort emission from rate limit headers.
- Add Import IR v1 + run manifest contracts and a deterministic IR -> CLI bridge events JSONL converter (library + script).

## Notes
- Engine stores auth material in-memory only; status is sanitized (no secrets).
- CI: expanded `python_smoke` to cover new contracts and importer.

## Compat break
- [x] Compat break