### PR TITLE
Fix ATP clean-clone verification portability

### DIFF
--- a/tests/atp_hilbert_fixture_utils.py
+++ b/tests/atp_hilbert_fixture_utils.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def install_minif2f_fixture(module: Any, root: Path) -> None:
+    task_ids = sorted(
+        {
+            task_id
+            for pack_task_ids in module.PACKS.values()
+            for task_id in pack_task_ids
+        }
+        | set(module.EXCLUDED_TASKS.keys())
+    )
+    lines = []
+    for task_id in task_ids:
+        lines.extend(
+            [
+                f"theorem {task_id} : True := by",
+                "  trivial",
+                "end",
+                "",
+            ]
+        )
+    midpoint = len(lines) // 2
+    test_path = root / "test.lean"
+    valid_path = root / "valid.lean"
+    test_path.write_text("\n".join(lines[:midpoint]) + "\n", encoding="utf-8")
+    valid_path.write_text("\n".join(lines[midpoint:]) + "\n", encoding="utf-8")
+    module.MINIF2F_FILES = [test_path, valid_path]
+
+
+def make_cross_system_report(
+    *,
+    task_count: int,
+    candidate_solved: int,
+    baseline_solved: int,
+    candidate_only: int | None = None,
+    baseline_only: int | None = None,
+) -> dict[str, Any]:
+    both_solved = min(candidate_solved, baseline_solved)
+    if candidate_only is None:
+        candidate_only = max(0, candidate_solved - both_solved)
+    if baseline_only is None:
+        baseline_only = max(0, baseline_solved - both_solved)
+    both_unsolved = max(0, task_count - both_solved - candidate_only - baseline_only)
+    return {
+        "task_count": task_count,
+        "candidate_system": "bb_hilbert_like",
+        "baseline_system": "hilbert_roselab",
+        "system_metrics": {
+            "bb_hilbert_like": {"solved_count": candidate_solved},
+            "hilbert_roselab": {"solved_count": baseline_solved},
+        },
+        "paired_outcomes": {
+            "n11_both_solved": both_solved,
+            "n10_candidate_only": candidate_only,
+            "n01_baseline_only": baseline_only,
+            "n00_both_unsolved": both_unsolved,
+        },
+        "directional_summary": {
+            "candidate_minus_baseline_solve_rate": round(
+                (candidate_solved - baseline_solved) / task_count if task_count else 0.0,
+                6,
+            )
+        },
+    }
+
+
+def install_canonical_baseline_fixture(module: Any, repo_root: Path) -> None:
+    module.REPO_ROOT = repo_root
+    for index, spec in enumerate(module.CANONICAL_BASELINES):
+        task_count = 4 if spec["role"] != "boundary_stress" else 2
+        candidate_solved = 3 if spec["role"] != "boundary_stress" else 0
+        baseline_solved = 2 if spec["role"] != "boundary_stress" else 0
+        report = make_cross_system_report(
+            task_count=task_count,
+            candidate_solved=candidate_solved,
+            baseline_solved=baseline_solved,
+        )
+        validation = {"ok": True}
+        status_doc = repo_root / spec["status_doc"]
+        status_doc.parent.mkdir(parents=True, exist_ok=True)
+        status_doc.write_text(
+            f"# {spec['pack_id']}\n\n- maintained Hilbert spend: ~$0.{index + 1:06d}\n",
+            encoding="utf-8",
+        )
+        write_json(repo_root / spec["report"], report)
+        write_json(repo_root / spec["validation"], validation)

--- a/tests/test_backfill_atp_hilbert_bb_spend_v1.py
+++ b/tests/test_backfill_atp_hilbert_bb_spend_v1.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
-import json
 import sys
 from pathlib import Path
+
+from atp_hilbert_fixture_utils import write_json
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "backfill_atp_hilbert_bb_spend_v1.py"
 sys.path.insert(0, str(MODULE_PATH.parent))
@@ -21,10 +22,43 @@ def test_extract_status_pack_ids_finds_pack_references() -> None:
     ]
 
 
