### PR TITLE
Port ATP Hilbert comparison tooling

### DIFF
--- a/agent_configs/atp_hilbert_like_gpt54_v2.yaml
+++ b/agent_configs/atp_hilbert_like_gpt54_v2.yaml
@@ -1,0 +1,70 @@
+extends: base_v2.yaml
+
+profile: { name: atp-hilbert-like-gpt54-v2 }
+
+providers:
+  default_model: openrouter/openai/gpt-5.4
+  models:
+    - id: openrouter/openai/gpt-5.4
+      adapter: openai
+      params:
+        temperature: 0.1
+        top_p: 0.9
+
+provider_tools:
+  use_native: false
+  suppress_prompts: false
+
+features:
+  plan: false
+  todos:
+    enabled: false
+
+prompts:
+  packs:
+    base:
+      system: config/e4_targets/atp_hilbert_like/2026-03-10/system.md
+      plan: config/e4_targets/atp_hilbert_like/2026-03-10/system.md
+      builder: config/e4_targets/atp_hilbert_like/2026-03-10/system.md
+      compact: config/e4_targets/atp_hilbert_like/2026-03-10/system.md
+      tools_catalog_full: config/e4_targets/atp_hilbert_like/2026-03-10/system.md
+      tools_catalog_short: config/e4_targets/atp_hilbert_like/2026-03-10/system.md
+  tool_prompt_mode: none
+  tool_prompt_synthesis:
+    enabled: false
+
+tools:
+  mark_task_complete: false
+  registry:
+    paths:
+      - implementations/tools/defs
+    include: []
+  aliases: {}
+
+modes:
+  - name: build
+    prompt: "@pack(base).builder"
+    tools_enabled: []
+    tools_disabled: ["*"]
+
+loop:
+  sequence:
+    - mode: build
+  plan_turn_limit: 0
+  turn_strategy:
+    relay: tool_role
+    flow: assistant_continuation
+    allow_multiple_per_turn: false
+
+completion:
+  confidence_threshold: 0.6
+  natural_finish:
+    idle_turn_limit: 1
+    no_tool_turns_threshold: 1
+  primary: hybrid
+  tool_finish: null
+  provider_signals: true
+  text_sentinels:
+    - TASK COMPLETE
+
+max_iterations: 8

--- a/agentic_coder_prototype/error_handling/error_handler.py
+++ b/agentic_coder_prototype/error_handling/error_handler.py
@@ -23,3 +23,24 @@ class ErrorHandler:
             "error_type": exc.__class__.__name__,
             "hint": None,
         }
+
+    def handle_validation_error(self, payload: Dict[str, Any]) -> str:
+        error = str(payload.get("error") or "validation_failed").strip()
+        tool_name = str(payload.get("tool_name") or "").strip()
+        details = payload.get("details")
+        message = ["<VALIDATION_ERROR>", error]
+        if tool_name:
+            message.append(f"tool={tool_name}")
+        if details:
+            message.append(str(details))
+        message.append("</VALIDATION_ERROR>")
+        return "\n".join(message)
+
+    def handle_constraint_violation(self, error: Any) -> str:
+        return "\n".join(
+            [
+                "<CONSTRAINT_VIOLATION>",
+                str(error),
+                "</CONSTRAINT_VIOLATION>",
+            ]
+        )

--- a/agentic_coder_prototype/utils/safe_delete.py
+++ b/agentic_coder_prototype/utils/safe_delete.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+import os
+import tempfile
+
+
+def _resolve_existing(path: Path) -> Path:
+    try:
+        return path.expanduser().resolve()
+    except FileNotFoundError:
+        return path.expanduser().absolute()
+
+
+def assert_disposable_workspace_path(
+    target: str | os.PathLike[str] | Path,
+    *,
+    repo_root: Path,
+    label: str = "workspace",
+) -> Path:
+    target_path = Path(target)
+    resolved = _resolve_existing(target_path)
+    repo_root_resolved = _resolve_existing(repo_root)
+    home = _resolve_existing(Path.home())
+    tmp_root = _resolve_existing(Path(tempfile.gettempdir()))
+
+    if resolved == Path("/"):
+        raise RuntimeError(f"[safety] Refusing {label}: '{resolved}'")
+    if resolved == repo_root_resolved:
+        raise RuntimeError(f"[safety] Refusing {label}: '{resolved}' (repo root)")
+    if resolved in repo_root_resolved.parents:
+        raise RuntimeError(
+            f"[safety] Refusing {label}: '{resolved}' (ancestor of repo root '{repo_root_resolved}')"
+        )
+    if resolved == home:
+        raise RuntimeError(f"[safety] Refusing {label}: '{resolved}' (home dir)")
+    if resolved == tmp_root:
+        raise RuntimeError(f"[safety] Refusing {label}: '{resolved}' (tmp root)")
+    if (resolved / ".git").exists():
+        raise RuntimeError(f"[safety] Refusing {label}: '{resolved}' (contains .git)")
+    return resolved

--- a/config/e4_targets/atp_hilbert_like/2026-03-10/system.md
+++ b/config/e4_targets/atp_hilbert_like/2026-03-10/system.md
@@ -1,0 +1,13 @@
+You are a Lean 4 proof engine operating inside BreadBoard for ATP benchmarking.
+
+Output requirements:
+- Produce a single complete Lean theorem file.
+- Preserve the theorem statement exactly. Do not rename the theorem. Do not change binders, hypotheses, imports, or the goal statement.
+- You may replace only the proof body.
+- Do not use `sorry`, `admit`, `axiom`, `by_contra!` hacks that change the theorem statement, or placeholders such as `exact?`.
+- Prefer short, verifier-friendly proofs using `norm_num`, `ring`, `linarith`, `nlinarith`, `omega`, `interval_cases`, `have`, `calc`, and simple case splits.
+- If you are unsure, still return the strongest complete candidate proof you can.
+
+Response format:
+- Return exactly one fenced ```lean``` block containing the full final file.
+- After the fenced block, write `TASK COMPLETE` on its own line.

