### PR TITLE
Repair markdown rendering and Codex model defaults

### DIFF
--- a/tui_skeleton/package-lock.json
+++ b/tui_skeleton/package-lock.json
@@ -15,6 +15,7 @@
         "@effect/printer": "^0.45.0",
         "@effect/printer-ansi": "^0.45.0",
         "@stream-mdx/core": "^0.5.0",
+        "@stream-mdx/tui": "^0.5.0",
         "@stream-mdx/worker": "^0.5.0",
         "@types/node": "^24.2.1",
         "chalk": "^5.3.0",
@@ -1591,6 +1592,25 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@stream-mdx/protocol": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@stream-mdx/protocol/-/protocol-0.5.0.tgz",
+      "integrity": "sha512-fJkb1uhqFaOw/VbysJAz93CRsWI3FYjbndHGPmIyS9v1uOLzbfOT55v/W7miQdcrCJ+yLwmZ/rd3PPNJKUn/0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@stream-mdx/core": "0.5.0"
+      }
+    },
+    "node_modules/@stream-mdx/tui": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@stream-mdx/tui/-/tui-0.5.0.tgz",
+      "integrity": "sha512-ji/OX1mQvkDl0843700hzRvX3vrmmuNLFVUVrjypfVWG4XzCAttSV4Oc7h/gJ84+JBo57AvuK+NlwWGqxrQNRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stream-mdx/core": "0.5.0",
+        "@stream-mdx/protocol": "0.5.0"
       }
     },
     "node_modules/@stream-mdx/worker": {

--- a/tui_skeleton/package.json
+++ b/tui_skeleton/package.json
@@ -162,6 +162,7 @@
     "@effect/printer": "^0.45.0",
     "@effect/printer-ansi": "^0.45.0",
     "@stream-mdx/core": "^0.5.0",
+    "@stream-mdx/tui": "^0.5.0",
     "@stream-mdx/worker": "^0.5.0",
     "@types/node": "^24.2.1",
     "chalk": "^5.3.0",

--- a/tui_skeleton/package.json
+++ b/tui_skeleton/package.json
@@ -62,6 +62,7 @@
     "qc:user-reported:post-submit-resize": "bash scripts/run_legacy_pty_case.sh --script scripts/qc_cases/resize_submit_churn.json --config ../agent_configs/misc/opencode_mock_c_fs.yaml --snapshots scripts/_tmp_qc_resize_submit_churn.txt --max-duration-ms 240000 && node --import tsx scripts/qc_resize_submit_gate.ts scripts/_tmp_qc_resize_submit_churn.txt",
     "qc:user-reported:menu-combo-stability": "bash scripts/run_legacy_pty_case.sh --script scripts/qc_cases/menu_combo_stability.json --snapshots scripts/_tmp_qc_menu_combo_stability.txt --max-duration-ms 240000 && rg -q \"src/repl/components/LineEditor.tsx\" scripts/_tmp_qc_menu_combo_stability.txt",
     "qc:user-reported:streaming-markdown": "bash scripts/qc_streaming_markdown_pty.sh",
+    "qc:user-reported:markdown-wrapper-render": "bash scripts/qc_markdown_wrapper_render_pty.sh",
     "qc:user-reported:tool-projection": "bash scripts/qc_tool_projection_pty.sh",
     "qc:user-reported:reasoning-projection": "bash scripts/qc_reasoning_projection_pty.sh",
     "qc:user-reported:disconnect-render-integrity": "bash scripts/qc_disconnect_render_integrity_pty.sh",

--- a/tui_skeleton/scripts/markdown_wrapper_render_pty.json
+++ b/tui_skeleton/scripts/markdown_wrapper_render_pty.json
@@ -1,0 +1,8 @@
+[
+  { "action": "waitFor", "text": "enter send", "timeoutMs": 20000, "mode": "frame" },
+  { "action": "type", "text": "Show me some markdown.", "typingDelayMs": 5 },
+  { "action": "press", "key": "enter" },
+  { "action": "waitFor", "text": "Sample Markdown", "timeoutMs": 30000, "mode": "either" },
+  { "action": "waitFor", "text": "enter send", "timeoutMs": 30000, "mode": "frame" },
+  { "action": "snapshot", "label": "markdown-wrapper-final", "mode": "history", "maxLines": 400 }
+]

--- a/tui_skeleton/scripts/mock_sse_markdown_wrapper_render.json
+++ b/tui_skeleton/scripts/mock_sse_markdown_wrapper_render.json
@@ -1,0 +1,31 @@
+[
+  { "delayMs": 0, "event": { "type": "turn_start", "payload": { "summary": "mock markdown wrapper render" }, "turn": 1 } },
+  { "delayMs": 120, "event": { "type": "assistant.message.start", "payload": { "message_id": "markdown-wrapper", "channel": "text", "format": "markdown" }, "turn": 1 } },
+  {
+    "delayMs": 120,
+    "event": {
+      "type": "assistant.message.delta",
+      "payload": {
+        "message_id": "markdown-wrapper",
+        "delta": "```markdown\n# Sample Markdown\n\n## Section Heading\n- **Bullet** item one\n- *Italic* item two\n> A blockquote for emphasis.\n\n```python\ndef greet(name):\n    return f\"Hello, {name}!\"\n```\n```\n"
+      },
+      "turn": 1
+    }
+  },
+  {
+    "delayMs": 120,
+    "event": {
+      "type": "assistant_message",
+      "payload": {
+        "text": "```markdown\n# Sample Markdown\n\n## Section Heading\n- **Bullet** item one\n- *Italic* item two\n> A blockquote for emphasis.\n\n```python\ndef greet(name):\n    return f\"Hello, {name}!\"\n```\n```\n",
+        "message": {
+          "role": "assistant",
+          "content": "```markdown\n# Sample Markdown\n\n## Section Heading\n- **Bullet** item one\n- *Italic* item two\n> A blockquote for emphasis.\n\n```python\ndef greet(name):\n    return f\"Hello, {name}!\"\n```\n```\n"
+        }
+      },
+      "turn": 1
+    }
+  },
+  { "delayMs": 120, "event": { "type": "completion", "payload": { "summary": { "completed": true, "reason": "mock-markdown-wrapper" } }, "turn": 1 } },
+  { "delayMs": 0, "event": { "type": "run_finished", "payload": { "eventCount": 6 }, "turn": 1 } }
+]

--- a/tui_skeleton/scripts/qc_markdown_wrapper_render_gate.ts
+++ b/tui_skeleton/scripts/qc_markdown_wrapper_render_gate.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs"
+
+const path = process.argv[2]
+if (!path) {
+  console.error("Usage: qc_markdown_wrapper_render_gate.ts <snapshots.txt>")
+  process.exit(2)
+}
+
+const snapshot = readFileSync(path, "utf8")
+const required = [
+  ["Sample Markdown", "heading text"],
+  ["Section Heading", "subheading text"],
+  ["- Bullet item one", "bold list item without delimiters"],
+  ["- Italic item two", "italic list item without delimiters"],
+  ["A blockquote for emphasis.", "blockquote content"],
+  ["def greet(name):", "nested code content"],
+] as const
+const forbidden = [
+  ["code · markdown", "markdown wrapper rendered as code"],
+  ["```markdown", "raw markdown fence"],
+  ["# Sample Markdown", "raw heading marker"],
+  ["**Bullet**", "raw bold marker"],
+  ["*Italic*", "raw italic marker"],
+  ["> A blockquote", "raw blockquote marker"],
+  ["Assistant latest", "height-pressure placeholder hiding final answer"],
+] as const
+
+const failures: string[] = []
+for (const [needle, label] of required) {
+  if (!snapshot.includes(needle)) failures.push(`missing ${label}: ${needle}`)
+}
+for (const [needle, label] of forbidden) {
+  if (snapshot.includes(needle)) failures.push(`forbidden ${label}: ${needle}`)
+}
+
+if (failures.length > 0) {
+  console.error(`[qc] markdown wrapper render gate failed (${failures.length})`)
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log("[qc] markdown wrapper render gate passed")

--- a/tui_skeleton/scripts/qc_markdown_wrapper_render_pty.sh
+++ b/tui_skeleton/scripts/qc_markdown_wrapper_render_pty.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[qc][legacy] $(basename "$0") is a compatibility or narrow-repro lane." >&2
+echo "[qc][legacy] Prefer scripts/qc_profile_matrix.sh and qc:profile:* for canonical QC." >&2
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+MOCK_HOST="127.0.0.1"
+MOCK_PORT="${BREADBOARD_CLI_MOCK_SSE_PORT:-9497}"
+MOCK_SCRIPT="${BREADBOARD_MOCK_SSE_SCRIPT:-${ROOT_DIR}/scripts/mock_sse_markdown_wrapper_render.json}"
+SNAPSHOT_PATH="${BREADBOARD_MARKDOWN_WRAPPER_SNAPSHOT:-${ROOT_DIR}/scripts/_tmp_qc_markdown_wrapper_render.txt}"
+MOCK_LOG="${ROOT_DIR}/scripts/_tmp_qc_markdown_wrapper_render_mock.log"
+
+cleanup() {
+  if [[ -n "${MOCK_PID:-}" ]]; then
+    kill "${MOCK_PID}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+rm -f "${SNAPSHOT_PATH}" "${MOCK_LOG}"
+
+pnpm exec tsx "${ROOT_DIR}/tools/mock/mockSseServer.ts" \
+  --script "${MOCK_SCRIPT}" \
+  --host "${MOCK_HOST}" \
+  --port "${MOCK_PORT}" \
+  >"${MOCK_LOG}" 2>&1 &
+MOCK_PID=$!
+
+sleep 1
+
+BREADBOARD_ENGINE_MODE="external" \
+BREADBOARD_API_URL="http://${MOCK_HOST}:${MOCK_PORT}" \
+node --import tsx "${ROOT_DIR}/scripts/repl_pty_harness.ts" \
+  --script "${ROOT_DIR}/scripts/markdown_wrapper_render_pty.json" \
+  --snapshots "${SNAPSHOT_PATH}" \
+  --max-duration-ms 120000
+
+node --import tsx "${ROOT_DIR}/scripts/qc_markdown_wrapper_render_gate.ts" "${SNAPSHOT_PATH}"

--- a/tui_skeleton/src/commands/repl/controller.ts
+++ b/tui_skeleton/src/commands/repl/controller.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events"
 import { promises as fs } from "node:fs"
 import path from "node:path"
+import YAML from "yaml"
 import type { Block } from "@stream-mdx/core/types"
 import type { MarkdownStreamer } from "../../markdown/streamer.js"
 import type {
@@ -120,6 +121,29 @@ export interface ReplControllerOptions {
   readonly todoAutoFollowHysteresisMs?: number
   readonly todoAutoFollowManualOverrideMs?: number
   readonly clock?: UIClock
+}
+
+const resolveConfigDefaultModel = async (configPath?: string | null): Promise<string | null> => {
+  if (!configPath) return null
+  try {
+    const raw = await fs.readFile(configPath, "utf8")
+    const parsed = YAML.parse(raw) as unknown
+    if (!parsed || typeof parsed !== "object") return null
+    const providers = (parsed as { providers?: unknown }).providers
+    if (!providers || typeof providers !== "object") return null
+    const value = (providers as { default_model?: unknown }).default_model
+    return typeof value === "string" && value.trim().length > 0 ? value.trim() : null
+  } catch {
+    return null
+  }
+}
+
+const resolveEffectiveRequestedModel = async (
+  config: { model?: string | null; configPath?: string | null },
+): Promise<string> => {
+  const cliModel = config.model?.trim()
+  if (cliModel) return cliModel
+  return (await resolveConfigDefaultModel(config.configPath)) ?? DEFAULT_MODEL_ID
 }
 
 export interface CompletionView {
@@ -588,8 +612,8 @@ export class ReplSessionController extends EventEmitter {
     this.todoScopeLastUpdateKey = null
     this.todoScopeLastUpdateAt = null
     this.activity = createActivitySnapshot("session")
-    const requestedModel = this.config.model?.trim()
-    const modelLabel = requestedModel ?? this.stats.model
+    const requestedModel = await resolveEffectiveRequestedModel(this.config)
+    const modelLabel = requestedModel || this.stats.model
     this.stats.model = modelLabel
     this.resolveProviderCapabilitiesSnapshot(modelLabel)
     const remotePreference = this.config.remotePreference ?? appConfig.remoteStreamDefault
@@ -616,10 +640,8 @@ export class ReplSessionController extends EventEmitter {
         overrides["permissions.webfetch.default"] ??= "ask"
       }
     }
-    if (requestedModel) {
-      metadata.model = requestedModel
-      overrides["providers.default_model"] = requestedModel
-    }
+    metadata.model = requestedModel
+    overrides["providers.default_model"] = requestedModel
     if (remotePreference) {
       metadata.enable_remote_stream = true
     }
@@ -636,7 +658,7 @@ export class ReplSessionController extends EventEmitter {
     this.sessionId = session.session_id
     try {
       const summary = await this.api().getSession(this.sessionId)
-      if (summary?.model && typeof summary.model === "string") {
+      if (!requestedModel && summary?.model && typeof summary.model === "string") {
         this.stats.model = summary.model
         this.resolveProviderCapabilitiesSnapshot(summary.model)
       }
@@ -692,7 +714,7 @@ export class ReplSessionController extends EventEmitter {
     const preserveLocalTranscript = options.preserveLocalTranscript === true
     if (!preserveLocalTranscript && (this.conversation.length > 0 || this.toolEvents.length > 0)) return false
     const appConfig = this.providers.args.config
-    const requestedModel = this.config.model?.trim()
+    const requestedModel = await resolveEffectiveRequestedModel(this.config)
     const remotePreference = this.config.remotePreference ?? appConfig.remoteStreamDefault
     const permissionValue = this.config.permissionMode?.trim()
     const permissionMode = permissionValue ? permissionValue.toLowerCase() : ""
@@ -718,10 +740,8 @@ export class ReplSessionController extends EventEmitter {
         overrides["permissions.webfetch.default"] ??= "ask"
       }
     }
-    if (requestedModel) {
-      metadata.model = requestedModel
-      overrides["providers.default_model"] = requestedModel
-    }
+    metadata.model = requestedModel
+    overrides["providers.default_model"] = requestedModel
     if (remotePreference) {
       metadata.enable_remote_stream = true
     }

--- a/tui_skeleton/src/markdown/streamer.ts
+++ b/tui_skeleton/src/markdown/streamer.ts
@@ -1,6 +1,7 @@
 import type { Worker } from "node:worker_threads"
 import type { Block, WorkerIn, WorkerOut, Patch } from "@stream-mdx/core/types"
-import { applyPatchBatch, createInitialSnapshot, type DocumentSnapshot } from "@stream-mdx/core"
+import { createSnapshotStore, type StreamMdxSnapshotStore } from "@stream-mdx/tui"
+import type { DocumentSnapshot } from "@stream-mdx/core"
 import { createMarkdownWorkerThread, type MarkdownThreadOptions } from "./workerThread.js"
 
 type Listener = (blocks: ReadonlyArray<Block>, meta?: { finalized?: boolean; error?: string | null }) => void
@@ -155,7 +156,7 @@ export class MarkdownStreamer {
   private readonly docPlugins?: MarkdownStreamerOptions["docPlugins"]
   private readonly workerOptions?: MarkdownThreadOptions
   private worker: Worker | null = null
-  private snapshot: DocumentSnapshot = createInitialSnapshot()
+  private store: StreamMdxSnapshotStore = createSnapshotStore()
   private pendingChunks: string[] = []
   private pendingFinalize = false
   private ready = false
@@ -181,7 +182,7 @@ export class MarkdownStreamer {
 
   initialize(initialContent = ""): void {
     if (this.disposed) return
-    this.snapshot = createInitialSnapshot()
+    this.store = createSnapshotStore()
     this.ready = false
     this.pendingFinalize = false
     this.finalized = false
@@ -284,7 +285,7 @@ export class MarkdownStreamer {
     switch (message.type) {
       case "INITIALIZED": {
         this.ready = true
-        this.snapshot = createInitialSnapshot(message.blocks)
+        this.store.setSnapshot(message.blocks)
         if (this.pendingChunks.length > 0) {
           for (const chunk of this.pendingChunks.splice(0)) {
             this.worker?.postMessage({ type: "APPEND", text: chunk } satisfies WorkerIn)
@@ -298,12 +299,12 @@ export class MarkdownStreamer {
         break
       }
       case "PATCH": {
-        applyPatchBatch(this.snapshot, message.patches as Patch[])
+        this.store.applyPatches(message.patches as Patch[])
         this.emit(false)
         break
       }
       case "RESET": {
-        this.snapshot = createInitialSnapshot()
+        this.store = createSnapshotStore()
         this.ready = false
         this.emit(false)
         break
@@ -323,7 +324,8 @@ export class MarkdownStreamer {
     if (this.inlineMode || !this.worker) {
       return buildInlineBlocks(this.inlineBuffer, this.finalized || this.errored != null)
     }
-    return attachCodeLineMeta(this.snapshot, this.snapshot.blocks)
+    const snapshot = this.store.getSnapshot() as DocumentSnapshot
+    return attachCodeLineMeta(snapshot, this.store.getBlocks())
   }
 
   private emit(finalized: boolean): void {

--- a/tui_skeleton/src/repl/components/replView/renderers/__tests__/conversationRendererMarkdown.test.ts
+++ b/tui_skeleton/src/repl/components/replView/renderers/__tests__/conversationRendererMarkdown.test.ts
@@ -63,7 +63,7 @@ describe("conversation markdown display policy", () => {
     expect(lines.join("\n")).not.toContain("Assistant latest")
   })
 
-  it("uses a bounded latest preview when activePreviewLines is explicitly applied", () => {
+  it("tail-slices rendered markdown instead of replacing final content with a latest placeholder", () => {
     const lines = resolveConversationEntryDisplayLines({ ...baseEntry, phase: "final", activePreviewLines: 1 }, {
       viewPrefs: { richMarkdown: true, collapseMode: "auto", virtualization: "auto" },
       markdownWidth: 80,
@@ -71,6 +71,8 @@ describe("conversation markdown display policy", () => {
     }).map(stripAnsiCodes)
 
     expect(lines).toHaveLength(1)
-    expect(lines.join("\n")).toContain("Assistant latest")
+    expect(lines.join("\n")).toContain("Visible body")
+    expect(lines.join("\n")).not.toContain("Assistant latest")
+    expect(lines.join("\n")).not.toContain("**Visible body**")
   })
 })

--- a/tui_skeleton/src/repl/components/replView/renderers/conversationRenderer.tsx
+++ b/tui_skeleton/src/repl/components/replView/renderers/conversationRenderer.tsx
@@ -67,6 +67,13 @@ const buildAssistantActivePreviewLines = (
   return [CHALK.dim(`${label}${suffix}`)].slice(0, Math.max(1, maxLines))
 }
 
+const tailRenderLines = (lines: readonly string[], maxLines: number): string[] => {
+  const trimmed = trimOuterBlankLines(lines)
+  const budget = Math.max(1, Math.floor(maxLines))
+  if (trimmed.length <= budget) return trimmed
+  return trimmed.slice(-budget)
+}
+
 export const resolveConversationEntryDisplayLines = (
   entry: ConversationEntry,
   options: {
@@ -97,7 +104,11 @@ export const resolveConversationEntryDisplayLines = (
       : buildAssistantActivePreviewLines(normalizedText, Math.max(1, streamingAssistantPreviewLines), markdownWidth, "Assistant streaming…")
   }
   if (activePreviewLines) {
-    return buildAssistantActivePreviewLines(normalizedText, Math.max(1, entry.activePreviewLines ?? 1), markdownWidth, "Assistant latest…")
+    const budget = Math.max(1, entry.activePreviewLines ?? 1)
+    return tailRenderLines(useRich
+      ? renderRichMarkdownLines(entry, { ...markdownRenderOptions, width: markdownWidth })
+      : fallback,
+    budget)
   }
   return trimOuterBlankLines(useRich
     ? renderRichMarkdownLines(entry, { ...markdownRenderOptions, width: markdownWidth })

--- a/tui_skeleton/src/repl/components/replView/renderers/markdown/__tests__/streamMdxAdapter.test.ts
+++ b/tui_skeleton/src/repl/components/replView/renderers/markdown/__tests__/streamMdxAdapter.test.ts
@@ -176,6 +176,61 @@ describe("streamMdxAdapter", () => {
     expect(lines).toEqual(["Bold text, italic text, and inline code."])
   })
 
+  it("unwraps markdown-language fences into rendered terminal markdown", () => {
+    const lines = renderMarkdownFallbackLines([
+      "```markdown",
+      "# Sample Markdown",
+      "",
+      "## Section Heading",
+      "- **Bullet** item",
+      "> A blockquote for emphasis.",
+      "",
+      "```python",
+      "def greet(name):",
+      "    return f\"Hello, {name}!\"",
+      "```",
+      "```",
+    ].join("\n"), { width: 80 }).map(stripAnsiCodes)
+
+    expect(lines).toContain("Sample Markdown")
+    expect(lines).toContain("Section Heading")
+    expect(lines).toContain("- Bullet item")
+    expect(lines).toContain("A blockquote for emphasis.")
+    expect(lines).toContain("code · python")
+    expect(lines).toContain("def greet(name):")
+    expect(lines.join("\n")).not.toContain("```markdown")
+    expect(lines.join("\n")).not.toContain("# Sample Markdown")
+    expect(lines.join("\n")).not.toContain("**Bullet**")
+    expect(lines.join("\n")).not.toContain("> A blockquote")
+  })
+
+  it("unwraps markdown code blocks before honoring stream-mdx codeLines", () => {
+    const blocks: Block[] = [
+      {
+        id: "markdown-code-with-token-lines",
+        type: "code",
+        isFinalized: true,
+        payload: {
+          raw: "```markdown\n# Sample Markdown\n- **Bullet** item\n```",
+          meta: {
+            lang: "markdown",
+            code: "# Sample Markdown\n- **Bullet** item",
+            codeLines: [
+              { text: "# Sample Markdown", tokens: null },
+              { text: "- **Bullet** item", tokens: null },
+            ],
+          },
+        },
+      },
+    ]
+    const lines = blocksToLines(blocks, { width: 80 }).map(stripAnsiCodes)
+    expect(lines).toContain("Sample Markdown")
+    expect(lines).toContain("- Bullet item")
+    expect(lines.join("\n")).not.toContain("code · markdown")
+    expect(lines.join("\n")).not.toContain("# Sample Markdown")
+    expect(lines.join("\n")).not.toContain("**Bullet**")
+  })
+
   it("falls back to raw diff line when tokens missing", () => {
     const blocks: Block[] = [
       {

--- a/tui_skeleton/src/repl/components/replView/renderers/markdown/streamMdxAdapter.ts
+++ b/tui_skeleton/src/repl/components/replView/renderers/markdown/streamMdxAdapter.ts
@@ -421,7 +421,11 @@ export const renderCodeLines = (raw: string, lang?: string, options?: MarkdownRe
   const { code, langHint } = stripFence(raw)
   const finalLang = lang ?? langHint
   const content = (code || raw).replace(/\r\n?/g, "\n")
-  const isDiff = finalLang ? finalLang.toLowerCase().includes("diff") : false
+  const normalizedLang = finalLang?.trim().toLowerCase()
+  if (normalizedLang === "markdown" || normalizedLang === "md") {
+    return renderMarkdownFallbackLines(content, options)
+  }
+  const isDiff = normalizedLang ? normalizedLang.includes("diff") : false
   const shikiLines = maybeHighlightCode(content, finalLang)
   if (shikiLines) return finalLang && !isDiff ? [CHALK.dim(uiText(`code · ${finalLang}`)), ...shikiLines] : shikiLines
   const diffStyle = options?.diffStyle ?? DEFAULT_DIFF_RENDER_STYLE
@@ -726,13 +730,30 @@ export const renderMarkdownFallbackLines = (rawText: string, options?: MarkdownR
     if (line.trim().startsWith("```")) {
       const fence = line.trim()
       const lang = fence.slice(3).trim() || undefined
+      const normalizedLang = lang?.toLowerCase()
       const codeLines: string[] = []
       index += 1
-      while (index < lines.length && !lines[index].trim().startsWith("```")) {
-        codeLines.push(lines[index])
-        index += 1
+      if (normalizedLang === "markdown" || normalizedLang === "md") {
+        let closingIndex = -1
+        for (let scan = lines.length - 1; scan >= index; scan -= 1) {
+          if (lines[scan].trim().startsWith("```")) {
+            closingIndex = scan
+            break
+          }
+        }
+        const end = closingIndex >= index ? closingIndex : lines.length
+        while (index < end) {
+          codeLines.push(lines[index])
+          index += 1
+        }
+        if (closingIndex >= 0) index = closingIndex + 1
+      } else {
+        while (index < lines.length && !lines[index].trim().startsWith("```")) {
+          codeLines.push(lines[index])
+          index += 1
+        }
+        if (index < lines.length) index += 1
       }
-      if (index < lines.length) index += 1
       const fenced = lang ? `\`\`\`${lang}\n${codeLines.join("\n")}\n\`\`\`` : codeLines.join("\n")
       output.push(...renderCodeLines(fenced, lang, options))
       continue
@@ -816,6 +837,15 @@ const blockToLines = (block: Block, options?: MarkdownRenderOptions): string[] =
             : typeof meta.info === "string"
               ? meta.info
               : undefined
+      const normalizedLang = lang?.trim().toLowerCase()
+      const raw = block.payload.raw ?? ""
+      if ((normalizedLang === "markdown" || normalizedLang === "md") && raw.trim().length > 0) {
+        const markdownSource = typeof meta.code === "string" && meta.code.length > 0 ? meta.code : stripFence(raw).code
+        return renderMarkdownFallbackLines(markdownSource, options)
+      }
+      if ((normalizedLang === "text" || !normalizedLang) && raw.trim() === "```") {
+        return []
+      }
       const diffBlocks = Array.isArray(meta.diffBlocks) ? (meta.diffBlocks as StreamDiffBlock[]) : null
       if (diffBlocks && diffBlocks.length > 0) {
         return renderDiffBlocks(diffBlocks, diffStyle)
@@ -826,7 +856,6 @@ const blockToLines = (block: Block, options?: MarkdownRenderOptions): string[] =
         const rendered = renderDiffFromCodeLines(codeLines, diffStyle)
         return lang && !isDiff ? [CHALK.dim(uiText(`code · ${lang}`)), ...rendered] : rendered
       }
-      const raw = block.payload.raw ?? ""
       return renderCodeLines(raw, lang, options)
     }
     case "list": {


### PR DESCRIPTION
## Summary
- Use the new `@stream-mdx/tui` snapshot store for streaming markdown state.
- Render markdown-language wrapper fences as rich terminal markdown instead of literal `code · markdown` blocks.
- Preserve final assistant content under height pressure instead of replacing it with `Assistant latest…`.
- Resolve the default TUI model from the active BreadBoard config so Codex defaults to `openai/gpt-5.4-mini`.
- Add a narrow user-reported PTY regression gate for malformed markdown wrapper output.

## Validation
- `npm run typecheck`
- `npm run build --if-present`
- `npm test` (`212 passed`, `1098 passed`)
- `npm run -s qc:user-reported:streaming-markdown`
- `npm run -s qc:user-reported:startup-landing`
- `npm run -s qc:user-reported:markdown-wrapper-render`
- Startup probe confirms `model openai/gpt-5.4-mini`.

## Notes
- `stream-mdx` convenience package was not added because its React DOM peer graph conflicts with this TUI package. The implementation uses the targeted `@stream-mdx/tui` package instead.