### PR TITLE
tmux: phase4 replay CI soft gate + canonical docs

### DIFF
--- a/.github/workflows/tmux-e2e-soft-gate.yml
+++ b/.github/workflows/tmux-e2e-soft-gate.yml
@@ -172,6 +172,9 @@ jobs:
     name: tmux phase4 replay (warn)
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      # Keep pane + engine logs under the workspace so they can be uploaded as artifacts.
+      BREADBOARD_PHASE4_REPLAY_LOG_ROOT: ${{ github.workspace }}/docs_tmp/tmux_captures/targets_logs
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -219,6 +222,17 @@ jobs:
             echo "### pane: $t"
             tmux capture-pane -pt "$t" | tail -n 40 || true
           done
+          echo ""
+          echo "### targets logs"
+          find "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/targets_logs" -maxdepth 3 -type f -name '*.log' -print 2>/dev/null | sort || true
+          for s in breadboard_test_ci_phase4_todo breadboard_test_ci_phase4_streaming breadboard_test_ci_phase4_subagents; do
+            echo ""
+            echo "### log tail: $s/pane.log"
+            tail -n 80 "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/targets_logs/$s/pane.log" 2>/dev/null || true
+            echo ""
+            echo "### log tail: $s/cli_bridge.log"
+            tail -n 80 "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/targets_logs/$s/cli_bridge.log" 2>/dev/null || true
+          done
 
       - name: Run phase4 replay scenarios
         run: |
@@ -261,12 +275,25 @@ jobs:
       - name: Validate phase4 replay runs (strict bundle integrity)
         if: ${{ always() }}
         run: |
-          TODO_RUN_DIR="$(find "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/scenarios/phase4_replay/todo_preview_v1" -name scenario_manifest.json -print | sort | tail -n1 | xargs dirname)"
-          STREAM_RUN_DIR="$(find "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/scenarios/phase4_replay/streaming_v1" -name scenario_manifest.json -print | sort | tail -n1 | xargs dirname)"
-          SUBAGENTS_RUN_DIR="$(find "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/scenarios/phase4_replay/subagents_v1" -name scenario_manifest.json -print | sort | tail -n1 | xargs dirname)"
-          python scripts/validate_tmux_capture_run.py --run-dir "$TODO_RUN_DIR" --strict
-          python scripts/validate_tmux_capture_run.py --run-dir "$STREAM_RUN_DIR" --strict
-          python scripts/validate_tmux_capture_run.py --run-dir "$SUBAGENTS_RUN_DIR" --strict
+          find_latest_run_dir() {
+            local base="$1"
+            local manifest
+            manifest="$(find "$base" -name scenario_manifest.json -print 2>/dev/null | sort | tail -n1 || true)"
+            if [[ -z "$manifest" ]]; then
+              echo ""
+              return 0
+            fi
+            dirname "$manifest"
+          }
+
+          TODO_RUN_DIR="$(find_latest_run_dir "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/scenarios/phase4_replay/todo_preview_v1")"
+          STREAM_RUN_DIR="$(find_latest_run_dir "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/scenarios/phase4_replay/streaming_v1")"
+          SUBAGENTS_RUN_DIR="$(find_latest_run_dir "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/scenarios/phase4_replay/subagents_v1")"
+
+          if [[ -n "$TODO_RUN_DIR" ]]; then python scripts/validate_tmux_capture_run.py --run-dir "$TODO_RUN_DIR" --strict; else echo "missing TODO_RUN_DIR"; fi
+          if [[ -n "$STREAM_RUN_DIR" ]]; then python scripts/validate_tmux_capture_run.py --run-dir "$STREAM_RUN_DIR" --strict; else echo "missing STREAM_RUN_DIR"; fi
+          if [[ -n "$SUBAGENTS_RUN_DIR" ]]; then python scripts/validate_tmux_capture_run.py --run-dir "$SUBAGENTS_RUN_DIR" --strict; else echo "missing SUBAGENTS_RUN_DIR"; fi
+
           echo "TODO_RUN_DIR=$TODO_RUN_DIR" >> "$GITHUB_ENV"
           echo "STREAM_RUN_DIR=$STREAM_RUN_DIR" >> "$GITHUB_ENV"
           echo "SUBAGENTS_RUN_DIR=$SUBAGENTS_RUN_DIR" >> "$GITHUB_ENV"
