### PR TITLE
ci: add legacy QueryLakeBackend naming guard

### DIFF
--- a/.github/workflows/legacy_path_guard.yml
+++ b/.github/workflows/legacy_path_guard.yml
@@ -1,0 +1,18 @@
+name: Legacy Path Guard
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  legacy-path-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enforce canonical QueryLake naming
+        run: bash scripts/ci_guard_legacy_querylakebackend_refs.sh
+

--- a/scripts/ci_guard_legacy_querylakebackend_refs.sh
+++ b/scripts/ci_guard_legacy_querylakebackend_refs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+PATTERN='QueryLakeBackend|/shared_folders/querylake_server/QueryLakeBackend|github.com/.*/QueryLakeBackend'
+
+MATCHES="$(git grep -n -I -E "$PATTERN" -- . || true)"
+if [[ -n "${MATCHES// }" ]]; then
+  echo "ERROR: Legacy QueryLakeBackend reference(s) detected."
+  echo "Please migrate to canonical QueryLake naming."
+  echo
+  echo "$MATCHES"
+  exit 1
+fi
+
+echo "Legacy path/name guard passed."
+


### PR DESCRIPTION
## Summary
- add CI guard script to fail on legacy QueryLakeBackend references
- add workflow to run guard on PR/push/main and manual dispatch

## Validation
- bash scripts/ci_guard_legacy_querylakebackend_refs.sh
