### PR TITLE
TUI: TODO preview polish (auto-follow, ctree indicator, churn gates)

### DIFF
--- a/.github/workflows/tui-goldens-tier2-nightly.yml
+++ b/.github/workflows/tui-goldens-tier2-nightly.yml
@@ -186,3 +186,61 @@ jobs:
           path: |
             artifacts/runtime_triage_nightly/**
           if-no-files-found: ignore
+
+  todo_preview_churn_gate:
+    name: "Todo preview churn gate"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install deps (tui_skeleton)
+        working-directory: tui_skeleton
+        run: npm ci
+
+      - name: Compute churn metrics (preview-only)
+        working-directory: tui_skeleton
+        run: |
+          node --import tsx scripts/todo_preview_churn_gate.ts \
+            --input ui_baselines/u1/scenarios/todo_preview_churn_gate/input/events.jsonl \
+            --config ../agent_configs/codex_cli_gpt51mini_e4_live.yaml \
+            --out ../artifacts/todo_preview_churn_nightly/summary.json \
+            --strict
+
+      - name: Append summary
+        if: always()
+        run: |
+          python - <<'PY'
+          import json, os, pathlib
+          p = pathlib.Path("artifacts/todo_preview_churn_nightly/summary.json")
+          if not p.exists():
+              raise SystemExit(0)
+          d = json.loads(p.read_text(encoding="utf-8"))
+          lines = [
+              "### Todo preview churn gate",
+              f"- churn events: `{d.get('churn')}`",
+              f"- todo events: `{d.get('todoEvents')}`",
+              f"- input: `{d.get('input')}`",
+              "",
+          ]
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with open(summary, "a", encoding="utf-8") as out:
+                  out.write("\\n".join(lines))
+          print("\\n".join(lines))
+          PY
+
+      - name: Upload churn artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: todo-preview-churn-nightly
+          path: |
+            artifacts/todo_preview_churn_nightly/**
+          if-no-files-found: ignore

--- a/tui_skeleton/scripts/todo_preview_churn_gate.ts
+++ b/tui_skeleton/scripts/todo_preview_churn_gate.ts
@@ -1,0 +1,208 @@
+import { promises as fs } from "node:fs"
+import path from "node:path"
+import { ReplSessionController } from "../src/commands/repl/controller.js"
+import { normalizeSessionEvent } from "../src/repl/transcript/normalizeSessionEvent.js"
+import { buildTodoPreviewModel } from "../src/repl/components/replView/composer/todoPreview.js"
+
+type CliOptions = {
+  inputPath: string
+  configPath: string
+  outPath: string | null
+  strict: boolean
+  maxItems: number
+  strategy: "first_n" | "incomplete_first" | "active_first"
+  showHiddenCount: boolean
+  style: "minimal" | "nice" | "dense"
+  cols: number | null
+}
+
+const parseArgs = (): CliOptions => {
+  const args = process.argv.slice(2)
+  let inputPath = ""
+  let configPath = "agent_configs/codex_cli_gpt51mini_e4_live.yaml"
+  let outPath: string | null = null
+  let strict = false
+  let maxItems = 7
+  let strategy: CliOptions["strategy"] = "active_first"
+  let showHiddenCount = true
+  let style: CliOptions["style"] = "dense"
+  let cols: number | null = 120
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i]
+    switch (arg) {
+      case "--input":
+        inputPath = args[++i] ?? inputPath
+        break
+      case "--config":
+        configPath = args[++i] ?? configPath
+        break
+      case "--out":
+        outPath = args[++i] ?? outPath
+        break
+      case "--strict":
+        strict = true
+        break
+      case "--max-items": {
+        const raw = args[++i]
+        const parsed = raw != null ? Number(raw) : Number.NaN
+        if (Number.isFinite(parsed) && parsed > 0) maxItems = Math.floor(parsed)
+        break
+      }
+      case "--strategy": {
+        const raw = (args[++i] ?? "").trim()
+        if (raw === "first_n" || raw === "incomplete_first" || raw === "active_first") {
+          strategy = raw
+        }
+        break
+      }
+      case "--show-hidden-count":
+        showHiddenCount = true
+        break
+      case "--hide-hidden-count":
+        showHiddenCount = false
+        break
+      case "--style": {
+        const raw = (args[++i] ?? "").trim()
+        if (raw === "minimal" || raw === "nice" || raw === "dense") {
+          style = raw
+        }
+        break
+      }
+      case "--cols": {
+        const raw = args[++i]
+        const parsed = raw != null ? Number(raw) : Number.NaN
+        cols = Number.isFinite(parsed) && parsed >= 10 ? Math.floor(parsed) : null
+        break
+      }
+      default:
+        break
+    }
+  }
+
+  if (!inputPath) {
+    throw new Error("Usage: tsx scripts/todo_preview_churn_gate.ts --input <events.jsonl> [--strict]")
+  }
+
+  return { inputPath, configPath, outPath, strict, maxItems, strategy, showHiddenCount, style, cols }
+}
+
+const normalizePath = (value: string, baseDir: string): string => {
+  if (path.isAbsolute(value)) return value
+  return path.resolve(baseDir, value)
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === "object" && value != null
+
+const parseEvent = (raw: string): Record<string, unknown> | null => {
+  let parsed: any
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!parsed || typeof parsed !== "object") return null
+  if (!parsed.type) return null
+  const normalized = normalizeSessionEvent(parsed as Record<string, unknown>) as Record<string, unknown> | null
+  if (!normalized) return null
+  if (isRecord((parsed as any).payload)) {
+    return { ...normalized, payload: (parsed as any).payload }
+  }
+  return normalized
+}
+
+const isTodoUpdateEvent = (event: Record<string, unknown>): boolean => {
+  if (!isRecord(event.payload)) return false
+  const payload = event.payload as Record<string, unknown>
+  if (Object.prototype.hasOwnProperty.call(payload, "todo") && payload.todo != null) return true
+  const toolNameRaw =
+    (typeof payload.tool_name === "string" ? payload.tool_name : null) ??
+    (typeof payload.toolName === "string" ? payload.toolName : null) ??
+    (typeof payload.name === "string" ? payload.name : null) ??
+    ""
+  const toolName = toolNameRaw.trim().toLowerCase()
+  if (toolName.includes("todowrite")) return true
+  if (Array.isArray(payload.todos) && toolName.includes("todo")) return true
+  return false
+}
+
+const serializeModel = (model: ReturnType<typeof buildTodoPreviewModel>): string => {
+  if (!model) return ""
+  const lines = []
+  if (model.headerLine) lines.push(model.headerLine)
+  for (const item of model.items) lines.push(item.label)
+  return lines.join("\n")
+}
+
+const main = async () => {
+  const options = parseArgs()
+  const absInput = normalizePath(options.inputPath, process.cwd())
+  const absConfig = normalizePath(options.configPath, process.cwd())
+  const raw = await fs.readFile(absInput, "utf8")
+  const lines = raw.split(/\r?\n/).filter((line) => line.trim().length > 0)
+
+  const controller = new ReplSessionController({
+    configPath: absConfig,
+    workspace: null,
+    model: null,
+    remotePreference: null,
+    permissionMode: null,
+  }) as any
+
+  let prev = ""
+  let churn = 0
+  let todoEvents = 0
+  const churnEvents: Array<{ seq?: number | null; type?: string | null }> = []
+
+  for (const line of lines) {
+    const evt = parseEvent(line)
+    if (!evt) continue
+    controller.applyEvent(evt)
+    const model = buildTodoPreviewModel(controller.getState().todoStore, {
+      maxItems: options.maxItems,
+      strategy: options.strategy,
+      showHiddenCount: options.showHiddenCount,
+      style: options.style,
+      cols: options.cols,
+      stale: controller.getState().todoScopeStale,
+      scopeKey: controller.getState().todoScopeKey,
+      scopeLabel: controller.getState().todoScopeLabel,
+    })
+    const current = serializeModel(model)
+    const isTodo = isTodoUpdateEvent(evt)
+    if (isTodo) {
+      todoEvents += 1
+      prev = current
+      continue
+    }
+    if (current !== prev) {
+      churn += 1
+      churnEvents.push({
+        seq: typeof evt.seq === "number" ? evt.seq : null,
+        type: typeof evt.type === "string" ? evt.type : null,
+      })
+      prev = current
+    }
+  }
+
+  const result = {
+    input: absInput,
+    churn,
+    todoEvents,
+    churnEvents,
+  }
+  const outJson = `${JSON.stringify(result, null, 2)}\n`
+  if (options.outPath) {
+    const absOut = normalizePath(options.outPath, process.cwd())
+    await fs.mkdir(path.dirname(absOut), { recursive: true })
+    await fs.writeFile(absOut, outJson, "utf8")
+  }
+
+  console.log(outJson.trimEnd())
+  process.exit(options.strict && churn > 0 ? 2 : 0)
+}
+
+main().catch((error) => {
+  console.error("[todo_preview_churn_gate] failed:", error)
+  process.exit(1)
+})

--- a/tui_skeleton/src/commands/repl/__tests__/todoAutoFollowScope.test.ts
+++ b/tui_skeleton/src/commands/repl/__tests__/todoAutoFollowScope.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest"
+import { ReplSessionController } from "../controller.js"
+
+const event = (seq: number, type: string, payload: Record<string, unknown> = {}) => ({
+  id: String(seq),
+  seq,
+  turn: 1,
+  type,
+  payload,
+})
+
+describe("todo auto-follow scope", () => {
+  it("switches active scope to the most recently updated non-active scope when enabled", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      todoAutoFollowScope: "on",
+      todoAutoFollowHysteresisMs: 0,
+      todoAutoFollowManualOverrideMs: 15000,
+    }) as any
+
+    expect(controller.getState().todoScopeKey).toBe("main")
+
+    controller.applyEvent(
+      event(1, "tool_result", {
+        todo: {
+          op: "replace",
+          revision: 1,
+          scopeKey: "lane_a",
+          items: [{ content: "Ship it", status: "in_progress" }],
+        },
+      }),
+    )
+
+    expect(controller.getState().todoScopeKey).toBe("lane_a")
+    expect(controller.getState().todos.map((t: any) => t.title)).toEqual(["Ship it"])
+  })
+
+  it("respects manual override window", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      todoAutoFollowScope: "on",
+      todoAutoFollowHysteresisMs: 0,
+      todoAutoFollowManualOverrideMs: 10_000,
+    }) as any
+
+    controller.activeTodoScopeKey = "main"
+    controller.noteTodoScopeManualSelection()
+    const overrideUntil = controller.todoAutoFollowManualOverrideUntilAt
+    expect(typeof overrideUntil).toBe("number")
+
+    controller.applyEvent(
+      event(1, "tool_result", {
+        todo: {
+          op: "replace",
+          revision: 1,
+          scopeKey: "lane_b",
+          items: [{ content: "Background", status: "todo" }],
+        },
+      }),
+    )
+
+    expect(controller.getState().todoScopeKey).toBe("main")
+  })
+
+  it("applies hysteresis to avoid bouncing between scopes", () => {
+    const controller = new ReplSessionController({
+      configPath: "agent_configs/test_simple_native.yaml",
+      todoAutoFollowScope: "on",
+      todoAutoFollowHysteresisMs: 10_000,
+      todoAutoFollowManualOverrideMs: 0,
+    }) as any
+
+    controller.applyEvent(
+      event(1, "tool_result", {
+        todo: {
+          op: "replace",
+          revision: 1,
+          scopeKey: "lane_a",
+          items: [{ content: "A", status: "todo" }],
+        },
+      }),
+    )
+    expect(controller.getState().todoScopeKey).toBe("lane_a")
+
+    controller.applyEvent(
+      event(2, "tool_result", {
+        todo: {
+          op: "replace",
+          revision: 2,
+          scopeKey: "lane_b",
+          items: [{ content: "B", status: "todo" }],
+        },
+      }),
+    )
+
+    // Still lane_a due to hysteresis.
+    expect(controller.getState().todoScopeKey).toBe("lane_a")
+  })
+})
+

--- a/tui_skeleton/src/commands/repl/__tests__/todoPreviewDeterminism.test.ts
+++ b/tui_skeleton/src/commands/repl/__tests__/todoPreviewDeterminism.test.ts
@@ -22,9 +22,11 @@ describe("todo preview determinism", () => {
 
     const model1 = buildTodoPreviewModel(controller.getState().todoStore, { maxItems: 7, strategy: "first_n" })
 
-    controller.applyEvent(event(2, "assistant.message.delta", { delta: "a" }))
-    controller.applyEvent(event(3, "assistant.message.delta", { delta: "b" }))
-    controller.applyEvent(event(4, "assistant_message", { text: "final" }))
+    controller.applyEvent(event(2, "tool_call", { tool_name: "ReadFile", path: "README.md" }))
+    controller.applyEvent(event(3, "assistant.message.delta", { delta: "a" }))
+    controller.applyEvent(event(4, "assistant.message.delta", { delta: "b" }))
+    controller.applyEvent(event(5, "tool_result", { tool_name: "ReadFile", result: "ok" }))
+    controller.applyEvent(event(6, "assistant_message", { text: "final" }))
 
     const model2 = buildTodoPreviewModel(controller.getState().todoStore, { maxItems: 7, strategy: "first_n" })
     expect(model2).toEqual(model1)

--- a/tui_skeleton/src/commands/repl/command.tsx
+++ b/tui_skeleton/src/commands/repl/command.tsx
@@ -588,6 +588,9 @@ const buildReplCommand = (name: string) =>
           model: modelValue ?? undefined,
           remotePreference,
           permissionMode: permissionValue ?? undefined,
+          todoAutoFollowScope: resolvedTuiConfig.composer.todoAutoFollowScope,
+          todoAutoFollowHysteresisMs: resolvedTuiConfig.composer.todoAutoFollowHysteresisMs,
+          todoAutoFollowManualOverrideMs: resolvedTuiConfig.composer.todoAutoFollowManualOverrideMs,
         })
 
         await controller.start()

--- a/tui_skeleton/src/commands/repl/controllerStateMethods.ts
+++ b/tui_skeleton/src/commands/repl/controllerStateMethods.ts
@@ -122,6 +122,7 @@ export function slashHandlers(this: any): Record<string, SlashHandler> {
         if (this.todoScopeLabelsByKey && !this.todoScopeLabelsByKey[next]) {
           this.todoScopeLabelsByKey[next] = next
         }
+        this.noteTodoScopeManualSelection?.()
         this.emitChange()
       }
 

--- a/tui_skeleton/src/repl/components/replView/composer/TodoPreviewWidget.tsx
+++ b/tui_skeleton/src/repl/components/replView/composer/TodoPreviewWidget.tsx
@@ -20,15 +20,35 @@ const previewColorForStatus = (status: string): string => {
 
 export const TodoPreviewWidget: React.FC<{ model: TodoPreviewModel }> = ({ model }) => {
   if (!model.items || model.items.length === 0) return null
-  return (
-    <Box flexDirection="column">
-      {model.header ? <Text color={COLORS.textMuted} wrap="truncate">{uiText(model.header)}</Text> : null}
+  const headerLine = model.headerLine
+
+  const body = (
+    <>
+      {headerLine ? (
+        <Text color={COLORS.textMuted} wrap="truncate">
+          {uiText(headerLine)}
+        </Text>
+      ) : null}
       {model.items.map((item) => (
         <Text key={item.id} color={previewColorForStatus(item.status)} wrap="truncate">
           {uiText(item.label)}
         </Text>
       ))}
+    </>
+  )
+
+  if (model.style === "minimal") {
+    return <Box flexDirection="column">{body}</Box>
+  }
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={COLORS.textMuted}
+      paddingX={1}
+      width={model.frameWidth ?? undefined}
+    >
+      {body}
     </Box>
   )
 }
-

--- a/tui_skeleton/src/repl/components/replView/composer/__tests__/todoPreview.test.ts
+++ b/tui_skeleton/src/repl/components/replView/composer/__tests__/todoPreview.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { buildTodoPreviewModel, DEFAULT_TODO_PREVIEW_MAX_ITEMS, getTodoPreviewRowCount } from "../todoPreview.js"
 
-const storeFromTodos = (todos: Array<{ id: string; title: string; status: string }>) => ({
+const storeFromTodos = (todos: Array<{ id: string; title: string; status: string; metadata?: Record<string, unknown> | null }>) => ({
   revision: 1,
   updatedAt: 0,
   itemsById: Object.fromEntries(todos.map((t) => [t.id, t])),
@@ -39,6 +39,14 @@ describe("buildTodoPreviewModel", () => {
     )
     expect(model?.header).toBe("TODOs: 0/1 (stale)")
     expect(model?.headerLine).toContain("TODOs: 0/1 (stale)")
+  })
+
+  it("adds a tree indicator when dense items are linked to ctree nodes", () => {
+    const model = buildTodoPreviewModel(
+      storeFromTodos([{ id: "1", title: "Only", status: "todo", metadata: { ctree_node_id: "node-1" } }]),
+      { style: "dense" },
+    )
+    expect(model?.header).toBe("TODOs: 0/1 · tree")
   })
 
   it("truncates to maxItems and preserves order", () => {

--- a/tui_skeleton/src/repl/components/replView/composer/__tests__/todoPreview.test.ts
+++ b/tui_skeleton/src/repl/components/replView/composer/__tests__/todoPreview.test.ts
@@ -35,9 +35,10 @@ describe("buildTodoPreviewModel", () => {
   it("marks header as stale when requested", () => {
     const model = buildTodoPreviewModel(
       storeFromTodos([{ id: "1", title: "Only", status: "todo" }]),
-      { stale: true },
+      { stale: true, style: "dense" },
     )
     expect(model?.header).toBe("TODOs: 0/1 (stale)")
+    expect(model?.headerLine).toContain("TODOs: 0/1 (stale)")
   })
 
   it("truncates to maxItems and preserves order", () => {
@@ -56,5 +57,15 @@ describe("buildTodoPreviewModel", () => {
     const model = buildTodoPreviewModel(storeFromTodos([{ id: "1", title: "Only", status: "todo" }]), { showHeader: false })
     expect(model?.header).toBe("")
     expect(getTodoPreviewRowCount(model)).toBe(1)
+  })
+
+  it("aligns hint on the right when width allows", () => {
+    const model = buildTodoPreviewModel(
+      storeFromTodos([{ id: "1", title: "Only", status: "todo" }]),
+      { style: "nice", cols: 60 },
+    )
+    expect(model?.header).toBe("TODOs: 0/1")
+    expect(model?.headerLine).toContain("Ctrl+T")
+    expect(model?.frameWidth).toBeLessThan(60)
   })
 })

--- a/tui_skeleton/src/repl/components/replView/composer/todoPreview.ts
+++ b/tui_skeleton/src/repl/components/replView/composer/todoPreview.ts
@@ -9,9 +9,13 @@ export type TodoPreviewItem = {
 
 export type TodoPreviewModel = {
   readonly header: string
+  readonly headerLine: string
   readonly doneCount: number
   readonly totalCount: number
   readonly items: readonly TodoPreviewItem[]
+  readonly style: "minimal" | "nice" | "dense"
+  readonly hint: string | null
+  readonly frameWidth: number | null
 }
 
 export const DEFAULT_TODO_PREVIEW_MAX_ITEMS = 7
@@ -24,6 +28,8 @@ type BuildTodoPreviewOptions = {
   readonly scopeKey?: string | null
   readonly scopeLabel?: string | null
   readonly stale?: boolean
+  readonly style?: "minimal" | "nice" | "dense"
+  readonly cols?: number | null
 }
 
 const statusMark = (status: string): string => {
@@ -41,6 +47,20 @@ const statusMark = (status: string): string => {
   }
 }
 
+const formatHeaderWithHint = (header: string, hint: string, cols: number | null): string => {
+  const safeCols = cols != null && Number.isFinite(cols) ? Math.max(10, Math.floor(cols) - 2) : null
+  const suffix = `· ${hint}`
+  if (!safeCols) return `${header} ${suffix}`
+  const headerLen = header.length
+  const suffixLen = suffix.length
+  const minSpacer = 1
+  const remaining = safeCols - headerLen - suffixLen
+  if (remaining >= minSpacer) {
+    return `${header}${" ".repeat(Math.max(minSpacer, remaining))}${suffix}`
+  }
+  return `${header} ${suffix}`
+}
+
 export const buildTodoPreviewModel = (
   store: TodoStoreSnapshot,
   options: BuildTodoPreviewOptions = {},
@@ -53,6 +73,8 @@ export const buildTodoPreviewModel = (
   const scopeKey = options.scopeKey?.trim() || null
   const scopeLabel = options.scopeLabel?.trim() || null
   const stale = Boolean(options.stale)
+  const style = options.style ?? "minimal"
+  const cols = options.cols ?? null
 
   const { done: doneCount, total: totalCount } = todoStoreCounts(store)
   const selection = selectTodoPreviewItems(store, { maxItems, strategy })
@@ -66,9 +88,13 @@ export const buildTodoPreviewModel = (
   const scopeName = scopeLabel ?? scopeKey
   const showScope = Boolean(scopeName && scopeName !== "main")
   const scopePrefix = showScope ? ` (${scopeName})` : ""
-  const staleSuffix = stale ? " (stale)" : ""
+  const staleSuffix = stale && style === "dense" ? " (stale)" : ""
   const header = showHeader ? `TODOs${scopePrefix}: ${doneCount}/${totalCount}${hiddenSuffix}${staleSuffix}` : ""
-  return { header, doneCount, totalCount, items }
+  const hint = style !== "minimal" && cols != null && cols >= 28 ? "Ctrl+T" : null
+  const headerLine = header && hint ? formatHeaderWithHint(header, hint, cols) : header
+  const frameWidth =
+    style === "minimal" || cols == null || !Number.isFinite(cols) ? null : Math.max(10, Math.floor(cols) - 2)
+  return { header, headerLine, doneCount, totalCount, items, style, hint, frameWidth }
 }
 
 export const getTodoPreviewRowCount = (model: TodoPreviewModel | null): number => {

--- a/tui_skeleton/src/repl/components/replView/controller/useReplViewController.tsx
+++ b/tui_skeleton/src/repl/components/replView/controller/useReplViewController.tsx
@@ -587,17 +587,26 @@ export const useReplViewController = ({
     if (!claudeChrome) return null
     if (overlayActive) return null
     if (!tuiConfig.composer.todoPreviewAboveInput) return null
+    if (rowCount < tuiConfig.composer.todoPreviewMinRowsToShow) return null
+    const maxItems =
+      rowCount < 14
+        ? Math.min(tuiConfig.composer.todoPreviewMaxItems, tuiConfig.composer.todoPreviewSmallRowsMaxItems)
+        : tuiConfig.composer.todoPreviewMaxItems
     return buildTodoPreviewModel(todoStore, {
-      maxItems: tuiConfig.composer.todoPreviewMaxItems,
+      maxItems,
       strategy: tuiConfig.composer.todoPreviewSelection,
       showHiddenCount: tuiConfig.composer.todoPreviewShowHiddenCount,
       scopeKey: todoScopeKey,
       scopeLabel: todoScopeLabel,
       stale: todoScopeStale,
+      style: tuiConfig.composer.todoPreviewStyle,
+      cols: contentWidth,
     })
   }, [
     claudeChrome,
     overlayActive,
+    rowCount,
+    contentWidth,
     todoStore,
     todoScopeKey,
     todoScopeLabel,
@@ -606,6 +615,9 @@ export const useReplViewController = ({
     tuiConfig.composer.todoPreviewMaxItems,
     tuiConfig.composer.todoPreviewSelection,
     tuiConfig.composer.todoPreviewShowHiddenCount,
+    tuiConfig.composer.todoPreviewStyle,
+    tuiConfig.composer.todoPreviewMinRowsToShow,
+    tuiConfig.composer.todoPreviewSmallRowsMaxItems,
   ])
 
   useEffect(() => {

--- a/tui_skeleton/src/tui_config/load.ts
+++ b/tui_skeleton/src/tui_config/load.ts
@@ -290,6 +290,12 @@ export const resolveTuiConfig = async (options: ResolvedTuiConfigOptions): Promi
         merged.composer?.todoPreviewSelection ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.todoPreviewSelection,
       todoPreviewShowHiddenCount:
         merged.composer?.todoPreviewShowHiddenCount ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.todoPreviewShowHiddenCount,
+      todoPreviewStyle:
+        merged.composer?.todoPreviewStyle ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.todoPreviewStyle,
+      todoPreviewMinRowsToShow:
+        merged.composer?.todoPreviewMinRowsToShow ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.todoPreviewMinRowsToShow,
+      todoPreviewSmallRowsMaxItems:
+        merged.composer?.todoPreviewSmallRowsMaxItems ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.todoPreviewSmallRowsMaxItems,
     },
     statusLine: {
       position: merged.statusLine?.position ?? DEFAULT_RESOLVED_TUI_CONFIG.statusLine.position,

--- a/tui_skeleton/src/tui_config/load.ts
+++ b/tui_skeleton/src/tui_config/load.ts
@@ -296,6 +296,13 @@ export const resolveTuiConfig = async (options: ResolvedTuiConfigOptions): Promi
         merged.composer?.todoPreviewMinRowsToShow ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.todoPreviewMinRowsToShow,
       todoPreviewSmallRowsMaxItems:
         merged.composer?.todoPreviewSmallRowsMaxItems ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.todoPreviewSmallRowsMaxItems,
+      todoAutoFollowScope:
+        merged.composer?.todoAutoFollowScope ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.todoAutoFollowScope,
+      todoAutoFollowHysteresisMs:
+        merged.composer?.todoAutoFollowHysteresisMs ?? DEFAULT_RESOLVED_TUI_CONFIG.composer.todoAutoFollowHysteresisMs,
+      todoAutoFollowManualOverrideMs:
+        merged.composer?.todoAutoFollowManualOverrideMs ??
+        DEFAULT_RESOLVED_TUI_CONFIG.composer.todoAutoFollowManualOverrideMs,
     },
     statusLine: {
       position: merged.statusLine?.position ?? DEFAULT_RESOLVED_TUI_CONFIG.statusLine.position,

--- a/tui_skeleton/src/tui_config/presets.ts
+++ b/tui_skeleton/src/tui_config/presets.ts
@@ -44,6 +44,9 @@ export const BUILTIN_TUI_PRESETS: Record<TuiPresetId, TuiConfigInput> = {
       todoPreviewStyle: "nice",
       todoPreviewMinRowsToShow: 10,
       todoPreviewSmallRowsMaxItems: 3,
+      todoAutoFollowScope: "on",
+      todoAutoFollowHysteresisMs: 1200,
+      todoAutoFollowManualOverrideMs: 15000,
     },
     statusLine: {
       position: "above_input",
@@ -242,6 +245,9 @@ export const DEFAULT_RESOLVED_TUI_CONFIG: ResolvedTuiConfig = {
     todoPreviewStyle: "minimal",
     todoPreviewMinRowsToShow: 10,
     todoPreviewSmallRowsMaxItems: 3,
+    todoAutoFollowScope: "off",
+    todoAutoFollowHysteresisMs: 1200,
+    todoAutoFollowManualOverrideMs: 15000,
   },
   statusLine: {
     position: "above_input",

--- a/tui_skeleton/src/tui_config/presets.ts
+++ b/tui_skeleton/src/tui_config/presets.ts
@@ -41,6 +41,9 @@ export const BUILTIN_TUI_PRESETS: Record<TuiPresetId, TuiConfigInput> = {
       todoPreviewMaxItems: 7,
       todoPreviewSelection: "active_first",
       todoPreviewShowHiddenCount: true,
+      todoPreviewStyle: "nice",
+      todoPreviewMinRowsToShow: 10,
+      todoPreviewSmallRowsMaxItems: 3,
     },
     statusLine: {
       position: "above_input",
@@ -236,6 +239,9 @@ export const DEFAULT_RESOLVED_TUI_CONFIG: ResolvedTuiConfig = {
     todoPreviewMaxItems: 7,
     todoPreviewSelection: "first_n",
     todoPreviewShowHiddenCount: false,
+    todoPreviewStyle: "minimal",
+    todoPreviewMinRowsToShow: 10,
+    todoPreviewSmallRowsMaxItems: 3,
   },
   statusLine: {
     position: "above_input",

--- a/tui_skeleton/src/tui_config/schema.ts
+++ b/tui_skeleton/src/tui_config/schema.ts
@@ -262,6 +262,9 @@ export const validateTuiConfigInput = (input: unknown, options: ValidationOption
         "todoPreviewMaxItems",
         "todoPreviewSelection",
         "todoPreviewShowHiddenCount",
+        "todoPreviewStyle",
+        "todoPreviewMinRowsToShow",
+        "todoPreviewSmallRowsMaxItems",
       ],
       ["composer"],
       issues,
@@ -294,6 +297,18 @@ export const validateTuiConfigInput = (input: unknown, options: ValidationOption
     if (todoPreviewSelection != null) composer.todoPreviewSelection = todoPreviewSelection
     const todoPreviewShowHiddenCount = readBoolean(composerRaw, "todoPreviewShowHiddenCount", ["composer"], issues)
     if (todoPreviewShowHiddenCount != null) composer.todoPreviewShowHiddenCount = todoPreviewShowHiddenCount
+    const todoPreviewStyle = readEnum(
+      composerRaw,
+      "todoPreviewStyle",
+      ["minimal", "nice", "dense"] as const,
+      ["composer"],
+      issues,
+    )
+    if (todoPreviewStyle != null) composer.todoPreviewStyle = todoPreviewStyle
+    const todoPreviewMinRowsToShow = readPositiveInt(composerRaw, "todoPreviewMinRowsToShow", ["composer"], issues)
+    if (todoPreviewMinRowsToShow != null) composer.todoPreviewMinRowsToShow = todoPreviewMinRowsToShow
+    const todoPreviewSmallRowsMaxItems = readPositiveInt(composerRaw, "todoPreviewSmallRowsMaxItems", ["composer"], issues)
+    if (todoPreviewSmallRowsMaxItems != null) composer.todoPreviewSmallRowsMaxItems = todoPreviewSmallRowsMaxItems
     config.composer = composer
   }
 

--- a/tui_skeleton/src/tui_config/schema.ts
+++ b/tui_skeleton/src/tui_config/schema.ts
@@ -265,6 +265,9 @@ export const validateTuiConfigInput = (input: unknown, options: ValidationOption
         "todoPreviewStyle",
         "todoPreviewMinRowsToShow",
         "todoPreviewSmallRowsMaxItems",
+        "todoAutoFollowScope",
+        "todoAutoFollowHysteresisMs",
+        "todoAutoFollowManualOverrideMs",
       ],
       ["composer"],
       issues,
@@ -309,6 +312,12 @@ export const validateTuiConfigInput = (input: unknown, options: ValidationOption
     if (todoPreviewMinRowsToShow != null) composer.todoPreviewMinRowsToShow = todoPreviewMinRowsToShow
     const todoPreviewSmallRowsMaxItems = readPositiveInt(composerRaw, "todoPreviewSmallRowsMaxItems", ["composer"], issues)
     if (todoPreviewSmallRowsMaxItems != null) composer.todoPreviewSmallRowsMaxItems = todoPreviewSmallRowsMaxItems
+    const todoAutoFollowScope = readEnum(composerRaw, "todoAutoFollowScope", ["off", "on"] as const, ["composer"], issues)
+    if (todoAutoFollowScope != null) composer.todoAutoFollowScope = todoAutoFollowScope
+    const todoAutoFollowHysteresisMs = readNonNegativeInt(composerRaw, "todoAutoFollowHysteresisMs", ["composer"], issues)
+    if (todoAutoFollowHysteresisMs != null) composer.todoAutoFollowHysteresisMs = todoAutoFollowHysteresisMs
+    const todoAutoFollowManualOverrideMs = readNonNegativeInt(composerRaw, "todoAutoFollowManualOverrideMs", ["composer"], issues)
+    if (todoAutoFollowManualOverrideMs != null) composer.todoAutoFollowManualOverrideMs = todoAutoFollowManualOverrideMs
     config.composer = composer
   }
 

--- a/tui_skeleton/src/tui_config/types.ts
+++ b/tui_skeleton/src/tui_config/types.ts
@@ -15,6 +15,7 @@ export type StatusLinePosition = "above_input" | "below_input"
 export type StatusLineAlign = "left" | "right"
 export type SubagentFocusMode = "lane" | "swap"
 export type TodoPreviewStyle = "minimal" | "nice" | "dense"
+export type TodoAutoFollowScopeMode = "off" | "on"
 
 export type TuiDiffColorPaletteInput = {
   addLineBg?: string
@@ -53,6 +54,9 @@ export type TuiConfigInput = {
     todoPreviewStyle?: TodoPreviewStyle
     todoPreviewMinRowsToShow?: number
     todoPreviewSmallRowsMaxItems?: number
+    todoAutoFollowScope?: TodoAutoFollowScopeMode
+    todoAutoFollowHysteresisMs?: number
+    todoAutoFollowManualOverrideMs?: number
   }
   statusLine?: {
     position?: StatusLinePosition
@@ -108,6 +112,9 @@ export type ResolvedTuiConfig = {
     readonly todoPreviewStyle: TodoPreviewStyle
     readonly todoPreviewMinRowsToShow: number
     readonly todoPreviewSmallRowsMaxItems: number
+    readonly todoAutoFollowScope: TodoAutoFollowScopeMode
+    readonly todoAutoFollowHysteresisMs: number
+    readonly todoAutoFollowManualOverrideMs: number
   }
   readonly statusLine: {
     readonly position: StatusLinePosition

--- a/tui_skeleton/src/tui_config/types.ts
+++ b/tui_skeleton/src/tui_config/types.ts
@@ -14,6 +14,7 @@ export type LandingBorderStyle = "round" | "single"
 export type StatusLinePosition = "above_input" | "below_input"
 export type StatusLineAlign = "left" | "right"
 export type SubagentFocusMode = "lane" | "swap"
+export type TodoPreviewStyle = "minimal" | "nice" | "dense"
 
 export type TuiDiffColorPaletteInput = {
   addLineBg?: string
@@ -49,6 +50,9 @@ export type TuiConfigInput = {
     todoPreviewMaxItems?: number
     todoPreviewSelection?: TodoPreviewSelectionStrategy
     todoPreviewShowHiddenCount?: boolean
+    todoPreviewStyle?: TodoPreviewStyle
+    todoPreviewMinRowsToShow?: number
+    todoPreviewSmallRowsMaxItems?: number
   }
   statusLine?: {
     position?: StatusLinePosition
@@ -101,6 +105,9 @@ export type ResolvedTuiConfig = {
     readonly todoPreviewMaxItems: number
     readonly todoPreviewSelection: TodoPreviewSelectionStrategy
     readonly todoPreviewShowHiddenCount: boolean
+    readonly todoPreviewStyle: TodoPreviewStyle
+    readonly todoPreviewMinRowsToShow: number
+    readonly todoPreviewSmallRowsMaxItems: number
   }
   readonly statusLine: {
     readonly position: StatusLinePosition

--- a/tui_skeleton/ui_baselines/u1/scenarios/todo_preview_churn_gate/input/events.jsonl
+++ b/tui_skeleton/ui_baselines/u1/scenarios/todo_preview_churn_gate/input/events.jsonl
@@ -1,0 +1,4 @@
+{"type":"tool_result","id":"1","seq":1,"timestamp":1,"payload":{"tool_name":"TodoWrite","todos":[{"content":"Ship U1 baseline","status":"done"},{"content":"Render todo preview above input","status":"in_progress"},{"content":"Add reducer tests","status":"todo"},{"content":"Fix flaky CI","status":"blocked"},{"content":"Refactor preview widget","status":"done"}]}}
+{"type":"assistant.message.delta","id":"2","seq":2,"timestamp":2,"payload":{"delta":"Working on it... "}}
+{"type":"assistant.message.delta","id":"3","seq":3,"timestamp":3,"payload":{"delta":"still streaming "}}
+{"type":"assistant_message","id":"4","seq":4,"timestamp":4,"payload":{"text":"final answer"}}


### PR DESCRIPTION
Polish tranche for TODO preview above input:\n\n- Style variants (minimal/nice/dense) + small-terminal safety\n- Dense-only stale suffix and ctree-linked indicator\n- Optional auto-follow scope with hysteresis + manual override (preset opt-in)\n- Stricter unit-test gates for preview determinism + selection invariants\n- Nightly warn-first churn metric job + artifact\n\nConfig knobs added under tuiConfig.composer:\n- todoPreviewStyle, todoPreviewMinRowsToShow, todoPreviewSmallRowsMaxItems\n- todoAutoFollowScope, todoAutoFollowHysteresisMs, todoAutoFollowManualOverrideMs\n\n