--- a/docs/atp_hilbert_pack_b_medium_status_2026-03-10.md
+++ b/docs/atp_hilbert_pack_b_medium_status_2026-03-10.md
@@ -1,0 +1,52 @@
+# ATP Hilbert Pack B Medium Status — 2026-03-10
+
+This note records the bounded Pack B comparison used after excluding the spend-heavy `imo_1977_p6` case and the sticky `mathd_numbertheory_530` case.
+
+## Pack
+
+Path:
+- `artifacts/benchmarks/hilbert_comparison_packs_v2/pack_b_medium_noimo530_minif2f_v1/`
+
+Tasks:
+- `mathd_numbertheory_780`
+- `numbertheory_exk2powkeqapb2mulbpa2_aeq1`
+- `mathd_algebra_156`
+- `mathd_algebra_171`
+- `aime_1984_p5`
+- `amc12a_2019_p12`
+- `numbertheory_2dvd4expn`
+- `mathd_algebra_107`
+
+## Result
+
+- BreadBoard (`bb_hilbert_like`): `2/8`
+- Hilbert maintained fork (`hilbert_roselab`): `2/8`
+- both solved: `2`
+- both unsolved: `6`
+- discordant pairs: `0`
+
+Solved by both:
+- `mathd_algebra_171`
+- `mathd_algebra_107`
+
+Unsolved by both:
+- `mathd_algebra_156`
+- `mathd_numbertheory_780`
+- `numbertheory_exk2powkeqapb2mulbpa2_aeq1`
+- `aime_1984_p5`
+- `amc12a_2019_p12`
+- `numbertheory_2dvd4expn`
+
+## Spend
+
+Hilbert exact telemetry from proof stats:
+- input tokens: `129,513`
+- output tokens: `39,240`
+- approximate OpenRouter spend at `openai/gpt-5.4` list pricing: `~$0.912382`
+
+BreadBoard exact provider-side spend is not available from the current direct formal runner artifacts.
+
+## Notes
+
+- `mathd_numbertheory_530` required theorem-header canonicalization in `scripts/build_hilbert_comparison_packs_v2.py`.
+- The canonical execution root that produced the artifacts was not a git worktree; this branch ports the runner/config/code changes into a real repository.