-def test_bb_spend_backfill_payload_contains_entries() -> None:
-    payload = module.build_payload(module.DEFAULT_INDEX)
+def test_bb_spend_backfill_payload_contains_entries(tmp_path: Path) -> None:
+    module.REPO_ROOT = tmp_path
+    index_path = tmp_path / "canonical_baseline_index_v1.json"
+    run_dir = tmp_path / "logging" / "run_a"
+    write_json(
+        run_dir / "meta" / "run_summary.json",
+        {
+            "turn_diagnostics": [
+                {
+                    "route_id": "openai/gpt-5.4",
+                    "provider_model": "openai/gpt-5.4",
+                    "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+                }
+            ]
+        },
+    )
+    raw_dir = tmp_path / "artifacts" / "benchmarks" / "hilbert_comparison_packs_v2" / "pack_b_core_noimo_minif2f_v1" / "bb_hilbert_like_raw_v1"
+    write_json(raw_dir / "task_a.json", {"task_id": "task_a", "run_dir": "logging/run_a"})
+    status_doc = tmp_path / "docs" / "pack_b_status.md"
+    status_doc.parent.mkdir(parents=True, exist_ok=True)
+    status_doc.write_text("# status\n", encoding="utf-8")
+    write_json(
+        index_path,
+        {
+            "entries": [
+                {
+                    "pack_id": "pack_b_core_noimo_minif2f_v1",
+                    "task_count": 1,
+                    "status_doc": "docs/pack_b_status.md",
+                    "report": "artifacts/benchmarks/hilbert_comparison_packs_v2/pack_b_core_noimo_minif2f_v1/cross_system_pilot_report_v1.json",
+                }
+            ]
+        },
+    )
+    payload = module.build_payload(index_path)
     assert payload["schema"] == "breadboard.atp_hilbert_bb_spend_backfill.v1"
-    assert payload["entry_count"] >= 10
+    assert payload["entry_count"] == 1
     pack_ids = {entry["pack_id"] for entry in payload["entries"]}
     assert "pack_b_core_noimo_minif2f_v1" in pack_ids
     assert any(float(entry["estimated_total_cost_usd"]) > 0 for entry in payload["entries"])

--- a/tests/test_build_atp_hilbert_canonical_baselines_v1.py
+++ b/tests/test_build_atp_hilbert_canonical_baselines_v1.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+from atp_hilbert_fixture_utils import install_canonical_baseline_fixture
+
 MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "build_atp_hilbert_canonical_baselines_v1.py"
 sys.path.insert(0, str(MODULE_PATH.parent))
 spec = importlib.util.spec_from_file_location("build_atp_hilbert_canonical_baselines_v1", MODULE_PATH)
@@ -12,7 +14,8 @@ module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 
 
-def test_canonical_baseline_payload_has_expected_entries() -> None:
+def test_canonical_baseline_payload_has_expected_entries(tmp_path: Path) -> None:
+    install_canonical_baseline_fixture(module, tmp_path)
     payload = module.build_payload()
     entries = payload["entries"]
     assert payload["schema"] == "breadboard.atp_hilbert_canonical_baselines.v1"
@@ -25,8 +28,9 @@ def test_canonical_baseline_payload_has_expected_entries() -> None:
     assert "pack_j_residue_gcd_mix_minif2f_v1" in pack_ids
 
 
-def test_canonical_baseline_payload_entries_reference_existing_files() -> None:
-    repo_root = Path(__file__).resolve().parents[1]
+def test_canonical_baseline_payload_entries_reference_existing_files(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    install_canonical_baseline_fixture(module, repo_root)
     payload = module.build_payload()
     for entry in payload["entries"]:
         assert (repo_root / entry["status_doc"]).exists()

--- a/tests/test_build_atp_hilbert_no_repair_slice_v1.py
+++ b/tests/test_build_atp_hilbert_no_repair_slice_v1.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+from atp_hilbert_fixture_utils import write_json
+
 MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "build_atp_hilbert_no_repair_slice_v1.py"
 sys.path.insert(0, str(MODULE_PATH.parent))
 spec = importlib.util.spec_from_file_location("build_atp_hilbert_no_repair_slice_v1", MODULE_PATH)
@@ -12,8 +14,30 @@ module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 
 
-def test_no_repair_slice_contains_pack_j() -> None:
-    payload = module.build_payload(module.DEFAULT_INDEX, module.DEFAULT_ARM_AUDIT)
+def test_no_repair_slice_contains_pack_j(tmp_path: Path) -> None:
+    index_path = tmp_path / "canonical_baseline_index_v1.json"
+    arm_audit_path = tmp_path / "arm_audit_v1.json"
+    write_json(
+        index_path,
+        {
+            "entries": [
+                {
+                    "pack_id": "pack_j_residue_gcd_mix_minif2f_v1",
+                    "role": "canonical_primary",
+                    "task_count": 6,
+                    "candidate_solved": 6,
+                    "baseline_solved": 4,
+                    "report": "r.json",
+                    "validation": "v.json",
+                }
+            ]
+        },
+    )
+    write_json(
+        arm_audit_path,
+        {"entries": [{"pack_id": "pack_j_residue_gcd_mix_minif2f_v1", "candidate_arm_mode": "baseline_only"}]},
+    )
+    payload = module.build_payload(index_path, arm_audit_path)
     assert payload["schema"] == "breadboard.atp_hilbert_no_repair_slice.v1"
     assert payload["entry_count"] >= 1
     pack_ids = {entry["pack_id"] for entry in payload["entries"]}

--- a/tests/test_build_atp_hilbert_repair_intensity_v1.py
+++ b/tests/test_build_atp_hilbert_repair_intensity_v1.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+from atp_hilbert_fixture_utils import write_json
+
 MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "build_atp_hilbert_repair_intensity_v1.py"
 sys.path.insert(0, str(MODULE_PATH.parent))
 spec = importlib.util.spec_from_file_location("build_atp_hilbert_repair_intensity_v1", MODULE_PATH)
@@ -12,9 +14,29 @@ module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 
 
-def test_repair_intensity_payload_has_primary_ratios() -> None:
-    payload = module.build_payload(module.DEFAULT_INDEX, module.DEFAULT_ARM_AUDIT)
+def test_repair_intensity_payload_has_primary_ratios(tmp_path: Path) -> None:
+    index_path = tmp_path / "canonical_baseline_index_v1.json"
+    arm_audit_path = tmp_path / "arm_audit_v1.json"
+    write_json(
+        index_path,
+        {
+            "entries": [
+                {"pack_id": "pack_f", "role": "canonical_primary", "task_count": 6},
+                {"pack_id": "pack_j", "role": "canonical_primary", "task_count": 6},
+            ]
+        },
+    )
+    write_json(
+        arm_audit_path,
+        {
+            "entries": [
+                {"pack_id": "pack_f", "candidate_arm_mode": "focused_repaired", "focused_task_count": 3},
+                {"pack_id": "pack_j", "candidate_arm_mode": "baseline_only", "focused_task_count": 0},
+            ]
+        },
+    )
+    payload = module.build_payload(index_path, arm_audit_path)
     assert payload["schema"] == "breadboard.atp_hilbert_repair_intensity.v1"
-    assert payload["primary_pack_count"] >= 8
+    assert payload["primary_pack_count"] == 2
     assert payload["primary_focused_pack_count"] >= 1
     assert payload["primary_focused_task_ratio"] > 0

--- a/tests/test_build_atp_hilbert_rollup_v1.py
+++ b/tests/test_build_atp_hilbert_rollup_v1.py
@@ -14,6 +14,59 @@ spec.loader.exec_module(module)
 
 
 def test_rollup_builds_all_expected_files(tmp_path: Path) -> None:
+    module.build_baseline_payload = lambda: {
+        "schema": "breadboard.atp_hilbert_canonical_baselines.v1",
+        "candidate_system": "bb_hilbert_like",
+        "baseline_system": "hilbert_roselab",
+        "entry_count": 1,
+        "entries": [
+            {
+                "pack_id": "pack_fixture",
+                "role": "canonical_primary",
+                "task_count": 3,
+                "candidate_solved": 2,
+                "baseline_solved": 1,
+                "candidate_only": 1,
+                "baseline_only": 0,
+                "both_solved": 1,
+                "both_unsolved": 1,
+                "status_doc": "docs/fixture.md",
+                "report": "artifacts/fixture_report.json",
+                "validation": "artifacts/fixture_validation.json",
+                "note": "fixture",
+            }
+        ],
+    }
+    module.build_arm_audit_payload = lambda: {
+        "schema": "breadboard.atp_hilbert_arm_audit.v1",
+        "entry_count": 1,
+        "entries": [{"pack_id": "pack_fixture", "candidate_arm_mode": "baseline_only", "focused_task_count": 0, "note": "fixture"}],
+        "mode_counts": {"baseline_only": 1},
+    }
+    module.build_bb_spend_payload = lambda baseline_json: {
+        "schema": "breadboard.atp_hilbert_bb_spend_backfill.v1",
+        "entries": [{"pack_id": "pack_fixture", "estimated_total_cost_usd": 0.25}],
+    }
+    module.build_scoreboard_payload = lambda baseline_json, bb_spend_json, arm_audit_json: {
+        "schema": "breadboard.atp_hilbert_scoreboard.v1",
+        "candidate_system": "bb_hilbert_like",
+        "baseline_system": "hilbert_roselab",
+        "headline_totals": {
+            "pack_count": 1,
+            "task_count": 3,
+            "candidate_solved_total": 2,
+            "baseline_solved_total": 1,
+            "candidate_only_total": 1,
+            "baseline_only_total": 0,
+            "candidate_ahead_pack_count": 1,
+            "tied_pack_count": 0,
+            "baseline_ahead_pack_count": 0,
+            "hilbert_exact_spend_usd_total": 0.125,
+            "breadboard_estimated_spend_usd_total": 0.25,
+        },
+        "arm_mode_breakdown": {"baseline_only": 1},
+        "entries": [],
+    }
     payload = module.build_rollup(tmp_path)
     assert payload["schema"] == "breadboard.atp_hilbert_rollup_manifest.v1"
     baseline_json = tmp_path / "canonical_baseline_index_v1.json"
@@ -27,4 +80,4 @@ def test_rollup_builds_all_expected_files(tmp_path: Path) -> None:
     assert scoreboard_json.exists()
     assert rollup_json.exists()
     scoreboard = json.loads(scoreboard_json.read_text())
-    assert scoreboard["headline_totals"]["pack_count"] >= 8
+    assert scoreboard["headline_totals"]["pack_count"] == 1

--- a/tests/test_build_atp_hilbert_scoreboard_v1.py
+++ b/tests/test_build_atp_hilbert_scoreboard_v1.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+from atp_hilbert_fixture_utils import write_json
+
 MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "build_atp_hilbert_scoreboard_v1.py"
 sys.path.insert(0, str(MODULE_PATH.parent))
 spec = importlib.util.spec_from_file_location("build_atp_hilbert_scoreboard_v1", MODULE_PATH)
@@ -12,17 +14,83 @@ module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 
 
-def test_scoreboard_payload_uses_primary_roles_for_headline() -> None:
-    payload = module.build_payload(module.DEFAULT_INDEX)
+def test_scoreboard_payload_uses_primary_roles_for_headline(tmp_path: Path) -> None:
+    index_path = tmp_path / "canonical_baseline_index_v1.json"
+    spend_path = tmp_path / "bb_spend_backfill_v1.json"
+    arm_audit_path = tmp_path / "arm_audit_v1.json"
+    status_doc = tmp_path / "docs" / "pack_a.md"
+    status_doc.parent.mkdir(parents=True, exist_ok=True)
+    status_doc.write_text("maintained Hilbert spend: ~$0.125000\n", encoding="utf-8")
+    write_json(tmp_path / "artifacts" / "pack_a_report.json", {})
+    write_json(tmp_path / "artifacts" / "pack_a_validation.json", {"ok": True})
+    write_json(
+        index_path,
+        {
+            "candidate_system": "bb_hilbert_like",
+            "baseline_system": "hilbert_roselab",
+            "entries": [
+                {
+                    "pack_id": "pack_a",
+                    "role": "canonical_primary",
+                    "status_doc": "docs/pack_a.md",
+                    "report": "artifacts/pack_a_report.json",
+                    "validation": "artifacts/pack_a_validation.json",
+                    "task_count": 5,
+                    "candidate_solved": 4,
+                    "baseline_solved": 2,
+                    "candidate_only": 2,
+                    "baseline_only": 0,
+                    "both_solved": 2,
+                    "both_unsolved": 1,
+                }
+            ],
+        },
+    )
+    write_json(spend_path, {"entries": [{"pack_id": "pack_a", "estimated_total_cost_usd": 0.03125}]})
+    write_json(arm_audit_path, {"entries": [{"pack_id": "pack_a", "candidate_arm_mode": "baseline_only", "focused_task_count": 0}]})
+    module.REPO_ROOT = tmp_path
+    payload = module.build_payload(index_path, spend_path, arm_audit_path)
     totals = payload["headline_totals"]
     assert payload["schema"] == "breadboard.atp_hilbert_scoreboard.v1"
-    assert totals["pack_count"] >= 8
+    assert totals["pack_count"] == 1
     assert totals["candidate_solved_total"] >= totals["baseline_solved_total"]
     assert totals["candidate_ahead_pack_count"] >= 1
 
 
-def test_scoreboard_entries_include_spend_for_primary_packs() -> None:
-    payload = module.build_payload(module.DEFAULT_INDEX, module.DEFAULT_BB_SPEND, module.DEFAULT_ARM_AUDIT)
+def test_scoreboard_entries_include_spend_for_primary_packs(tmp_path: Path) -> None:
+    index_path = tmp_path / "canonical_baseline_index_v1.json"
+    spend_path = tmp_path / "bb_spend_backfill_v1.json"
+    arm_audit_path = tmp_path / "arm_audit_v1.json"
+    status_doc = tmp_path / "docs" / "pack_b.md"
+    status_doc.parent.mkdir(parents=True, exist_ok=True)
+    status_doc.write_text("maintained Hilbert spend: ~$0.250000\n", encoding="utf-8")
+    write_json(
+        index_path,
+        {
+            "candidate_system": "bb_hilbert_like",
+            "baseline_system": "hilbert_roselab",
+            "entries": [
+                {
+                    "pack_id": "pack_b",
+                    "role": "canonical_primary",
+                    "status_doc": "docs/pack_b.md",
+                    "report": "artifacts/pack_b_report.json",
+                    "validation": "artifacts/pack_b_validation.json",
+                    "task_count": 4,
+                    "candidate_solved": 3,
+                    "baseline_solved": 2,
+                    "candidate_only": 1,
+                    "baseline_only": 0,
+                    "both_solved": 2,
+                    "both_unsolved": 1,
+                }
+            ],
+        },
+    )
+    write_json(spend_path, {"entries": [{"pack_id": "pack_b", "estimated_total_cost_usd": 0.125}]})
+    write_json(arm_audit_path, {"entries": [{"pack_id": "pack_b", "candidate_arm_mode": "baseline_only", "focused_task_count": 0}]})
+    module.REPO_ROOT = tmp_path
+    payload = module.build_payload(index_path, spend_path, arm_audit_path)
     primary_entries = [entry for entry in payload["entries"] if entry["is_primary"]]
     assert primary_entries
     assert any(entry["hilbert_exact_spend_usd"] is not None for entry in primary_entries)

--- a/tests/test_build_hilbert_comparison_packs_v2.py
+++ b/tests/test_build_hilbert_comparison_packs_v2.py
@@ -4,6 +4,9 @@ import importlib.util
 import json
 from pathlib import Path
 
+import pytest
+from atp_hilbert_fixture_utils import install_minif2f_fixture
+
 MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "build_hilbert_comparison_packs_v2.py"
 import sys
 
@@ -12,6 +15,11 @@ spec = importlib.util.spec_from_file_location("build_hilbert_comparison_packs_v2
 assert spec and spec.loader
 packs = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(packs)
+
+
+@pytest.fixture(autouse=True)
+def _minif2f_fixture(tmp_path: Path) -> None:
+    install_minif2f_fixture(packs, tmp_path)
 
 
 def test_known_unsound_task_is_excluded_from_medium_pack(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- make ATP clean-clone verification tests self-contained instead of depending on local miniF2F checkouts and ignored artifact trees
- add small fixture helpers for synthetic miniF2F theorem blocks and canonical pack/report JSON
- keep merged-main ATP verification green without requiring local benchmark artifacts

## Validation
- `pytest -q tests/test_build_hilbert_comparison_packs_v2.py tests/test_convert_hilbert_results_to_cross_system_v2.py tests/test_run_bb_formal_pack_v1.py tests/test_build_atp_hilbert_arm_audit_v1.py tests/test_build_atp_hilbert_canonical_baselines_v1.py tests/test_build_atp_hilbert_no_repair_slice_v1.py tests/test_build_atp_hilbert_repair_intensity_v1.py tests/test_build_atp_hilbert_rollup_v1.py tests/test_build_atp_hilbert_scoreboard_v1.py tests/test_backfill_atp_hilbert_bb_spend_v1.py tests/test_build_atp_invalid_extract_ledger_v1.py`
- `python -m py_compile scripts/build_hilbert_comparison_packs_v2.py scripts/convert_hilbert_results_to_cross_system_v2.py scripts/run_bb_formal_pack_v1.py scripts/build_atp_hilbert_arm_audit_v1.py scripts/build_atp_hilbert_canonical_baselines_v1.py scripts/build_atp_hilbert_no_repair_slice_v1.py scripts/build_atp_hilbert_repair_intensity_v1.py scripts/build_atp_hilbert_rollup_v1.py scripts/build_atp_hilbert_scoreboard_v1.py scripts/backfill_atp_hilbert_bb_spend_v1.py scripts/build_atp_invalid_extract_ledger_v1.py tests/test_build_hilbert_comparison_packs_v2.py tests/test_convert_hilbert_results_to_cross_system_v2.py tests/test_run_bb_formal_pack_v1.py tests/test_build_atp_hilbert_arm_audit_v1.py tests/test_build_atp_hilbert_canonical_baselines_v1.py tests/test_build_atp_hilbert_no_repair_slice_v1.py tests/test_build_atp_hilbert_repair_intensity_v1.py tests/test_build_atp_hilbert_rollup_v1.py tests/test_build_atp_hilbert_scoreboard_v1.py tests/test_backfill_atp_hilbert_bb_spend_v1.py tests/test_build_atp_invalid_extract_ledger_v1.py`