@@ -289,3 +316,4 @@ jobs:
             docs_tmp/tmux_captures/scenarios/phase4_replay/todo_preview_v1
             docs_tmp/tmux_captures/scenarios/phase4_replay/streaming_v1
             docs_tmp/tmux_captures/scenarios/phase4_replay/subagents_v1
+            docs_tmp/tmux_captures/targets_logs

--- a/.github/workflows/tmux-e2e-soft-gate.yml
+++ b/.github/workflows/tmux-e2e-soft-gate.yml
@@ -220,7 +220,10 @@ jobs:
           for t in breadboard_test_ci_phase4_todo:0.0 breadboard_test_ci_phase4_streaming:0.0 breadboard_test_ci_phase4_subagents:0.0; do
             echo ""
             echo "### pane: $t"
+            echo "- normal:"
             tmux capture-pane -pt "$t" | tail -n 40 || true
+            echo "- alternate:"
+            tmux capture-pane -apt "$t" | tail -n 40 || true
           done
           echo ""
           echo "### targets logs"
@@ -236,6 +239,8 @@ jobs:
 
       - name: Run phase4 replay scenarios
         run: |
+          set +e
+          rc=0
           python scripts/run_tmux_capture_scenario.py \
             --target breadboard_test_ci_phase4_todo:0.0 \
             --scenario phase4_replay/todo_preview_v1 \
@@ -247,6 +252,7 @@ jobs:
             --post-sleep 0.2 \
             --semantic-timeout 10 \
             --capture-label phase4_replay_todo_preview_v1
+          rc=$((rc | $?))
 
           python scripts/run_tmux_capture_scenario.py \
             --target breadboard_test_ci_phase4_streaming:0.0 \
@@ -259,6 +265,7 @@ jobs:
             --post-sleep 0.2 \
             --semantic-timeout 10 \
             --capture-label phase4_replay_streaming_v1
+          rc=$((rc | $?))
 
           python scripts/run_tmux_capture_scenario.py \
             --target breadboard_test_ci_phase4_subagents:0.0 \
@@ -271,6 +278,8 @@ jobs:
             --post-sleep 0.2 \
             --semantic-timeout 10 \
             --capture-label phase4_replay_subagents_v1
+          rc=$((rc | $?))
+          exit "$rc"
 
       - name: Validate phase4 replay runs (strict bundle integrity)
         if: ${{ always() }}

--- a/.github/workflows/tmux-e2e-soft-gate.yml
+++ b/.github/workflows/tmux-e2e-soft-gate.yml
@@ -167,3 +167,120 @@ jobs:
             docs_tmp/tmux_captures/scenarios/ci/input_bus_local_v1
             docs_tmp/tmux_captures/scenarios/ci/resize_action_smoke_v1
             docs_tmp/tmux_captures/goldens/ci_soft_gate_local
