### PR TITLE
TUI todo: snapshot-on-connect + todo event projection

### DIFF
--- a/agentic_coder_prototype/todo/projection.py
+++ b/agentic_coder_prototype/todo/projection.py
@@ -1,0 +1,41 @@
+"""Project TodoStore state into a TUI-friendly envelope.
+
+The engine may emit TODO updates as part of tool_call/tool_result payloads. The
+TUI expects a permissive, forward-compatible envelope (see
+docs/contracts/cli_bridge/schemas/session_event_payload_todo_update.schema.json).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def project_store_snapshot_to_tui_envelope(
+    snapshot: Dict[str, Any],
+    *,
+    scope_key: Optional[str] = None,
+    scope_label: Optional[str] = None,
+) -> Dict[str, Any]:
+    todos = snapshot.get("todos") if isinstance(snapshot, dict) else None
+    if not isinstance(todos, list):
+        todos = []
+
+    items: List[Dict[str, Any]] = []
+    for todo in todos:
+        if isinstance(todo, dict):
+            items.append(dict(todo))
+
+    journal = snapshot.get("journal") if isinstance(snapshot, dict) else None
+    revision = len(journal) if isinstance(journal, list) else None
+
+    envelope: Dict[str, Any] = {
+        "op": "snapshot",
+        "items": items,
+        "revision": revision,
+    }
+    if scope_key:
+        envelope["scope_key"] = scope_key
+    if scope_label:
+        envelope["scope_label"] = scope_label
+    return envelope
+


### PR DESCRIPTION
Adds snapshot-on-connect for todo state (CLI bridge injects latest todo snapshot when connecting without replay), and projects todo tool activity into payload.todo so the Ink TUI converges after reconnect/resume reset.

Tests:
- python -m pytest tests/test_session_state_events.py
- python -m pytest tests/test_cli_backend_streaming.py