--- a/scripts/_cross_system_eval_v1.py
+++ b/scripts/_cross_system_eval_v1.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+try:
+    import yaml
+except Exception:  # pragma: no cover
+    yaml = None
+
+
+VALID_RESULT_STATUSES = {"SOLVED", "UNSOLVED", "ERROR", "TIMEOUT"}
+
+
+def load_manifest(path: Path) -> Dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        if yaml is None:
+            raise RuntimeError("PyYAML is required to parse YAML manifests")
+        payload = yaml.safe_load(text)
+    else:
+        payload = json.loads(text)
+    if not isinstance(payload, dict):
+        raise ValueError(f"manifest must be an object: {path}")
+    return payload
+
+
+def dump_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def load_jsonl(paths: Iterable[Path]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for path in paths:
+        if not path.exists():
+            raise FileNotFoundError(f"result file missing: {path}")
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise ValueError(f"result row must be object at {path}:{line_no}")
+            payload["_source_path"] = str(path)
+            payload["_source_line"] = line_no
+            rows.append(payload)
+    return rows
+
+
+def validate_manifest_shape(manifest: Dict[str, Any]) -> List[str]:
+    errors: List[str] = []
+    for key in ("run_id", "created_at_utc", "owner", "purpose"):
+        if not str(manifest.get(key) or "").strip():
+            errors.append(f"manifest.{key} missing")
+    benchmark = manifest.get("benchmark")
+    if not isinstance(benchmark, dict):
+        errors.append("manifest.benchmark missing or invalid")
+        benchmark = {}
+    slice_block = benchmark.get("slice")
+    if not isinstance(slice_block, dict):
+        errors.append("manifest.benchmark.slice missing or invalid")
+        slice_block = {}
+    task_ids_raw = slice_block.get("task_ids")
+    if not isinstance(task_ids_raw, list) or not task_ids_raw:
+        errors.append("manifest.benchmark.slice.task_ids must be non-empty list")
+    n_tasks = slice_block.get("n_tasks")
+    if not isinstance(n_tasks, int) or n_tasks <= 0:
+        errors.append("manifest.benchmark.slice.n_tasks must be integer > 0")
+    systems = manifest.get("systems")
+    if not isinstance(systems, list) or not systems:
+        errors.append("manifest.systems must be non-empty list")
+    return errors
+
+
+def required_result_fields(manifest: Dict[str, Any]) -> List[str]:
+    base = [
+        "task_id",
+        "toolchain_id",
+        "input_hash",
+        "prover_system",
+        "budget_class",
+        "status",
+        "verification_log_digest",
+    ]
+    acceptance = manifest.get("acceptance")
+    required_fields = acceptance.get("required_fields") if isinstance(acceptance, dict) else []
+    if isinstance(required_fields, list):
+        for item in required_fields:
+            value = str(item).strip()
+            if value and value not in base:
+                base.append(value)
+    return base
+
+
+def solve_bool(status: Any) -> bool:
+    return str(status or "").strip().upper() == "SOLVED"
+
+
+def wilson_interval(successes: int, total: int, z: float = 1.96) -> Dict[str, float]:
+    if total <= 0:
+        return {"low": 0.0, "high": 0.0}
+    phat = float(successes) / float(total)
+    z2 = z * z
+    denom = 1.0 + (z2 / float(total))
+    center = (phat + (z2 / (2.0 * float(total)))) / denom
+    half = (z * math.sqrt((phat * (1.0 - phat) + (z2 / (4.0 * float(total)))) / float(total))) / denom
+    return {"low": max(0.0, center - half), "high": min(1.0, center + half)}
+
+
+def exact_mcnemar_pvalue(cand_wins: int, base_wins: int) -> float:
+    discordant = int(cand_wins) + int(base_wins)
+    if discordant <= 0:
+        return 1.0
+    smaller = min(int(cand_wins), int(base_wins))
+    cdf = 0.0
+    for i in range(0, smaller + 1):
+        cdf += math.comb(discordant, i) * (0.5 ** discordant)
+    return float(min(1.0, 2.0 * cdf))

--- a/scripts/build_hilbert_comparison_packs_v2.py
+++ b/scripts/build_hilbert_comparison_packs_v2.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+from _cross_system_eval_v1 import dump_json
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MINIF2F_FILES = [
+    REPO_ROOT.parent / "other_harness_refs" / "miniF2F" / "lean" / "src" / "test.lean",
+    REPO_ROOT.parent / "other_harness_refs" / "miniF2F" / "lean" / "src" / "valid.lean",
+]
+DEFAULT_OUT_ROOT = REPO_ROOT / "artifacts" / "benchmarks" / "hilbert_comparison_packs_v2"
+PACKS = {
+    "pack_b_hilbert_comparator_minif2f_v2": [
+        "imo_1977_p6",
+        "mathd_numbertheory_780",
+        "mathd_numbertheory_530",
+        "numbertheory_exk2powkeqapb2mulbpa2_aeq1",
+        "mathd_algebra_156",
+        "mathd_algebra_171",
+        "aime_1984_p5",
+        "amc12a_2019_p12",
+        "numbertheory_2dvd4expn",
+        "mathd_algebra_107",
+    ],
+    "pack_b_core_noimo_minif2f_v1": [
+        "mathd_numbertheory_780",
+        "mathd_numbertheory_530",
+        "numbertheory_exk2powkeqapb2mulbpa2_aeq1",
+        "mathd_algebra_156",
+        "mathd_algebra_171",
+        "aime_1984_p5",
+        "amc12a_2019_p12",
+        "numbertheory_2dvd4expn",
+        "mathd_algebra_107",
+    ],
+    "pack_b_medium_noimo530_minif2f_v1": [
+        "mathd_numbertheory_780",
+        "numbertheory_exk2powkeqapb2mulbpa2_aeq1",
+        "mathd_algebra_156",
+        "mathd_algebra_171",
+        "aime_1984_p5",
+        "amc12a_2019_p12",
+        "numbertheory_2dvd4expn",
+        "mathd_algebra_107",
+    ],
+}
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _extract_theorem_block(text: str, theorem_name: str) -> str:
+    pattern = re.compile(
+        rf"(?ms)^theorem\s+{re.escape(theorem_name)}\b.*?^end\s*$"
+    )
+    match = pattern.search(text)
+    if not match:
+        raise KeyError(theorem_name)
+    return match.group(0).strip() + "\n"
+
+
+def _extract_header_and_statement(block: str) -> tuple[str, str]:
+    block = block.strip()
+    if ":=\n" in block:
+        head, _ = block.split(":=\n", 1)
+        return "import Mathlib\n\n", head + " := by\n"
+    if ":=\r\n" in block:
+        head, _ = block.split(":=\r\n", 1)
+        return "import Mathlib\n\n", head + " := by\n"
+    if ":=" in block:
+        head, _ = block.split(":=", 1)
+        return "import Mathlib\n\n", head.rstrip() + " := by\n"
+    if "begin" in block:
+        head, _ = block.split("begin", 1)
+        return "import Mathlib\n\n", head.rstrip() + ":= by\n"
+    raise ValueError("unable to split theorem statement")
+
+
+def _canonical_starter_file(header: str, formal_statement: str) -> str:
+    return header + formal_statement + "  sorry\n"
+
+
+def _canonicalize_formal_statement(task_id: str, formal_statement: str) -> str:
+    if task_id == "mathd_numbertheory_530":
+        return (
+            "theorem mathd_numbertheory_530\n"
+            "  (n k : ℕ)\n"
+            "  (hpos : 0 < n ∧ 0 < k)\n"
+            "  (h_lt : (n : ℝ) / k < 6)\n"
+            "  (h_gt : (5 : ℝ) < n / k) :\n"
+            "  22 ≤ (Nat.lcm n k) / (Nat.gcd n k) := by\n"
+        )
+    return formal_statement
+
+
+def _load_tasks(task_ids: List[str]) -> List[Dict[str, Any]]:
+    texts = [path.read_text(encoding="utf-8") for path in MINIF2F_FILES]
+    merged = "\n\n".join(texts)
+    tasks: List[Dict[str, Any]] = []
+    for task_id in task_ids:
+        block = _extract_theorem_block(merged, task_id)
+        header, formal_statement = _extract_header_and_statement(block)
+        formal_statement = _canonicalize_formal_statement(task_id, formal_statement)
+        tasks.append(
+            {
+                "task_id": task_id,
+                "header": header,
+                "formal_statement": formal_statement,
+                "full_file": _canonical_starter_file(header, formal_statement),
+                "input_hash": _sha256(header + formal_statement),
+            }
+        )
+    return tasks
+
+
+def _write_jsonl(path: Path, rows: List[Dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n", encoding="utf-8")
+
+
+def _build_manifest(pack_name: str, tasks: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return {
+        "run_id": f"hilbert-compare-{pack_name}",
+        "created_at_utc": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "owner": "atp-team",
+        "purpose": "hilbert_comparison",
+        "benchmark": {
+            "name": "miniF2F",
+            "version": {"benchmark_git_sha": "local", "dataset_sha256": _sha256(pack_name + ''.join(t['input_hash'] for t in tasks))},
+            "slice": {
+                "method": "manual_curated",
+                "seed": 1337,
+                "n_tasks": len(tasks),
+                "task_ids": [task["task_id"] for task in tasks],
+            },
+        },
+        "toolchain": {
+            "lean_version": "4.16.0",
+            "mathlib_commit": "unknown",
+            "docker_image_digest": "sha256:local",
+        },
+        "budget": {
+            "class": "B",
+            "max_candidates": 4,
+            "max_repair_rounds": 2,
+            "wall_clock_cap_s": 480,
+            "cost_cap_usd": 10.0,
+        },
+        "systems": [
+            {"system_id": "bb_hilbert_like", "config_ref": "agent_configs/atp_hilbert_like_gpt54_v2.yaml"},
+            {"system_id": "hilbert_roselab", "config_ref": "other_harness_refs/ml-hilbert"},
+        ],
+        "acceptance": {
+            "determinism_reruns": 1,
+            "required_fields": ["verification_log_digest"],
+        },
+    }
+
+
+def build_pack(pack_name: str, out_root: Path) -> Dict[str, Any]:
+    tasks = _load_tasks(PACKS[pack_name])
+    pack_dir = out_root / pack_name
+    pack_dir.mkdir(parents=True, exist_ok=True)
+
+    hilbert_rows = []
+    bb_tasks = []
+    for task in tasks:
+        hilbert_rows.append(
+            {
+                "name": task["task_id"],
+                "header": task["header"],
+                "formal_statement": task["formal_statement"],
+                "split": "test",
+                "informal_prefix": f"/-- Solve {task['task_id']} --/",
+            }
+        )
+        bb_tasks.append(
+            {
+                "task_id": task["task_id"],
+                "input_mode": "formal_lean",
+                "input_text": task["full_file"],
+                "input_hash": task["input_hash"],
+            }
+        )
+
+    manifest = _build_manifest(pack_name, tasks)
+    dump_json(pack_dir / "cross_system_manifest.json", manifest)
+    dump_json(pack_dir / "bb_task_inputs.json", {"schema": "breadboard.bb_task_inputs.v2", "tasks": bb_tasks})
+    _write_jsonl(pack_dir / "hilbert_dataset.jsonl", hilbert_rows)
+
+    return {
+        "pack_name": pack_name,
+        "task_count": len(tasks),
+        "task_ids": [task["task_id"] for task in tasks],
+        "dir": str(pack_dir),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out-root", default=str(DEFAULT_OUT_ROOT))
+    parser.add_argument("--pack", action="append")
+    args = parser.parse_args()
+
+    out_root = Path(args.out_root).resolve()
+    packs = args.pack or list(PACKS)
+    summaries = [build_pack(pack_name, out_root) for pack_name in packs]
+    dump_json(out_root / "summary.json", {"packs": summaries})
+    print(json.dumps({"packs": summaries}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_pilot_comparison_report_v1.py
+++ b/scripts/build_pilot_comparison_report_v1.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from _cross_system_eval_v1 import (
+    dump_json,
+    exact_mcnemar_pvalue,
+    load_jsonl,
+    load_manifest,
+    solve_bool,
+    wilson_interval,
+)
+
+
+def _to_row_index(rows: List[Dict[str, Any]]) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    index: Dict[str, Dict[str, Dict[str, Any]]] = {}
+    for row in rows:
+        task_id = str(row.get("task_id") or "").strip()
+        system_id = str(row.get("prover_system") or "").strip()
+        if task_id and system_id:
+            index.setdefault(task_id, {})[system_id] = row
+    return index
+
+
+def _build_report(manifest: Dict[str, Any], rows: List[Dict[str, Any]], baseline_system: str, candidate_system: str) -> Dict[str, Any]:
+    task_ids = [str(item).strip() for item in (((manifest.get("benchmark") or {}).get("slice") or {}).get("task_ids") or [])]
+    system_ids = [
+        str(item.get("system_id") or "").strip()
+        for item in (manifest.get("systems") or [])
+        if isinstance(item, dict) and str(item.get("system_id") or "").strip()
+    ]
+    index = _to_row_index(rows)
+    per_system: Dict[str, Dict[str, Any]] = {}
+    for system_id in system_ids:
+        available_rows = [index.get(task_id, {}).get(system_id) for task_id in task_ids]
+        available_rows = [row for row in available_rows if isinstance(row, dict)]
+        solved_count = sum(1 for row in available_rows if solve_bool(row.get("status")))
+        coverage = len(available_rows)
+        per_system[system_id] = {
+            "coverage_count": coverage,
+            "coverage_rate": (float(coverage) / float(len(task_ids))) if task_ids else 0.0,
+            "solved_count": solved_count,
+            "solve_rate": (float(solved_count) / float(coverage)) if coverage else 0.0,
+            "solve_rate_ci95": wilson_interval(solved_count, coverage),
+        }
+    paired = {
+        "n11_both_solved": 0,
+        "n10_candidate_only": 0,
+        "n01_baseline_only": 0,
+        "n00_both_unsolved": 0,
+        "paired_task_count": 0,
+        "unpaired_task_count": 0,
+    }
+    for task_id in task_ids:
+        baseline_row = index.get(task_id, {}).get(baseline_system)
+        candidate_row = index.get(task_id, {}).get(candidate_system)
+        if baseline_row is None or candidate_row is None:
+            paired["unpaired_task_count"] += 1
+            continue
+        paired["paired_task_count"] += 1
+        baseline_ok = solve_bool(baseline_row.get("status"))
+        candidate_ok = solve_bool(candidate_row.get("status"))
+        if baseline_ok and candidate_ok:
+            paired["n11_both_solved"] += 1
+        elif (not baseline_ok) and candidate_ok:
+            paired["n10_candidate_only"] += 1
+        elif baseline_ok and (not candidate_ok):
+            paired["n01_baseline_only"] += 1
+        else:
+            paired["n00_both_unsolved"] += 1
+    cand_wins = paired["n10_candidate_only"]
+    base_wins = paired["n01_baseline_only"]
+    return {
+        "schema": "breadboard.cross_system_pilot_report.v1",
+        "run_id": str(manifest.get("run_id") or ""),
+        "benchmark_name": str((manifest.get("benchmark") or {}).get("name") or ""),
+        "baseline_system": baseline_system,
+        "candidate_system": candidate_system,
+        "task_count": len(task_ids),
+        "system_metrics": per_system,
+        "paired_outcomes": paired,
+        "mcnemar": {
+            "discordant_pairs": cand_wins + base_wins,
+            "candidate_wins": cand_wins,
+            "baseline_wins": base_wins,
+            "exact_two_sided_pvalue": exact_mcnemar_pvalue(cand_wins, base_wins),
+        },
+        "directional_summary": {
+            "candidate_minus_baseline_solve_rate": float(per_system.get(candidate_system, {}).get("solve_rate", 0.0))
+            - float(per_system.get(baseline_system, {}).get("solve_rate", 0.0)),
+            "candidate_advantage_discordant": cand_wins - base_wins,
+        },
+    }
+
+
+def _to_markdown(report: Dict[str, Any]) -> str:
+    baseline = report["baseline_system"]
+    candidate = report["candidate_system"]
+    paired = report["paired_outcomes"]
+    mcnemar = report["mcnemar"]
+    lines = [
+        "# Cross-System Pilot Comparison Report v1",
+        "",
+        f"- run_id: `{report.get('run_id', '')}`",
+        f"- benchmark: `{report.get('benchmark_name', '')}`",
+        f"- task_count: `{report.get('task_count', 0)}`",
+        f"- baseline: `{baseline}`",
+        f"- candidate: `{candidate}`",
+        "",
+        "## System Metrics",
+        "",
+        "| system | coverage | solve_rate | solved | ci95 |",
+        "| --- | ---: | ---: | ---: | --- |",
+    ]
+    for system_id in (baseline, candidate):
+        metrics = report["system_metrics"].get(system_id, {})
+        ci = metrics.get("solve_rate_ci95", {})
+        lines.append(
+            f"| {system_id} | {int(metrics.get('coverage_count', 0))} | {float(metrics.get('solve_rate', 0.0)):.4f} | {int(metrics.get('solved_count', 0))} | [{float(ci.get('low', 0.0)):.3f}, {float(ci.get('high', 0.0)):.3f}] |"
+        )
+    lines.extend([
+        "",
+        "## Paired Outcomes",
+        "",
+        f"- paired_task_count: `{paired.get('paired_task_count', 0)}`",
+        f"- unpaired_task_count: `{paired.get('unpaired_task_count', 0)}`",
+        f"- n11_both_solved: `{paired.get('n11_both_solved', 0)}`",
+        f"- n10_candidate_only: `{paired.get('n10_candidate_only', 0)}`",
+        f"- n01_baseline_only: `{paired.get('n01_baseline_only', 0)}`",
+        f"- n00_both_unsolved: `{paired.get('n00_both_unsolved', 0)}`",
+        "",
+        "## McNemar (Exact)",
+        "",
+        f"- discordant_pairs: `{mcnemar.get('discordant_pairs', 0)}`",
+        f"- candidate_wins: `{mcnemar.get('candidate_wins', 0)}`",
+        f"- baseline_wins: `{mcnemar.get('baseline_wins', 0)}`",
+        f"- exact_two_sided_pvalue: `{float(mcnemar.get('exact_two_sided_pvalue', 1.0)):.6f}`",
+        "",
+    ])
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--results", action="append", required=True)
+    parser.add_argument("--baseline-system", required=True)
+    parser.add_argument("--candidate-system", required=True)
+    parser.add_argument("--out-json", default="artifacts/benchmarks/cross_system_pilot_report_v1.latest.json")
+    parser.add_argument("--out-md", default="artifacts/benchmarks/cross_system_pilot_report_v1.latest.md")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    manifest = load_manifest(Path(args.manifest).resolve())
+    rows = load_jsonl([Path(item).resolve() for item in args.results])
+    report = _build_report(manifest, rows, str(args.baseline_system).strip(), str(args.candidate_system).strip())
+    out_json = Path(args.out_json).resolve()
+    out_md = Path(args.out_md).resolve()
+    dump_json(out_json, report)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(_to_markdown(report), encoding="utf-8")
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"[cross-system-pilot-report-v1] baseline={report['baseline_system']} candidate={report['candidate_system']} tasks={report['task_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/convert_hilbert_results_to_cross_system_v2.py
+++ b/scripts/convert_hilbert_results_to_cross_system_v2.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from _cross_system_eval_v1 import dump_json, load_manifest
+
+
+def _normalize_hash(text: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _load_task_hashes(path: Path) -> Dict[str, str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    tasks = payload.get("tasks") if isinstance(payload, dict) else payload
+    mapping = {}
+    for task in tasks:
+        if isinstance(task, dict):
+            mapping[str(task["task_id"])] = str(task.get("input_hash") or "")
+    return mapping
+
+
+def convert(
+    manifest_path: Path,
+    hilbert_result_path: Path,
+    task_inputs_path: Path,
+    out_path: Path,
+    summary_out: Path,
+) -> Dict[str, Any]:
+    manifest = load_manifest(manifest_path)
+    task_hashes = _load_task_hashes(task_inputs_path)
+    payload = json.loads(hilbert_result_path.read_text(encoding="utf-8"))
+    successes = payload.get("successes", {})
+    proofs = payload.get("proofs", {})
+    formal_statements = payload.get("formal_statements", {})
+    if not successes and isinstance(payload.get("results"), dict):
+        successes = payload.get("results", {})
+    problem_ids = payload.get("problem_ids", [])
+    if not problem_ids and isinstance(successes, dict):
+        problem_ids = list(successes.keys())
+    budget_class = manifest["budget"]["class"]
+    toolchain = manifest["toolchain"]
+    run_id = str(manifest.get("run_id") or "hilbert-pack")
+    rows: List[Dict[str, Any]] = []
+    status_counts: Dict[str, int] = {}
+    for idx, task_id in enumerate(problem_ids):
+        task_id = str(task_id)
+        success = bool(
+            successes.get(task_id, successes.get(str(idx), successes.get(idx, False)))
+        )
+        proof_text = proofs.get(task_id, proofs.get(str(idx), proofs.get(idx)))
+        formal_statement = formal_statements.get(task_id, formal_statements.get(str(idx), formal_statements.get(idx, "")))
+        status = "SOLVED" if success else "UNSOLVED"
+        status_counts[status] = status_counts.get(status, 0) + 1
+        rows.append(
+            {
+                "task_id": task_id,
+                "toolchain_id": f"lean-{toolchain['lean_version']}__mathlib-{toolchain['mathlib_commit']}",
+                "input_hash": task_hashes.get(task_id) or _normalize_hash(formal_statement),
+                "prover_system": "hilbert_roselab",
+                "budget_class": budget_class,
+                "status": status,
+                "verification_log_digest": _normalize_hash(json.dumps({"success": success, "proof_present": bool(proof_text)}, sort_keys=True)),
+                "run_id": run_id,
+                "attempts": 1,
+                "repair_rounds_used": 0,
+                "wall_clock_ms": 0,
+            }
+        )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n", encoding="utf-8")
+    summary = {"ok": True, "task_count": len(rows), "status_counts": status_counts, "result_path": str(out_path)}
+    dump_json(summary_out, summary)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--hilbert-results", required=True)
+    parser.add_argument("--task-inputs", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--summary-out", required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    summary = convert(
+        manifest_path=Path(args.manifest).resolve(),
+        hilbert_result_path=Path(args.hilbert_results).resolve(),
+        task_inputs_path=Path(args.task_inputs).resolve(),
+        out_path=Path(args.out).resolve(),
+        summary_out=Path(args.summary_out).resolve(),
+    )
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(f"[convert-hilbert-v2] ok={summary['ok']} tasks={summary['task_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_bb_formal_pack_v1.py
+++ b/scripts/run_bb_formal_pack_v1.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from _cross_system_eval_v1 import dump_json, load_manifest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _normalize_hash(text: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _read_env_key() -> None:
+    if os.environ.get("OPENROUTER_API_KEY"):
+        return
+    env_path = REPO_ROOT.parent / "misc" / "hermes_ref" / "firecrawl_compact" / ".env"
+    if not env_path.exists():
+        return
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        if line.startswith("OPENROUTER_API_KEY="):
+            os.environ["OPENROUTER_API_KEY"] = line.split("=", 1)[1].strip()
+            return
+
+
+def _load_tasks(path: Path) -> List[Dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    tasks = payload.get("tasks") if isinstance(payload, dict) else payload
+    if not isinstance(tasks, list):
+        raise ValueError("task inputs must contain a tasks array")
+    return tasks
+
+
+def _statement_prefix(text: str) -> str:
+    if ":= by" in text:
+        return text.split(":= by", 1)[0].rstrip()
+    if "begin" in text:
+        return text.split("begin", 1)[0].rstrip()
+    return text.strip()
+
+
+def _extract_lean_block(text: str) -> Optional[str]:
+    match = re.search(r"```lean\s*(.*?)```", text, re.DOTALL | re.IGNORECASE)
+    if match:
+        return match.group(1).strip() + "\n"
+    stripped = text.strip()
+    if stripped.startswith("import ") or stripped.startswith("theorem "):
+        return stripped + ("\n" if not stripped.endswith("\n") else "")
+    return None
+
+
+def _verify_with_kimina(proof_text: str, verifier_base_url: str) -> tuple[bool, Optional[str]]:
+    import sys
+
+    hilbert_root = REPO_ROOT.parent / "other_harness_refs" / "ml-hilbert"
+    if str(hilbert_root) not in sys.path:
+        sys.path.insert(0, str(hilbert_root))
+    from kimina_client.sync_client import KiminaClient
+    from src.tools.proof_utils import read_client_response
+    from src.tools.lean_utils import extract_all_error_messages
+
+    client = KiminaClient(api_url=verifier_base_url)
+    response = client.check(proof_text.strip(), timeout=60, infotree="original")
+    verification = read_client_response(response)[0]
+    ok = bool(verification.get("is_correct_no_sorry"))
+    if ok:
+        return True, None
+    try:
+        errors = extract_all_error_messages(response, [proof_text])
+        return False, errors[0]
+    except Exception:
+        return False, "verification_failed"
+
+
+def _result_cost_usd(run_dir: Path) -> float:
+    summary_path = run_dir / "meta" / "provider_metrics.json"
+    if not summary_path.exists():
+        return 0.0
+    try:
+        payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    except Exception:
+        return 0.0
+    total = payload.get("total_cost_usd")
+    try:
+        return float(total or 0.0)
+    except Exception:
+        return 0.0
+
+
+def _build_prompt(task_id: str, full_file: str) -> str:
+    return (
+        f"Task id: {task_id}\n"
+        "Return a complete Lean 4 file that preserves the theorem statement exactly and replaces only the proof body.\n"
+        "Do not modify imports, theorem name, binders, or hypotheses.\n"
+        "Do not use sorry, admit, exact?, or theorem rewrites.\n"
+        "Return exactly one ```lean fenced block, then TASK COMPLETE.\n\n"
+        "Starter file:\n"
+        "```lean\n"
+        f"{full_file.strip()}\n"
+        "```"
+    )
+
+
+def run_pack(
+    *,
+    manifest_path: Path,
+    task_inputs_path: Path,
+    out_path: Path,
+    summary_path: Path,
+    proof_output_dir: Path,
+    raw_output_dir: Path,
+    verifier_base_url: str,
+    max_iterations: int,
+    config_path: Path,
+) -> Dict[str, Any]:
+    _read_env_key()
+    os.environ.setdefault("RAY_SCE_LOCAL_MODE", "1")
+    manifest = load_manifest(manifest_path)
+    tasks = _load_tasks(task_inputs_path)
+    toolchain = manifest["toolchain"]
+    budget_class = manifest["budget"]["class"]
+    run_id = str(manifest.get("run_id") or "bb-formal-pack")
+    proof_output_dir.mkdir(parents=True, exist_ok=True)
+    raw_output_dir.mkdir(parents=True, exist_ok=True)
+    rows: List[Dict[str, Any]] = []
+    status_counts: Dict[str, int] = {}
+    total_cost = 0.0
+
+    for task in tasks:
+        task_id = str(task["task_id"])
+        input_text = str(task["input_text"])
+        task_hash = str(task.get("input_hash") or _normalize_hash(input_text))
+        workspace = raw_output_dir.parent / "bb_workspaces_v1" / task_id
+        if workspace.exists():
+            shutil.rmtree(workspace)
+        workspace.mkdir(parents=True, exist_ok=True)
+        result_json = workspace / "result.json"
+        cmd = [
+            "python",
+            "main.py",
+            str(config_path.relative_to(REPO_ROOT)),
+            "--workspace",
+            str(workspace),
+            "--task",
+            _build_prompt(task_id, input_text),
+            "--max-iterations",
+            str(max_iterations),
+            "--result-json",
+            str(result_json),
+        ]
+        proc = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True, timeout=900)
+        candidate_text = None
+        run_dir = None
+        result_payload: Dict[str, Any] | None = None
+        if result_json.exists():
+            result_payload = json.loads(result_json.read_text(encoding="utf-8"))
+            result_payload = result_payload.get("result") if isinstance(result_payload, dict) else None
+        if isinstance(result_payload, dict):
+            run_dir = Path(str(result_payload.get("run_dir") or result_payload.get("logging_dir") or ""))
+            messages = result_payload.get("messages") or []
+            for message in reversed(messages):
+                if isinstance(message, dict) and message.get("role") == "assistant":
+                    candidate_text = _extract_lean_block(str(message.get("content") or ""))
+                    if candidate_text:
+                        break
+        statement_ok = False
+        verify_ok = False
+        verify_error = None
+        proof_path = proof_output_dir / f"{task_id}.lean"
+        if candidate_text:
+            statement_ok = _statement_prefix(candidate_text) == _statement_prefix(input_text)
+            if statement_ok:
+                proof_path.write_text(candidate_text, encoding="utf-8")
+                verify_ok, verify_error = _verify_with_kimina(candidate_text, verifier_base_url)
+        if run_dir and run_dir.exists():
+            total_cost += _result_cost_usd(run_dir)
+        if verify_ok and statement_ok:
+            status = "SOLVED"
+        elif proc.returncode != 0:
+            status = "ERROR"
+        else:
+            status = "UNSOLVED"
+        status_counts[status] = status_counts.get(status, 0) + 1
+        diagnostic = {
+            "task_id": task_id,
+            "proc_returncode": proc.returncode,
+            "stdout_tail": proc.stdout[-4000:],
+            "stderr_tail": proc.stderr[-4000:],
+            "statement_ok": statement_ok,
+            "verify_ok": verify_ok,
+            "verify_error": verify_error,
+            "run_dir": str(run_dir) if run_dir else None,
+            "candidate_text": candidate_text,
+        }
+        raw_path = raw_output_dir / f"{task_id}.json"
+        raw_path.write_text(json.dumps(diagnostic, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        row = {
+            "task_id": task_id,
+            "toolchain_id": f"lean-{toolchain['lean_version']}__mathlib-{toolchain['mathlib_commit']}",
+            "input_hash": task_hash,
+            "prover_system": "bb_hilbert_like",
+            "budget_class": budget_class,
+            "status": status,
+            "verification_log_digest": _normalize_hash(json.dumps({"statement_ok": statement_ok, "verify_ok": verify_ok, "verify_error": verify_error}, sort_keys=True)),
+            "run_id": run_id,
+            "attempts": 1,
+            "repair_rounds_used": 0,
+            "wall_clock_ms": 0,
+            "proof_artifact_ref": str(proof_path) if proof_path.exists() else None,
+        }
+        rows.append(row)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n", encoding="utf-8")
+    summary = {
+        "schema": "breadboard.bb_formal_pack_run.v1",
+        "ok": True,
+        "run_id": run_id,
+        "task_count": len(rows),
+        "status_counts": status_counts,
+        "estimated_total_cost_usd": round(total_cost, 6),
+        "manifest_path": str(manifest_path),
+        "task_inputs_path": str(task_inputs_path),
+        "result_path": str(out_path),
+    }
+    dump_json(summary_path, summary)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--task-inputs", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--summary-out", required=True)
+    parser.add_argument("--proof-output-dir", required=True)
+    parser.add_argument("--raw-output-dir", required=True)
+    parser.add_argument("--verifier-url", default="http://127.0.0.1:18001/")
+    parser.add_argument("--config", default="agent_configs/atp_hilbert_like_gpt54_v2.yaml")
+    parser.add_argument("--max-iterations", type=int, default=8)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    summary = run_pack(
+        manifest_path=Path(args.manifest).resolve(),
+        task_inputs_path=Path(args.task_inputs).resolve(),
+        out_path=Path(args.out).resolve(),
+        summary_path=Path(args.summary_out).resolve(),
+        proof_output_dir=Path(args.proof_output_dir).resolve(),
+        raw_output_dir=Path(args.raw_output_dir).resolve(),
+        verifier_base_url=str(args.verifier_url).rstrip("/"),
+        max_iterations=int(args.max_iterations),
+        config_path=(REPO_ROOT / args.config).resolve(),
+    )
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(f"[bb-formal-pack-v1] ok={summary['ok']} tasks={summary['task_count']} statuses={summary['status_counts']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_cross_system_run_v1.py
+++ b/scripts/validate_cross_system_run_v1.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from _cross_system_eval_v1 import (
+    VALID_RESULT_STATUSES,
+    dump_json,
+    load_jsonl,
+    load_manifest,
+    required_result_fields,
+    validate_manifest_shape,
+)
+
+
+def validate_results(
+    manifest: Dict[str, Any],
+    rows: List[Dict[str, Any]],
+    *,
+    allow_incomplete_matrix: bool,
+) -> Tuple[List[str], List[str], Dict[str, Any]]:
+    errors: List[str] = []
+    warnings: List[str] = []
+    task_ids = set(str(item).strip() for item in (((manifest.get("benchmark") or {}).get("slice") or {}).get("task_ids") or []))
+    system_ids = set(
+        str(item.get("system_id") or "").strip()
+        for item in (manifest.get("systems") or [])
+        if isinstance(item, dict)
+    )
+    required_fields = required_result_fields(manifest)
+    seen_pairs: set[tuple[str, str]] = set()
+    rows_per_system: Dict[str, int] = {system_id: 0 for system_id in system_ids}
+    status_counts: Dict[str, int] = {status: 0 for status in VALID_RESULT_STATUSES}
+    for index, row in enumerate(rows):
+        source = f"{row.get('_source_path')}:{row.get('_source_line')}"
+        for field in required_fields:
+            value = row.get(field)
+            if value is None or (isinstance(value, str) and not value.strip()):
+                errors.append(f"rows[{index}] {source} missing required field: {field}")
+        task_id = str(row.get("task_id") or "").strip()
+        system_id = str(row.get("prover_system") or "").strip()
+        status = str(row.get("status") or "").strip().upper()
+        if task_id and task_ids and task_id not in task_ids:
+            errors.append(f"rows[{index}] {source} task_id not in manifest slice: {task_id}")
+        if system_id and system_ids and system_id not in system_ids:
+            errors.append(f"rows[{index}] {source} prover_system not in manifest.systems: {system_id}")
+        if status not in VALID_RESULT_STATUSES:
+            errors.append(f"rows[{index}] {source} invalid status={status!r}")
+        else:
+            status_counts[status] = int(status_counts.get(status, 0)) + 1
+        if task_id and system_id:
+            pair = (task_id, system_id)
+            if pair in seen_pairs:
+                errors.append(f"duplicate task/system pair: {task_id}/{system_id}")
+            seen_pairs.add(pair)
+            if system_id in rows_per_system:
+                rows_per_system[system_id] += 1
+    expected_pairs = len(task_ids) * len(system_ids)
+    actual_pairs = len(seen_pairs)
+    if expected_pairs > 0 and actual_pairs < expected_pairs:
+        message = f"incomplete matrix coverage: expected_pairs={expected_pairs} actual_pairs={actual_pairs}"
+        if allow_incomplete_matrix:
+            warnings.append(message)
+        else:
+            errors.append(message)
+    summary = {
+        "row_count": len(rows),
+        "expected_pairs": expected_pairs,
+        "actual_pairs": actual_pairs,
+        "rows_per_system": rows_per_system,
+        "status_counts": status_counts,
+        "required_result_fields": required_fields,
+    }
+    return errors, warnings, summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--results", action="append", required=True)
+    parser.add_argument("--json-out", default="artifacts/benchmarks/cross_system_validation_report_v1.latest.json")
+    parser.add_argument("--allow-incomplete-matrix", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    manifest_path = Path(args.manifest).resolve()
+    result_paths = [Path(item).resolve() for item in args.results]
+    manifest = load_manifest(manifest_path)
+    rows = load_jsonl(result_paths)
+    errors = validate_manifest_shape(manifest)
+    result_errors, warnings, summary = validate_results(manifest, rows, allow_incomplete_matrix=bool(args.allow_incomplete_matrix))
+    errors.extend(result_errors)
+    payload = {
+        "schema": "breadboard.cross_system_validation_report.v1",
+        "ok": len(errors) == 0,
+        "manifest_path": str(manifest_path),
+        "result_paths": [str(path) for path in result_paths],
+        "error_count": len(errors),
+        "warning_count": len(warnings),
+        "errors": errors,
+        "warnings": warnings,
+        "summary": summary,
+    }
+    out_path = Path(args.json_out).resolve()
+    dump_json(out_path, payload)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"[cross-system-validate-v1] ok={payload['ok']} errors={payload['error_count']} warnings={payload['warning_count']} rows={summary['row_count']}")
+    return 0 if payload["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- port the ATP/Hilbert comparison tooling from the local canonical phase6 recovery tree into a real git branch
- add bounded Hilbert comparison pack builders, a direct BreadBoard formal-pack runner, and cross-system validation/report helpers
- document the bounded Pack B medium result and add the Hilbert-like GPT-5.4 config/prompt used for the comparison lane

## Validation
- `python scripts/build_hilbert_comparison_packs_v2.py --pack pack_b_medium_noimo530_minif2f_v1`
- `python scripts/convert_hilbert_results_to_cross_system_v2.py --manifest artifacts/benchmarks/hilbert_comparison_packs_v2/pack_b_medium_noimo530_minif2f_v1/cross_system_manifest.json --hilbert-results-json <ported results> --output-jsonl <ported normalized rows>`
- `python scripts/validate_cross_system_run_v1.py --manifest artifacts/benchmarks/hilbert_comparison_packs_v2/pack_b_medium_noimo530_minif2f_v1/cross_system_manifest.json --inputs bb_hilbert_like:<ported bb rows> hilbert_roselab:<ported hilbert rows> --output-json artifacts/benchmarks/hilbert_comparison_packs_v2/pack_b_medium_noimo530_minif2f_v1/cross_system_validation_report_v1.json`

## Notes
- generated benchmark artifacts remain local because `artifacts/` is gitignored
- the bounded Pack B medium status note is checked in at `docs/atp_hilbert_pack_b_medium_status_2026-03-10.md`
- local unrelated modifications in `README.md` and `docs/INDEX.md` were intentionally left out of this PR