+
+  tmux-phase4-replay:
+    name: tmux phase4 replay (warn)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install engine dependencies
+        run: |
+          python -m pip install -r requirements.txt
+          # Needed for PNG render in tmux capture artifacts.
+          python -m pip install pillow
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: tui_skeleton/package-lock.json
+
+      - name: Install TUI dependencies
+        working-directory: tui_skeleton
+        run: npm ci
+
+      - name: Build TUI (for --use-dist entrypoint)
+        working-directory: tui_skeleton
+        env:
+          BREADBOARD_SKIP_LOCAL_BIN_INSTALL: "1"
+          BREADBOARD_INSTALL_QUIET: "1"
+        run: npm run build
+
+      - name: Start phase4 replay tmux targets
+        env:
+          RAY_SCE_LOCAL_MODE: "1"
+        run: |
+          bash scripts/start_tmux_phase4_replay_target.sh --session breadboard_test_ci_phase4_todo --cols 160 --rows 45 --port 9103 --use-dist
+          bash scripts/start_tmux_phase4_replay_target.sh --session breadboard_test_ci_phase4_streaming --cols 160 --rows 45 --port 9101 --use-dist
+          bash scripts/start_tmux_phase4_replay_target.sh --session breadboard_test_ci_phase4_subagents --cols 160 --rows 45 --port 9102 --use-dist
+
+      - name: Run phase4 replay scenarios
+        run: |
+          python scripts/run_tmux_capture_scenario.py \
+            --target breadboard_test_ci_phase4_todo:0.0 \
+            --scenario phase4_replay/todo_preview_v1 \
+            --actions "$GITHUB_WORKSPACE/config/tmux_scenario_actions/phase4_replay/todo_preview_v1.json" \
+            --out-root "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/scenarios" \
+            --duration 35 \
+            --interval 0.5 \
+            --pre-sleep 0.2 \
+            --post-sleep 0.2 \
+            --semantic-timeout 10 \
+            --capture-label phase4_replay_todo_preview_v1
+
+          python scripts/run_tmux_capture_scenario.py \
+            --target breadboard_test_ci_phase4_streaming:0.0 \
+            --scenario phase4_replay/streaming_v1 \
+            --actions "$GITHUB_WORKSPACE/config/tmux_scenario_actions/phase4_replay/streaming_v1.json" \
+            --out-root "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/scenarios" \
+            --duration 40 \
+            --interval 0.5 \
+            --pre-sleep 0.2 \
+            --post-sleep 0.2 \
+            --semantic-timeout 10 \
+            --capture-label phase4_replay_streaming_v1
+
+          python scripts/run_tmux_capture_scenario.py \
+            --target breadboard_test_ci_phase4_subagents:0.0 \
+            --scenario phase4_replay/subagents_v1 \
+            --actions "$GITHUB_WORKSPACE/config/tmux_scenario_actions/phase4_replay/subagents_v1.json" \
+            --out-root "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/scenarios" \
+            --duration 40 \
+            --interval 0.5 \
+            --pre-sleep 0.2 \
+            --post-sleep 0.2 \
+            --semantic-timeout 10 \
+            --capture-label phase4_replay_subagents_v1
+
+      - name: Validate phase4 replay runs (strict bundle integrity)
+        if: ${{ always() }}
+        run: |
+          TODO_RUN_DIR="$(find "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/scenarios/phase4_replay/todo_preview_v1" -name scenario_manifest.json -print | sort | tail -n1 | xargs dirname)"
+          STREAM_RUN_DIR="$(find "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/scenarios/phase4_replay/streaming_v1" -name scenario_manifest.json -print | sort | tail -n1 | xargs dirname)"
+          SUBAGENTS_RUN_DIR="$(find "$GITHUB_WORKSPACE/docs_tmp/tmux_captures/scenarios/phase4_replay/subagents_v1" -name scenario_manifest.json -print | sort | tail -n1 | xargs dirname)"
+          python scripts/validate_tmux_capture_run.py --run-dir "$TODO_RUN_DIR" --strict
+          python scripts/validate_tmux_capture_run.py --run-dir "$STREAM_RUN_DIR" --strict
+          python scripts/validate_tmux_capture_run.py --run-dir "$SUBAGENTS_RUN_DIR" --strict
+          echo "TODO_RUN_DIR=$TODO_RUN_DIR" >> "$GITHUB_ENV"
+          echo "STREAM_RUN_DIR=$STREAM_RUN_DIR" >> "$GITHUB_ENV"
+          echo "SUBAGENTS_RUN_DIR=$SUBAGENTS_RUN_DIR" >> "$GITHUB_ENV"
+
+      - name: Add summary to PR
+        if: ${{ always() }}
+        run: |
+          echo "## tmux phase4 replay (warn)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- todo: \`$TODO_RUN_DIR\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- streaming: \`$STREAM_RUN_DIR\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- subagents: \`$SUBAGENTS_RUN_DIR\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload phase4 replay artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: tmux-phase4-replay-artifacts
+          path: |
+            docs_tmp/tmux_captures/scenarios/phase4_replay/todo_preview_v1
+            docs_tmp/tmux_captures/scenarios/phase4_replay/streaming_v1
+            docs_tmp/tmux_captures/scenarios/phase4_replay/subagents_v1

--- a/.github/workflows/tmux-e2e-soft-gate.yml
+++ b/.github/workflows/tmux-e2e-soft-gate.yml
@@ -187,7 +187,7 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
           # Needed for PNG render in tmux capture artifacts.
-          python -m pip install pillow
+          python -m pip install pillow wcwidth
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -200,20 +200,25 @@ jobs:
         working-directory: tui_skeleton
         run: npm ci
 
-      - name: Build TUI (for --use-dist entrypoint)
-        working-directory: tui_skeleton
-        env:
-          BREADBOARD_SKIP_LOCAL_BIN_INSTALL: "1"
-          BREADBOARD_INSTALL_QUIET: "1"
-        run: npm run build
-
       - name: Start phase4 replay tmux targets
         env:
           RAY_SCE_LOCAL_MODE: "1"
         run: |
-          bash scripts/start_tmux_phase4_replay_target.sh --session breadboard_test_ci_phase4_todo --cols 160 --rows 45 --port 9103 --use-dist
-          bash scripts/start_tmux_phase4_replay_target.sh --session breadboard_test_ci_phase4_streaming --cols 160 --rows 45 --port 9101 --use-dist
-          bash scripts/start_tmux_phase4_replay_target.sh --session breadboard_test_ci_phase4_subagents --cols 160 --rows 45 --port 9102 --use-dist
+          # Prefer the dev entrypoint in CI: it has historically been the most reliable
+          # for Ink rendering under tmux capture on GitHub runners.
+          bash scripts/start_tmux_phase4_replay_target.sh --session breadboard_test_ci_phase4_todo --cols 160 --rows 45 --port 9103
+          bash scripts/start_tmux_phase4_replay_target.sh --session breadboard_test_ci_phase4_streaming --cols 160 --rows 45 --port 9101
+          bash scripts/start_tmux_phase4_replay_target.sh --session breadboard_test_ci_phase4_subagents --cols 160 --rows 45 --port 9102
+
+      - name: Debug capture (tmux panes)
+        if: ${{ always() }}
+        run: |
+          sleep 1
+          for t in breadboard_test_ci_phase4_todo:0.0 breadboard_test_ci_phase4_streaming:0.0 breadboard_test_ci_phase4_subagents:0.0; do
+            echo ""
+            echo "### pane: $t"
+            tmux capture-pane -pt "$t" | tail -n 40 || true
+          done
 
       - name: Run phase4 replay scenarios
         run: |

--- a/config/tmux_scenario_actions/README.md
+++ b/config/tmux_scenario_actions/README.md
@@ -1,0 +1,25 @@
+# tmux Scenario Actions (Canonical, Committed)
+
+This directory is the canonical, git-tracked home for tmux scenario action JSON files consumed by:
+
+- `scripts/run_tmux_capture_scenario.py`
+- CI soft gates (for example `.github/workflows/tmux-e2e-soft-gate.yml`)
+
+## Structure
+
+- `ci/`: deterministic self-check scenarios (synthetic panes; no network/providers).
+- `phase4_replay/`: deterministic replay-in-tmux scenarios used for Phase 4 closeout verification.
+- Top-level `*_e2e_*.json`: provider-driven scenarios (typically nightly/report-only; do not make PR CI flaky).
+
+## What Does Not Belong Here
+
+- Captured run artifacts (frames, PNGs, manifests) are output-only and should go under `docs_tmp/` (gitignored).
+- tmux "goldens" are treated as local/ops artifacts under `docs_tmp/tmux_captures/goldens` (not git-tracked) and are managed via
+  `scripts/bless_tmux_golden.py`.
+
+## Conventions
+
+- Always target `breadboard_test_*` sessions in automation (default safety posture of the runner).
+- Include an initial `wait_until` ready marker (for example `for shortcuts`) before sending input.
+- Prefer `must_contain`/`must_match_regex` semantic assertions over brittle full-screen text matching.
+

--- a/scripts/phase4_replay_target_entrypoint.sh
+++ b/scripts/phase4_replay_target_entrypoint.sh
@@ -56,9 +56,6 @@ log_root="${BREADBOARD_PHASE4_REPLAY_LOG_ROOT:-$repo_root/docs_tmp/tmux_phase4_r
 log_dir="$log_root/$session"
 mkdir -p "$log_dir"
 
-# Ensure pane captures are never blank: everything is echoed and also tee'd to a file.
-exec > >(tee -a "$log_dir/pane.log") 2>&1
-
 echo "[phase4 replay target] starting"
 echo "[phase4 replay target] session=$session port=$port preset=$tui_preset use_dist=$use_dist"
 echo "[phase4 replay target] repo_root=$repo_root"
@@ -130,4 +127,3 @@ echo "[phase4 replay target exited]"
 
 # Keep the pane open for post-mortem capture.
 exec bash
-

--- a/scripts/phase4_replay_target_entrypoint.sh
+++ b/scripts/phase4_replay_target_entrypoint.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: phase4_replay_target_entrypoint.sh --session NAME --port N
+                                         [--tui-preset PRESET]
+                                         [--config PATH]
+                                         [--workspace PATH]
+                                         [--use-dist]
+
+Runs inside a tmux pane. Starts the local CLI-bridge engine and then launches
+the Ink TUI in "classic" mode, emitting clear markers into the pane so CI
+captures are never blank when something goes wrong.
+
+Logs:
+- Writes a combined pane transcript to:
+    $BREADBOARD_PHASE4_REPLAY_LOG_ROOT/<session>/pane.log
+- Writes CLI-bridge logs to:
+    $BREADBOARD_PHASE4_REPLAY_LOG_ROOT/<session>/cli_bridge.log
+EOF
+  exit 1
+}
+
+session=""
+port=""
+tui_preset="claude_code_like"
+config_path="agent_configs/opencode_openrouter_grok4fast_cli_default.yaml"
+workspace=""
+use_dist=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --session) shift; session="${1:-}";;
+    --port) shift; port="${1:-}";;
+    --tui-preset) shift; tui_preset="${1:-}";;
+    --config) shift; config_path="${1:-}";;
+    --workspace) shift; workspace="${1:-}";;
+    --use-dist) use_dist=1;;
+    --help|-h) usage;;
+    *) echo "Unknown arg: $1" >&2; usage;;
+  esac
+  shift
+done
+
+if [[ -z "$session" || -z "$port" ]]; then
+  echo "Missing --session or --port" >&2
+  usage
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workspace="${workspace:-$repo_root}"
+workspace="$(cd "$workspace" && pwd)"
+
+log_root="${BREADBOARD_PHASE4_REPLAY_LOG_ROOT:-$repo_root/docs_tmp/tmux_phase4_replay_targets}"
+log_dir="$log_root/$session"
+mkdir -p "$log_dir"
+
+# Ensure pane captures are never blank: everything is echoed and also tee'd to a file.
+exec > >(tee -a "$log_dir/pane.log") 2>&1
+
+echo "[phase4 replay target] starting"
+echo "[phase4 replay target] session=$session port=$port preset=$tui_preset use_dist=$use_dist"
+echo "[phase4 replay target] repo_root=$repo_root"
+echo "[phase4 replay target] workspace=$workspace"
+echo "[phase4 replay target] PATH=$PATH"
+
+echo "[phase4 replay target] python=$(command -v python || true)"
+python --version || true
+echo "[phase4 replay target] node=$(command -v node || true)"
+node --version || true
+echo "[phase4 replay target] npm=$(command -v npm || true)"
+npm --version || true
+
+export BREADBOARD_TUI_SUPPRESS_MAINTENANCE=1
+export RAY_SCE_LOCAL_MODE="${RAY_SCE_LOCAL_MODE:-1}"
+export BREADBOARD_CLI_HOST=127.0.0.1
+export BREADBOARD_CLI_PORT="$port"
+export BREADBOARD_API_URL="http://127.0.0.1:$port"
+export BREADBOARD_STREAM_SCHEMA=2
+export BREADBOARD_STREAM_INCLUDE_LEGACY=0
+
+echo "[phase4 replay target] launching cli_bridge"
+cd "$repo_root"
+python -m agentic_coder_prototype.api.cli_bridge.server >"$log_dir/cli_bridge.log" 2>&1 &
+server_pid=$!
+
+cleanup() {
+  kill "$server_pid" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+for i in $(seq 1 80); do
+  if curl -fsS "http://127.0.0.1:$port/health" >/dev/null 2>&1; then
+    echo "[phase4 replay target] cli_bridge health check complete"
+    break
+  fi
+  if [[ $i -eq 80 ]]; then
+    echo "[phase4 replay target] cli_bridge health check failed (timeout)"
+    echo "[phase4 replay target] tail cli_bridge.log:"
+    tail -n 80 "$log_dir/cli_bridge.log" || true
+    exit 3
+  fi
+  sleep 0.1
+done
+
+cd "$repo_root/tui_skeleton"
+
+if [[ $use_dist -eq 1 ]]; then
+  if [[ ! -f "$repo_root/tui_skeleton/dist/main.js" ]]; then
+    echo "[phase4 replay target] missing tui_skeleton/dist/main.js (run: cd tui_skeleton && npm run build)"
+    exit 2
+  fi
+  tui_cmd=(node dist/main.js repl)
+else
+  tui_cmd=(npm run dev -- repl)
+fi
+
+# Keep transcript content in the live Ink pane; scrollback mode tends to scroll out
+# of the visible viewport and makes debugging harder.
+export BREADBOARD_TUI_SCROLLBACK=0
+
+echo "[phase4 replay target] launching TUI"
+echo "[phase4 replay target] cmd=${tui_cmd[*]} --tui classic --tui-preset $tui_preset --config $config_path --workspace $workspace"
+
+"${tui_cmd[@]}" --tui classic --tui-preset "$tui_preset" --config "$config_path" --workspace "$workspace"
+
+echo ""
+echo "[phase4 replay target exited]"
+
+# Keep the pane open for post-mortem capture.
+exec bash
+

--- a/scripts/start_tmux_phase4_replay_target.sh
+++ b/scripts/start_tmux_phase4_replay_target.sh
@@ -104,6 +104,9 @@ else
 fi
 
 cmd="cd \"$repo_root\" && \
+# tmux sessions are started via a login shell; explicitly pin PATH from the caller
+# (CI uses setup-node/setup-python which primarily work by exporting PATH).
+export PATH=\"$PATH\" && \
 export BREADBOARD_TUI_SUPPRESS_MAINTENANCE=1 && \
 RAY_SCE_LOCAL_MODE=1 \
 BREADBOARD_CLI_HOST=127.0.0.1 \

--- a/scripts/start_tmux_phase4_replay_target.sh
+++ b/scripts/start_tmux_phase4_replay_target.sh
@@ -116,6 +116,8 @@ pane_cmd=(
   --tui-preset "$tui_preset"
   --config "$config_path"
   --workspace "$workspace"
+  --cols "$cols"
+  --rows "$rows"
   "${entrypoint_use_dist[@]}"
 )
 

--- a/scripts/tmux_capture_preflight.py
+++ b/scripts/tmux_capture_preflight.py
@@ -45,6 +45,11 @@ def capture_pane_text(target: str, socket_name: str) -> str:
     code, out, err = run_tmux_socket(["capture-pane", "-p", "-t", target], socket_name)
     if code != 0:
         raise RuntimeError(f"tmux capture-pane failed for {target}: {err.strip()}")
+    # Many TUIs render on tmux's alternate screen; include it so readiness checks
+    # work reliably across environments.
+    code_a, out_a, _ = run_tmux_socket(["capture-pane", "-a", "-p", "-t", target], socket_name)
+    if code_a == 0 and out_a and out_a.strip() and out_a != out:
+        return out + "\n\n[tmux:alternate_screen]\n" + out_a
     return out
 
 


### PR DESCRIPTION
Adds a dedicated tmux Phase 4 replay soft-gate job (warn-only) to .github/workflows/tmux-e2e-soft-gate.yml. It builds the TUI, launches deterministic CLI-bridge replay targets inside breadboard_test_* tmux sessions, runs the phase4 replay scenarios, and validates artifact bundle integrity strictly.\n\nAlso adds canonical documentation for config/tmux_scenario_actions and fixes --use-dist env scoping in scripts/start_tmux_phase4_replay_target.sh.