### PR TITLE
NS01: canonical Harness Definition model and validation

### DIFF
--- a/agent_configs/templates/minimal_harness.v3.yaml
+++ b/agent_configs/templates/minimal_harness.v3.yaml
@@ -1,0 +1,15 @@
+# Minimal canonical Harness Definition for an offline-safe single-mode agent.
+schema_version: bb.harness_definition.v1
+version: 1
+workspace:
+  root: .
+providers:
+  default_model: mock/reference
+  models:
+    - id: mock/reference
+      adapter: mock_chat
+modes:
+  - name: respond
+loop:
+  sequence:
+    - mode: respond

--- a/breadboard/product/harness/model.py
+++ b/breadboard/product/harness/model.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterator, Mapping, Sequence
+import math
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any, TypeAlias
@@ -12,22 +13,31 @@ JsonScalar: TypeAlias = None | bool | int | float | str
 FrozenJsonValue: TypeAlias = (
     JsonScalar | Mapping[str, "FrozenJsonValue"] | tuple["FrozenJsonValue", ...]
 )
+_SCALAR_TYPES = (bool, int, str)
+
+
+def _copy_json(value: Any, freeze: bool) -> Any:
+    if isinstance(value, Mapping):
+        if any(type(key) is not str for key in value):
+            raise TypeError("JSON object keys must be strings")
+        items = {key: _copy_json(item, freeze) for key, item in value.items()}
+        return MappingProxyType(items) if freeze else items
+    sequence = list if freeze else tuple
+    if isinstance(value, sequence):
+        items = (_copy_json(item, freeze) for item in value)
+        return tuple(items) if freeze else list(items)
+    kind = type(value)
+    if value is None or kind in _SCALAR_TYPES or kind is float and math.isfinite(value):
+        return value
+    raise TypeError(f"unsupported JSON value: {kind.__name__}")
 
 
 def _freeze(value: Any) -> FrozenJsonValue:
-    if isinstance(value, Mapping):
-        return MappingProxyType({key: _freeze(item) for key, item in value.items()})
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return tuple(_freeze(item) for item in value)
-    return value
+    return _copy_json(value, True)
 
 
 def _thaw(value: FrozenJsonValue) -> Any:
-    if isinstance(value, Mapping):
-        return {key: _thaw(item) for key, item in value.items()}
-    if isinstance(value, tuple):
-        return [_thaw(item) for item in value]
-    return value
+    return _copy_json(value, False)
 
 
 @dataclass(frozen=True, slots=True, init=False)
@@ -48,7 +58,6 @@ class HarnessDefinition(Mapping[str, FrozenJsonValue]):
 
     @classmethod
     def _from_validated(cls, document: Mapping[str, Any]) -> HarnessDefinition:
-        """Construct from a mapping that has already passed public validation."""
         instance = object.__new__(cls)
         frozen = _freeze(document)
         if not isinstance(frozen, Mapping):

--- a/breadboard/product/harness/model.py
+++ b/breadboard/product/harness/model.py
@@ -14,7 +14,7 @@ FrozenJsonValue: TypeAlias = (
     JsonScalar | Mapping[str, "FrozenJsonValue"] | tuple["FrozenJsonValue", ...]
 )
 _SCALAR_TYPES = (bool, str)
-_MAX_JSON_INTEGER = 10**1000 - 1
+_MAX_JSON_INTEGER = 10**640 - 1
 
 
 def _copy_json(value: Any, freeze: bool) -> Any:
@@ -28,7 +28,8 @@ def _copy_json(value: Any, freeze: bool) -> Any:
         items = (_copy_json(item, freeze) for item in value)
         return tuple(items) if freeze else list(items)
     kind = type(value)
-    if value is None or kind in _SCALAR_TYPES or kind is int and abs(value) <= _MAX_JSON_INTEGER or kind is float and math.isfinite(value):
+    if (value is None or kind in _SCALAR_TYPES or kind is int and abs(value) <= _MAX_JSON_INTEGER
+            or kind is float and math.isfinite(value)):
         return value
     raise TypeError(f"unsupported JSON value: {kind.__name__}")
 

--- a/breadboard/product/harness/model.py
+++ b/breadboard/product/harness/model.py
@@ -13,7 +13,8 @@ JsonScalar: TypeAlias = None | bool | int | float | str
 FrozenJsonValue: TypeAlias = (
     JsonScalar | Mapping[str, "FrozenJsonValue"] | tuple["FrozenJsonValue", ...]
 )
-_SCALAR_TYPES = (bool, int, str)
+_SCALAR_TYPES = (bool, str)
+_MAX_JSON_INTEGER = 10**1000 - 1
 
 
 def _copy_json(value: Any, freeze: bool) -> Any:
@@ -27,7 +28,7 @@ def _copy_json(value: Any, freeze: bool) -> Any:
         items = (_copy_json(item, freeze) for item in value)
         return tuple(items) if freeze else list(items)
     kind = type(value)
-    if value is None or kind in _SCALAR_TYPES or kind is float and math.isfinite(value):
+    if value is None or kind in _SCALAR_TYPES or kind is int and abs(value) <= _MAX_JSON_INTEGER or kind is float and math.isfinite(value):
         return value
     raise TypeError(f"unsupported JSON value: {kind.__name__}")
 

--- a/breadboard/product/harness/model.py
+++ b/breadboard/product/harness/model.py
@@ -1,0 +1,80 @@
+"""Immutable author-side representation of a BreadBoard harness definition."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any, TypeAlias
+
+JsonScalar: TypeAlias = None | bool | int | float | str
+FrozenJsonValue: TypeAlias = (
+    JsonScalar | Mapping[str, "FrozenJsonValue"] | tuple["FrozenJsonValue", ...]
+)
+
+
+def _freeze(value: Any) -> FrozenJsonValue:
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze(item) for key, item in value.items()})
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+def _thaw(value: FrozenJsonValue) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class HarnessDefinition(Mapping[str, FrozenJsonValue]):
+    """A validated harness definition with recursively immutable contents."""
+
+    _document: Mapping[str, FrozenJsonValue] = field(repr=False)
+
+    @classmethod
+    def from_mapping(cls, document: Mapping[str, Any]) -> HarnessDefinition:
+        """Validate and detach an author mapping before exposing it as immutable."""
+        from .validate import HarnessDefinitionValidationError, validate_harness_definition
+
+        findings = validate_harness_definition(document)
+        if findings:
+            raise HarnessDefinitionValidationError(findings)
+        return cls._from_validated(document)
+
+    @classmethod
+    def _from_validated(cls, document: Mapping[str, Any]) -> HarnessDefinition:
+        """Construct from a mapping that has already passed public validation."""
+        instance = object.__new__(cls)
+        frozen = _freeze(document)
+        if not isinstance(frozen, Mapping):
+            raise TypeError("a harness definition must be a mapping")
+        object.__setattr__(instance, "_document", frozen)
+        return instance
+
+    def __getitem__(self, key: str) -> FrozenJsonValue:
+        return self._document[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._document)
+
+    def __len__(self) -> int:
+        return len(self._document)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a fully detached mutable copy of the author document."""
+        return {key: _thaw(value) for key, value in self._document.items()}
+
+    def canonical_json(self) -> str:
+        """Return stable compact JSON without changing any author values."""
+        return json.dumps(
+            self.as_dict(),
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )

--- a/breadboard/product/harness/model.py
+++ b/breadboard/product/harness/model.py
@@ -17,6 +17,23 @@ _SCALAR_TYPES = (bool, str)
 _MAX_JSON_INTEGER = 10**640 - 1
 
 
+def _snapshot(value: Any, memo: dict[int, Any] | None = None) -> Any:
+    if not isinstance(value, (Mapping, list)):
+        return value
+    memo = {} if memo is None else memo
+    identity = id(value)
+    if identity in memo:
+        return memo[identity]
+    snapshot: Any = {} if isinstance(value, Mapping) else []
+    memo[identity] = snapshot
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            snapshot[key] = _snapshot(item, memo)
+    else:
+        snapshot.extend(_snapshot(item, memo) for item in value)
+    return snapshot
+
+
 def _copy_json(value: Any, freeze: bool) -> Any:
     if isinstance(value, Mapping):
         if any(type(key) is not str for key in value):
@@ -50,21 +67,19 @@ class HarnessDefinition(Mapping[str, FrozenJsonValue]):
 
     @classmethod
     def from_mapping(cls, document: Mapping[str, Any]) -> HarnessDefinition:
-        """Validate and detach an author mapping before exposing it as immutable."""
+        """Detach, validate, and freeze one stable author snapshot."""
         from .validate import HarnessDefinitionValidationError, validate_harness_definition
 
-        findings = validate_harness_definition(document)
+        snapshot = _snapshot(document)
+        findings = validate_harness_definition(snapshot)
         if findings:
             raise HarnessDefinitionValidationError(findings)
-        return cls._from_validated(document)
+        return cls._from_validated(snapshot)
 
     @classmethod
     def _from_validated(cls, document: Mapping[str, Any]) -> HarnessDefinition:
         instance = object.__new__(cls)
-        frozen = _freeze(document)
-        if not isinstance(frozen, Mapping):
-            raise TypeError("a harness definition must be a mapping")
-        object.__setattr__(instance, "_document", frozen)
+        object.__setattr__(instance, "_document", _freeze(document))
         return instance
 
     def __getitem__(self, key: str) -> FrozenJsonValue:
@@ -82,10 +97,5 @@ class HarnessDefinition(Mapping[str, FrozenJsonValue]):
 
     def canonical_json(self) -> str:
         """Return stable compact JSON without changing any author values."""
-        return json.dumps(
-            self.as_dict(),
-            allow_nan=False,
-            ensure_ascii=False,
-            separators=(",", ":"),
-            sort_keys=True,
-        )
+        return json.dumps(self.as_dict(), allow_nan=False, ensure_ascii=False,
+                          separators=(",", ":"), sort_keys=True)

--- a/breadboard/product/harness/model.py
+++ b/breadboard/product/harness/model.py
@@ -17,7 +17,9 @@ _SCALAR_TYPES = (bool, str)
 _MAX_JSON_INTEGER = 10**640 - 1
 
 
-def _snapshot(value: Any, memo: dict[int, Any] | None = None) -> Any:
+def _snapshot(value: Any, memo: dict[int, Any] | None = None, depth: int = 0) -> Any:
+    if depth > 100:
+        return value
     if not isinstance(value, (Mapping, list)):
         return value
     memo = {} if memo is None else memo
@@ -28,9 +30,9 @@ def _snapshot(value: Any, memo: dict[int, Any] | None = None) -> Any:
     memo[identity] = snapshot
     if isinstance(value, Mapping):
         for key, item in value.items():
-            snapshot[key] = _snapshot(item, memo)
+            snapshot[key] = _snapshot(item, memo, depth + 1)
     else:
-        snapshot.extend(_snapshot(item, memo) for item in value)
+        snapshot.extend(_snapshot(item, memo, depth + 1) for item in value)
     return snapshot
 
 

--- a/breadboard/product/harness/templates.py
+++ b/breadboard/product/harness/templates.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sysconfig
+
+from .model import HarnessDefinition
+from .validate import load_harness_definition
+
+
+_TEMPLATE_RELATIVE_PATH = Path("agent_configs/templates/minimal_harness.v3.yaml")
+
+
+def minimal_template_path() -> Path:
+    """Return the canonical template path in a checkout or installed distribution."""
+    candidates = (Path(__file__).resolve().parents[3] / _TEMPLATE_RELATIVE_PATH, Path(sysconfig.get_path("data")) / _TEMPLATE_RELATIVE_PATH)
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(f"minimal Harness Definition template not found; searched: {', '.join(map(str, candidates))}")
+
+def minimal_template_text() -> str:
+    """Return the checked-in canonical template without transforming it."""
+    return minimal_template_path().read_text(encoding="utf-8")
+
+def load_minimal_harness() -> HarnessDefinition:
+    """Load and strictly validate the canonical minimal Harness Definition."""
+    return load_harness_definition(minimal_template_path())

--- a/breadboard/product/harness/validate.py
+++ b/breadboard/product/harness/validate.py
@@ -29,6 +29,7 @@ _KNOWN_VERSIONS = {
     _CANONICAL[0]: _CANONICAL[1],
     _LEGACY[0]: _LEGACY[1],
 }
+_MAX_JSON_INTEGER = 10**1000 - 1
 
 @dataclass(frozen=True, order=True)
 class ValidationFinding:
@@ -84,8 +85,15 @@ def _pointer(path: Sequence[object]) -> str:
 def _json_findings(
     value: object, path: tuple[object, ...] = (), active: set[int] | None = None
 ) -> list[ValidationFinding]:
-    if type(value) in (type(None), bool, int, str):
+    if len(path) > 100:
+        return [ValidationFinding(
+            _pointer(path), "json_depth", "JSON paths must not exceed 100 segments")]
+    if value is None or type(value) in (bool, str):
         return []
+    if type(value) is int:
+        return [] if abs(value) <= _MAX_JSON_INTEGER else [
+            ValidationFinding(_pointer(path), "integer_range",
+                              "JSON integers must contain at most 1000 decimal digits")]
     if type(value) is float:
         return [] if math.isfinite(value) else [
             ValidationFinding(_pointer(path), "finite", "JSON numbers must be finite")

--- a/breadboard/product/harness/validate.py
+++ b/breadboard/product/harness/validate.py
@@ -29,7 +29,7 @@ _KNOWN_VERSIONS = {
     _CANONICAL[0]: _CANONICAL[1],
     _LEGACY[0]: _LEGACY[1],
 }
-_MAX_JSON_INTEGER = 10**1000 - 1
+_MAX_JSON_INTEGER = 10**640 - 1
 
 @dataclass(frozen=True, order=True)
 class ValidationFinding:
@@ -93,7 +93,7 @@ def _json_findings(
     if type(value) is int:
         return [] if abs(value) <= _MAX_JSON_INTEGER else [
             ValidationFinding(_pointer(path), "integer_range",
-                              "JSON integers must contain at most 1000 decimal digits")]
+                              "JSON integers must contain at most 640 decimal digits")]
     if type(value) is float:
         return [] if math.isfinite(value) else [
             ValidationFinding(_pointer(path), "finite", "JSON numbers must be finite")

--- a/breadboard/product/harness/validate.py
+++ b/breadboard/product/harness/validate.py
@@ -201,7 +201,7 @@ def _source_pair_findings(document: Mapping[str, object]) -> list[ValidationFind
             ValidationFinding(
                 "/schema_version",
                 "unsupported_schema_version",
-                f"Unsupported schema_version {schema_version!r}; expected one of {supported}",
+                f"Unsupported schema_version; expected one of {supported}",
             )
         )
     if expected is not None and (type(version) is not int or version != expected):
@@ -209,8 +209,7 @@ def _source_pair_findings(document: Mapping[str, object]) -> list[ValidationFind
             ValidationFinding(
                 "/version",
                 "unsupported_version",
-                f"Version {version!r} does not match schema_version "
-                f"{schema_version!r}; expected {expected}",
+                f"Version does not match schema_version; expected {expected}",
             )
         )
     elif expected is None and not (
@@ -220,7 +219,7 @@ def _source_pair_findings(document: Mapping[str, object]) -> list[ValidationFind
             ValidationFinding(
                 "/version",
                 "unsupported_version",
-                f"Unsupported version {version!r}; expected integer 1 or 2",
+                "Unsupported version; expected integer 1 or 2",
             )
         )
     return findings
@@ -244,11 +243,9 @@ def validate_harness_definition(
     return tuple(sorted(set(findings)))
 
 def parse_harness_definition(document: Mapping[str, object]) -> HarnessDefinition:
-    if findings := validate_harness_definition(document):
-        raise HarnessDefinitionValidationError(findings)
     from .model import HarnessDefinition
 
-    return HarnessDefinition._from_validated(document)
+    return HarnessDefinition.from_mapping(document)
 
 def load_harness_definition(path: str | Path) -> HarnessDefinition:
     with Path(path).open(encoding="utf-8") as definition_file:

--- a/breadboard/product/harness/validate.py
+++ b/breadboard/product/harness/validate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 import sysconfig
 from collections.abc import Mapping, Sequence
@@ -34,8 +35,6 @@ class ValidationFinding:
     pointer: str
     code: str
     message: str
-
-
 class HarnessDefinitionValidationError(ValueError):
     def __init__(self, findings: Sequence[ValidationFinding]) -> None:
         self.findings = tuple(sorted(set(findings)))
@@ -43,15 +42,11 @@ class HarnessDefinitionValidationError(ValueError):
             f"{item.pointer} [{item.code}]: {item.message}" for item in self.findings
         )
         super().__init__(detail or "Harness definition validation failed")
-
-
 def _schema_root() -> Path:
     source_root = Path(__file__).resolve().parents[3]
     if (source_root / _SCHEMA_PATHS[_CANONICAL]).is_file():
         return source_root
     return Path(sysconfig.get_path("data"))
-
-
 def _load_schema(relative_path: Path) -> dict[str, Any]:
     path = _schema_root() / relative_path
     with path.open(encoding="utf-8") as schema_file:
@@ -59,18 +54,12 @@ def _load_schema(relative_path: Path) -> dict[str, Any]:
     if not isinstance(schema, dict):
         raise RuntimeError(f"Schema root must be an object: {path}")
     return schema
-
-
 def _is_mapping(_checker: object, instance: object) -> bool:
     return isinstance(instance, Mapping)
-
-
 _MappingDraft202012Validator = validators.extend(
     Draft202012Validator,
     type_checker=Draft202012Validator.TYPE_CHECKER.redefine("object", _is_mapping),
 )
-
-
 @lru_cache(maxsize=1)
 def _schema_validators() -> dict[tuple[str, int], Validator]:
     schemas = {pair: _load_schema(path) for pair, path in _SCHEMA_PATHS.items()}
@@ -86,74 +75,106 @@ def _schema_validators() -> dict[tuple[str, int], Validator]:
         pair: _MappingDraft202012Validator(schema, registry=registry)
         for pair, schema in schemas.items()
     }
-
-
 def _pointer(path: Sequence[object]) -> str:
     if not path:
         return "/"
     return "/" + "/".join(
         str(part).replace("~", "~0").replace("/", "~1") for part in path
     )
-
-
-def _required_property(error: ValidationError) -> str | None:
-    if not isinstance(error.validator_value, list):
-        return None
-    missing = [
-        name
-        for name in error.validator_value
-        if isinstance(name, str)
-        and isinstance(error.instance, Mapping)
-        and name not in error.instance
-    ]
-    for name in missing:
-        if error.message == f"{name!r} is a required property":
-            return name
-    return missing[0] if len(missing) == 1 else None
-
-
+def _json_findings(
+    value: object, path: tuple[object, ...] = (), active: set[int] | None = None
+) -> list[ValidationFinding]:
+    if type(value) in (type(None), bool, int, str):
+        return []
+    if type(value) is float:
+        return [] if math.isfinite(value) else [
+            ValidationFinding(_pointer(path), "finite", "JSON numbers must be finite")
+        ]
+    if isinstance(value, Mapping) or type(value) is list:
+        active = set() if active is None else active
+        if id(value) in active:
+            return [ValidationFinding(
+                _pointer(path), "json_cycle", "JSON values must not contain cycles"
+            )]
+        active.add(id(value))
+        findings: list[ValidationFinding] = []
+        if isinstance(value, Mapping):
+            keys = [key for key in value if type(key) is str]
+            if len(keys) != len(value):
+                findings.append(ValidationFinding(
+                    _pointer(path), "json_key", "Object keys must be strings"
+                ))
+            for key in sorted(keys):
+                findings.extend(_json_findings(value[key], (*path, key), active))
+        else:
+            for index, item in enumerate(value):
+                findings.extend(_json_findings(item, (*path, index), active))
+        active.remove(id(value))
+        return findings
+    return [ValidationFinding(
+        _pointer(path), "json_type", "Value is not a JSON-domain value"
+    )]
+def _required_properties(error: ValidationError) -> list[str]:
+    if not isinstance(error.validator_value, list) or not isinstance(error.instance, Mapping):
+        return []
+    return sorted(
+        name for name in error.validator_value
+        if isinstance(name, str) and name not in error.instance
+    )
 def _additional_properties(error: ValidationError) -> list[str]:
     if not isinstance(error.instance, Mapping) or not isinstance(error.schema, Mapping):
         return []
-    properties = error.schema.get("properties", {})
-    patterns = error.schema.get("patternProperties", {})
+    properties, patterns = error.schema.get("properties", {}), error.schema.get("patternProperties", {})
     known = properties if isinstance(properties, Mapping) else {}
     regexes = (
         [re.compile(pattern) for pattern in patterns if isinstance(pattern, str)]
-        if isinstance(patterns, Mapping)
-        else []
+        if isinstance(patterns, Mapping) else []
     )
     return sorted(
-        key
-        for key in error.instance
-        if isinstance(key, str)
-        and key not in known
+        key for key in error.instance if isinstance(key, str) and key not in known
         and not any(regex.search(key) for regex in regexes)
     )
 
-
+def _constraint_message(error: ValidationError) -> str:
+    value = json.dumps(error.validator_value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    messages = {
+        "type": f"Value must have type {value}",
+        "const": f"Value must equal {value}",
+        "enum": f"Value must be one of {value}",
+        "minItems": f"Array must contain at least {value} item(s)",
+        "maxItems": f"Array must contain at most {value} item(s)",
+        "minLength": f"String must contain at least {value} character(s)",
+        "maxLength": f"String must contain at most {value} character(s)",
+        "oneOf": "Value must match exactly one allowed schema",
+        "anyOf": "Value must match at least one allowed schema",
+        "not": "Value must not match the disallowed schema",
+    }
+    return messages.get(str(error.validator), f"Value violates {error.validator} constraint {value}")
 def _schema_error_findings(error: ValidationError) -> list[ValidationFinding]:
     path, code = tuple(error.absolute_path), str(error.validator)
+    if error.context:
+        groups: dict[object, list[ValidationError]] = {}
+        offset = len(error.absolute_schema_path)
+        for child in error.context:
+            branch = tuple(child.absolute_schema_path)[offset]
+            groups.setdefault(branch, []).append(child)
+        compatible = [children for children in groups.values() if not any(
+            child.validator == "type" and tuple(child.absolute_path) == path
+            for child in children)]
+        if compatible:
+            return [finding for children in compatible for child in children
+                    for finding in _schema_error_findings(child)]
     if error.validator == "required":
-        if missing := _required_property(error):
-            return [
-                ValidationFinding(
-                    _pointer((*path, missing)), code, f"{missing!r} is a required property"
-                )
-            ]
+        return [
+            ValidationFinding(_pointer((*path, name)), code, f"{name!r} is a required property")
+            for name in _required_properties(error)
+        ]
     if error.validator == "additionalProperties":
-        if unexpected := _additional_properties(error):
-            return [
-                ValidationFinding(
-                    _pointer((*path, name)),
-                    code,
-                    f"Additional property {name!r} is not allowed",
-                )
-                for name in unexpected
-            ]
-    return [ValidationFinding(_pointer(path), code, error.message)]
-
-
+        return [
+            ValidationFinding(_pointer((*path, name)), code, f"Additional property {name!r} is not allowed")
+            for name in _additional_properties(error)
+        ]
+    return [ValidationFinding(_pointer(path), code, _constraint_message(error))]
 def _source_pair_findings(document: Mapping[str, object]) -> list[ValidationFinding]:
     findings = [
         ValidationFinding(f"/{name}", "required", f"{name!r} is a required property")
@@ -196,10 +217,11 @@ def _source_pair_findings(document: Mapping[str, object]) -> list[ValidationFind
         )
     return findings
 
-
 def validate_harness_definition(
     document: Mapping[str, object],
 ) -> tuple[ValidationFinding, ...]:
+    if findings := _json_findings(document):
+        return tuple(sorted(set(findings)))
     if not isinstance(document, Mapping):
         return (ValidationFinding("/", "type", "Harness definition must be a mapping"),)
     if findings := _source_pair_findings(document):
@@ -213,14 +235,12 @@ def validate_harness_definition(
     ]
     return tuple(sorted(set(findings)))
 
-
 def parse_harness_definition(document: Mapping[str, object]) -> HarnessDefinition:
     if findings := validate_harness_definition(document):
         raise HarnessDefinitionValidationError(findings)
     from .model import HarnessDefinition
 
     return HarnessDefinition._from_validated(document)
-
 
 def load_harness_definition(path: str | Path) -> HarnessDefinition:
     with Path(path).open(encoding="utf-8") as definition_file:

--- a/breadboard/product/harness/validate.py
+++ b/breadboard/product/harness/validate.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+import re
+import sysconfig
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from jsonschema import Draft202012Validator, validators
+from jsonschema.exceptions import ValidationError
+from jsonschema.protocols import Validator
+from referencing import Registry, Resource
+
+if TYPE_CHECKING:
+    from .model import HarnessDefinition
+
+_CANONICAL = ("bb.harness_definition.v1", 1)
+_LEGACY = ("bb.agent_config_surface.v2", 2)
+_SCHEMA_PATHS = {
+    _CANONICAL: Path("contracts/public/schemas/bb.harness_definition.v1.schema.json"),
+    _LEGACY: Path("contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json"),
+}
+_KNOWN_VERSIONS = {
+    _CANONICAL[0]: _CANONICAL[1],
+    _LEGACY[0]: _LEGACY[1],
+}
+
+@dataclass(frozen=True, order=True)
+class ValidationFinding:
+    pointer: str
+    code: str
+    message: str
+
+
+class HarnessDefinitionValidationError(ValueError):
+    def __init__(self, findings: Sequence[ValidationFinding]) -> None:
+        self.findings = tuple(sorted(set(findings)))
+        detail = "; ".join(
+            f"{item.pointer} [{item.code}]: {item.message}" for item in self.findings
+        )
+        super().__init__(detail or "Harness definition validation failed")
+
+
+def _schema_root() -> Path:
+    source_root = Path(__file__).resolve().parents[3]
+    if (source_root / _SCHEMA_PATHS[_CANONICAL]).is_file():
+        return source_root
+    return Path(sysconfig.get_path("data"))
+
+
+def _load_schema(relative_path: Path) -> dict[str, Any]:
+    path = _schema_root() / relative_path
+    with path.open(encoding="utf-8") as schema_file:
+        schema = json.load(schema_file)
+    if not isinstance(schema, dict):
+        raise RuntimeError(f"Schema root must be an object: {path}")
+    return schema
+
+
+def _is_mapping(_checker: object, instance: object) -> bool:
+    return isinstance(instance, Mapping)
+
+
+_MappingDraft202012Validator = validators.extend(
+    Draft202012Validator,
+    type_checker=Draft202012Validator.TYPE_CHECKER.redefine("object", _is_mapping),
+)
+
+
+@lru_cache(maxsize=1)
+def _schema_validators() -> dict[tuple[str, int], Validator]:
+    schemas = {pair: _load_schema(path) for pair, path in _SCHEMA_PATHS.items()}
+    resources = []
+    for schema in schemas.values():
+        Draft202012Validator.check_schema(schema)
+        schema_id = schema.get("$id")
+        if not isinstance(schema_id, str):
+            raise RuntimeError("Harness definition schemas must have canonical $id values")
+        resources.append((schema_id, Resource.from_contents(schema)))
+    registry = Registry().with_resources(resources)
+    return {
+        pair: _MappingDraft202012Validator(schema, registry=registry)
+        for pair, schema in schemas.items()
+    }
+
+
+def _pointer(path: Sequence[object]) -> str:
+    if not path:
+        return "/"
+    return "/" + "/".join(
+        str(part).replace("~", "~0").replace("/", "~1") for part in path
+    )
+
+
+def _required_property(error: ValidationError) -> str | None:
+    if not isinstance(error.validator_value, list):
+        return None
+    missing = [
+        name
+        for name in error.validator_value
+        if isinstance(name, str)
+        and isinstance(error.instance, Mapping)
+        and name not in error.instance
+    ]
+    for name in missing:
+        if error.message == f"{name!r} is a required property":
+            return name
+    return missing[0] if len(missing) == 1 else None
+
+
+def _additional_properties(error: ValidationError) -> list[str]:
+    if not isinstance(error.instance, Mapping) or not isinstance(error.schema, Mapping):
+        return []
+    properties = error.schema.get("properties", {})
+    patterns = error.schema.get("patternProperties", {})
+    known = properties if isinstance(properties, Mapping) else {}
+    regexes = (
+        [re.compile(pattern) for pattern in patterns if isinstance(pattern, str)]
+        if isinstance(patterns, Mapping)
+        else []
+    )
+    return sorted(
+        key
+        for key in error.instance
+        if isinstance(key, str)
+        and key not in known
+        and not any(regex.search(key) for regex in regexes)
+    )
+
+
+def _schema_error_findings(error: ValidationError) -> list[ValidationFinding]:
+    path, code = tuple(error.absolute_path), str(error.validator)
+    if error.validator == "required":
+        if missing := _required_property(error):
+            return [
+                ValidationFinding(
+                    _pointer((*path, missing)), code, f"{missing!r} is a required property"
+                )
+            ]
+    if error.validator == "additionalProperties":
+        if unexpected := _additional_properties(error):
+            return [
+                ValidationFinding(
+                    _pointer((*path, name)),
+                    code,
+                    f"Additional property {name!r} is not allowed",
+                )
+                for name in unexpected
+            ]
+    return [ValidationFinding(_pointer(path), code, error.message)]
+
+
+def _source_pair_findings(document: Mapping[str, object]) -> list[ValidationFinding]:
+    findings = [
+        ValidationFinding(f"/{name}", "required", f"{name!r} is a required property")
+        for name in ("schema_version", "version")
+        if name not in document
+    ]
+    if findings:
+        return findings
+    schema_version, version = document["schema_version"], document["version"]
+    expected = (
+        _KNOWN_VERSIONS.get(schema_version) if isinstance(schema_version, str) else None
+    )
+    if expected is None:
+        supported = ", ".join(repr(value) for value in sorted(_KNOWN_VERSIONS))
+        findings.append(
+            ValidationFinding(
+                "/schema_version",
+                "unsupported_schema_version",
+                f"Unsupported schema_version {schema_version!r}; expected one of {supported}",
+            )
+        )
+    if expected is not None and (type(version) is not int or version != expected):
+        findings.append(
+            ValidationFinding(
+                "/version",
+                "unsupported_version",
+                f"Version {version!r} does not match schema_version "
+                f"{schema_version!r}; expected {expected}",
+            )
+        )
+    elif expected is None and not (
+        type(version) is int and version in _KNOWN_VERSIONS.values()
+    ):
+        findings.append(
+            ValidationFinding(
+                "/version",
+                "unsupported_version",
+                f"Unsupported version {version!r}; expected integer 1 or 2",
+            )
+        )
+    return findings
+
+
+def validate_harness_definition(
+    document: Mapping[str, object],
+) -> tuple[ValidationFinding, ...]:
+    if not isinstance(document, Mapping):
+        return (ValidationFinding("/", "type", "Harness definition must be a mapping"),)
+    if findings := _source_pair_findings(document):
+        return tuple(sorted(set(findings)))
+    pair = (document["schema_version"], document["version"])
+    validator = _schema_validators()[pair]  # type: ignore[index]
+    findings = [
+        finding
+        for error in validator.iter_errors(document)
+        for finding in _schema_error_findings(error)
+    ]
+    return tuple(sorted(set(findings)))
+
+
+def parse_harness_definition(document: Mapping[str, object]) -> HarnessDefinition:
+    if findings := validate_harness_definition(document):
+        raise HarnessDefinitionValidationError(findings)
+    from .model import HarnessDefinition
+
+    return HarnessDefinition._from_validated(document)
+
+
+def load_harness_definition(path: str | Path) -> HarnessDefinition:
+    with Path(path).open(encoding="utf-8") as definition_file:
+        document = yaml.safe_load(definition_file)
+    if not isinstance(document, Mapping):
+        raise HarnessDefinitionValidationError(
+            (ValidationFinding("/", "type", "Harness definition must be a mapping"),)
+        )
+    return parse_harness_definition(document)

--- a/contracts/public/schemas/bb.harness_definition.v1.schema.json
+++ b/contracts/public/schemas/bb.harness_definition.v1.schema.json
@@ -1,0 +1,30 @@
+{
+  "$id": "https://breadboard.dev/contracts/public/schemas/bb.harness_definition.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "completion": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/completion"},
+    "concurrency": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/concurrency"},
+    "dossier": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/dossier"},
+    "enhanced_tools": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/enhanced_tools"},
+    "features": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/features"},
+    "guardrails": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/guardrails"},
+    "long_running": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/long_running"},
+    "loop": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/loop"},
+    "modes": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/modes"},
+    "multi_agent": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/multi_agent"},
+    "permissions": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/permissions"},
+    "prompts": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/prompts"},
+    "provider_tools": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/provider_tools"},
+    "providers": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/providers"},
+    "replay": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/replay"},
+    "schema_version": {"const": "bb.harness_definition.v1"},
+    "tools": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/tools"},
+    "turn_strategy": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/turn_strategy"},
+    "version": {"const": 1},
+    "workspace": {"$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json#/properties/workspace"}
+  },
+  "required": ["schema_version", "version", "workspace", "providers", "modes", "loop"],
+  "title": "BreadBoard Harness Definition V1",
+  "type": "object"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,24 @@ name = "breadboard-harness-cli"
 version = "0.0.0"
 description = "BreadBoard harness authoring front door"
 requires-python = ">=3.10"
+dependencies = ["jsonschema>=4.18", "PyYAML>=6.0"]
 
 [project.scripts]
 bbh = "scripts.breadboard_cli:main"
 
 [tool.setuptools]
-packages = ["scripts", "agentic_coder_prototype", "breadboard_sdk", "breadboard", "conformance"]
+packages = [
+  "scripts",
+  "agentic_coder_prototype",
+  "breadboard_sdk",
+  "breadboard",
+  "breadboard.product",
+  "breadboard.product.harness",
+  "conformance",
+]
 py-modules = ["adaptive_iter"]
+
+[tool.setuptools.data-files]
+"agent_configs/templates" = ["agent_configs/templates/minimal_harness.v3.yaml"]
+"contracts/kernel/schemas" = ["contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json"]
+"contracts/public/schemas" = ["contracts/public/schemas/bb.harness_definition.v1.schema.json"]

--- a/tests/product/harness/test_model.py
+++ b/tests/product/harness/test_model.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from breadboard.product.harness.model import HarnessDefinition
+from breadboard.product.harness.validate import HarnessDefinitionValidationError
+
+ROOT = Path(__file__).parents[3]
+CONFIGS = (
+    ROOT / "agent_configs/templates/minimal_harness.v2.yaml",
+    ROOT / "agent_configs/v2/codex_0-107-0_e4_3-6-2026.yaml",
+)
+
+
+def _load(path: Path) -> dict[str, Any]:
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(document, dict)
+    return document
+
+
+def _assert_exact(actual: Any, expected: Any) -> None:
+    assert type(actual) is type(expected)
+    if isinstance(expected, dict):
+        assert actual.keys() == expected.keys()
+        for key in expected:
+            _assert_exact(actual[key], expected[key])
+    elif isinstance(expected, list):
+        assert len(actual) == len(expected)
+        for actual_item, expected_item in zip(actual, expected):
+            _assert_exact(actual_item, expected_item)
+    else:
+        assert actual == expected
+
+
+@pytest.mark.parametrize("path", CONFIGS, ids=("minimal-v2", "complex-v2"))
+def test_actual_v2_configs_round_trip_exactly_without_coercion(path: Path) -> None:
+    source = _load(path)
+    expected = copy.deepcopy(source)
+    definition = HarnessDefinition.from_mapping(source)
+    source["workspace"]["root"] = "mutated"
+
+    _assert_exact(definition.as_dict(), expected)
+
+
+def test_definition_is_recursively_immutable_and_copies_are_detached() -> None:
+    source = _load(CONFIGS[1])
+    definition = HarnessDefinition.from_mapping(source)
+    first, second = definition.as_dict(), definition.as_dict()
+
+    with pytest.raises(TypeError):
+        definition["workspace"]["root"] = "mutated"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        definition["modes"][0]["name"] = "mutated"  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        definition["modes"].append({"name": "mutated"})  # type: ignore[union-attr]
+
+    first["workspace"]["root"] = "changed"
+    first["modes"][0]["tools_enabled"].append("extra")
+    assert second == source == definition.as_dict()
+    assert first["workspace"] is not second["workspace"]
+    assert first["modes"] is not second["modes"]
+
+
+def test_canonical_json_is_stable_compact_utf8_safe_and_has_no_newline() -> None:
+    source = _load(CONFIGS[1])
+    source["modes"][0]["prompt"] = "Plan — then execute"
+    reordered = dict(reversed(tuple(source.items())))
+
+    canonical = HarnessDefinition.from_mapping(source).canonical_json()
+    assert canonical == HarnessDefinition.from_mapping(reordered).canonical_json()
+    assert canonical == json.dumps(
+        source,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    assert "—" in canonical and not canonical.endswith("\n")
+
+
+def test_from_mapping_delegates_rejection_to_public_validation_contract() -> None:
+    invalid = _load(CONFIGS[0])
+    invalid.update(schema_version="bb.unknown.v9", version=9)
+
+    with pytest.raises(HarnessDefinitionValidationError):
+        HarnessDefinition.from_mapping(invalid)

--- a/tests/product/harness/test_model.py
+++ b/tests/product/harness/test_model.py
@@ -43,6 +43,18 @@ def test_actual_v2_configs_round_trip_exactly_without_coercion(path: Path) -> No
     assert _typed(definition.as_dict()) == _typed(expected)
     assert json.loads(definition.canonical_json()) == expected
 
+def test_construction_validates_the_detached_snapshot() -> None:
+    class ClearingMapping(dict[str, Any]):
+        def items(self):  # type: ignore[override]
+            entries = dict(self).items()
+            self.clear()
+            return entries
+
+    source = ClearingMapping(_load(CONFIGS[0]))
+    definition = HarnessDefinition.from_mapping(source)
+    assert not source
+    assert definition.as_dict() == _load(CONFIGS[0])
+
 
 def test_definition_is_recursively_immutable_and_copies_are_detached() -> None:
     source = _load(CONFIGS[1])
@@ -70,12 +82,7 @@ def test_canonical_json_is_stable_compact_utf8_safe_and_has_no_newline() -> None
     canonical = HarnessDefinition.from_mapping(source).canonical_json()
     assert canonical == HarnessDefinition.from_mapping(reordered).canonical_json()
     assert canonical == json.dumps(
-        source,
-        allow_nan=False,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    )
+        source, allow_nan=False, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
     assert "—" in canonical and not canonical.endswith("\n")
 
 

--- a/tests/product/harness/test_model.py
+++ b/tests/product/harness/test_model.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import json
 from pathlib import Path
 from typing import Any
@@ -9,7 +8,10 @@ import pytest
 import yaml
 
 from breadboard.product.harness.model import HarnessDefinition
-from breadboard.product.harness.validate import HarnessDefinitionValidationError
+from breadboard.product.harness.validate import (
+    HarnessDefinitionValidationError,
+    ValidationFinding,
+)
 
 ROOT = Path(__file__).parents[3]
 CONFIGS = (
@@ -24,54 +26,47 @@ def _load(path: Path) -> dict[str, Any]:
     return document
 
 
-def _assert_exact(actual: Any, expected: Any) -> None:
-    assert type(actual) is type(expected)
-    if isinstance(expected, dict):
-        assert actual.keys() == expected.keys()
-        for key in expected:
-            _assert_exact(actual[key], expected[key])
-    elif isinstance(expected, list):
-        assert len(actual) == len(expected)
-        for actual_item, expected_item in zip(actual, expected):
-            _assert_exact(actual_item, expected_item)
-    else:
-        assert actual == expected
+def _typed(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _typed(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_typed(item) for item in value]
+    return type(value), value
 
 
 @pytest.mark.parametrize("path", CONFIGS, ids=("minimal-v2", "complex-v2"))
 def test_actual_v2_configs_round_trip_exactly_without_coercion(path: Path) -> None:
     source = _load(path)
-    expected = copy.deepcopy(source)
+    expected = _load(path)
     definition = HarnessDefinition.from_mapping(source)
     source["workspace"]["root"] = "mutated"
-
-    _assert_exact(definition.as_dict(), expected)
+    assert _typed(definition.as_dict()) == _typed(expected)
+    assert json.loads(definition.canonical_json()) == expected
 
 
 def test_definition_is_recursively_immutable_and_copies_are_detached() -> None:
     source = _load(CONFIGS[1])
+    source["dossier"] = {"nested": [{"value": "original"}]}
     definition = HarnessDefinition.from_mapping(source)
+    source["dossier"]["nested"][0]["value"] = "source"
     first, second = definition.as_dict(), definition.as_dict()
-
     with pytest.raises(TypeError):
         definition["workspace"]["root"] = "mutated"  # type: ignore[index]
     with pytest.raises(TypeError):
         definition["modes"][0]["name"] = "mutated"  # type: ignore[index]
     with pytest.raises(AttributeError):
         definition["modes"].append({"name": "mutated"})  # type: ignore[union-attr]
-
     first["workspace"]["root"] = "changed"
     first["modes"][0]["tools_enabled"].append("extra")
-    assert second == source == definition.as_dict()
-    assert first["workspace"] is not second["workspace"]
-    assert first["modes"] is not second["modes"]
+    first["dossier"]["nested"][0]["value"] = "copy"
+    assert second == json.loads(definition.canonical_json()) == definition.as_dict()
+    assert second["dossier"]["nested"][0]["value"] == "original"
 
 
 def test_canonical_json_is_stable_compact_utf8_safe_and_has_no_newline() -> None:
     source = _load(CONFIGS[1])
     source["modes"][0]["prompt"] = "Plan — then execute"
     reordered = dict(reversed(tuple(source.items())))
-
     canonical = HarnessDefinition.from_mapping(source).canonical_json()
     assert canonical == HarnessDefinition.from_mapping(reordered).canonical_json()
     assert canonical == json.dumps(
@@ -86,7 +81,10 @@ def test_canonical_json_is_stable_compact_utf8_safe_and_has_no_newline() -> None
 
 def test_from_mapping_delegates_rejection_to_public_validation_contract() -> None:
     invalid = _load(CONFIGS[0])
-    invalid.update(schema_version="bb.unknown.v9", version=9)
-
-    with pytest.raises(HarnessDefinitionValidationError):
+    invalid["dossier"] = {"bad": {1, 2}}
+    expected = ValidationFinding(
+        "/dossier/bad", "json_type", "Value is not a JSON-domain value"
+    )
+    with pytest.raises(HarnessDefinitionValidationError) as raised:
         HarnessDefinition.from_mapping(invalid)
+    assert raised.value.findings == (expected,)

--- a/tests/product/harness/test_templates.py
+++ b/tests/product/harness/test_templates.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from breadboard.product.harness.model import HarnessDefinition
+from breadboard.product.harness.templates import (
+    load_minimal_harness,
+    minimal_template_path,
+    minimal_template_text,
+)
+from breadboard.product.harness.validate import validate_harness_definition
+
+ROOT = Path(__file__).resolve().parents[3]
+TEMPLATE = ROOT / "agent_configs" / "templates" / "minimal_harness.v3.yaml"
+
+
+def test_checked_in_template_is_exact_minimal_canonical_model() -> None:
+    text = minimal_template_text()
+    document = yaml.safe_load(text)
+    assert minimal_template_path() == TEMPLATE
+    assert text == TEMPLATE.read_text(encoding="utf-8")
+    assert len(text.splitlines()) <= 80
+    assert document["schema_version"] == "bb.harness_definition.v1"
+    assert document["version"] == 1
+    assert set(document) == {
+        "schema_version",
+        "version",
+        "workspace",
+        "providers",
+        "modes",
+        "loop",
+    }
+    assert all(marker not in text for marker in ("implementations/", "import_path", "runtime"))
+    assert validate_harness_definition(document) == ()
+    harness = load_minimal_harness()
+    assert isinstance(harness, HarnessDefinition)
+    assert harness.as_dict() == document
+
+def test_wheel_import_loads_template_from_distribution_data_root(tmp_path: Path) -> None:
+    wheelhouse = tmp_path / "wheelhouse"
+    outside_repo = tmp_path / "outside-repo"
+    wheelhouse.mkdir()
+    outside_repo.mkdir()
+    environment = os.environ.copy()
+    environment.pop("PYTHONPATH", None)
+    environment["PYTHONNOUSERSITE"] = "1"
+
+    def run(*command: str) -> str:
+        process = subprocess.run(
+            command,
+            cwd=outside_repo,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        assert process.returncode == 0, process.stderr
+        return process.stdout
+
+    run(
+        sys.executable,
+        "-m",
+        "pip",
+        "wheel",
+        "--no-deps",
+        "--no-build-isolation",
+        "--wheel-dir",
+        str(wheelhouse),
+        str(ROOT),
+    )
+    wheel = next(wheelhouse.glob("*.whl"))
+    venv = tmp_path / "venv"
+    run(sys.executable, "-m", "venv", "--system-site-packages", str(venv))
+    venv_python = venv / "bin" / "python"
+    run(str(venv_python), "-m", "pip", "install", "--no-deps", str(wheel))
+    script = (
+        "import json, sysconfig; from breadboard.product.harness.templates import "
+        "load_minimal_harness, minimal_template_path, minimal_template_text; "
+        "print(json.dumps({'data_root': sysconfig.get_path('data'), 'path': str(minimal_template_path()), "
+        "'text': minimal_template_text(), 'document': load_minimal_harness().as_dict()}))"
+    )
+    payload = json.loads(run(str(venv_python), "-I", "-c", script))
+    expected_text = TEMPLATE.read_text(encoding="utf-8")
+    expected_installed_path = (
+        Path(payload["data_root"])
+        / "agent_configs/templates/minimal_harness.v3.yaml"
+    )
+    assert Path(payload["path"]) == expected_installed_path
+    assert payload["text"] == expected_text
+    assert payload["document"] == yaml.safe_load(expected_text)

--- a/tests/product/harness/test_templates.py
+++ b/tests/product/harness/test_templates.py
@@ -63,22 +63,13 @@ def test_wheel_import_loads_template_from_distribution_data_root(tmp_path: Path)
         assert process.returncode == 0, process.stderr
         return process.stdout
 
-    run(
-        sys.executable,
-        "-m",
-        "pip",
-        "wheel",
-        "--no-deps",
-        "--no-build-isolation",
-        "--wheel-dir",
-        str(wheelhouse),
-        str(ROOT),
-    )
+    run(sys.executable, "-m", "pip", "wheel", "--no-deps", "--no-build-isolation",
+        "--wheel-dir", str(wheelhouse), str(ROOT))
     wheel = next(wheelhouse.glob("*.whl"))
     venv = tmp_path / "venv"
-    run(sys.executable, "-m", "venv", "--system-site-packages", str(venv))
+    run(sys.executable, "-m", "venv", str(venv))
     venv_python = venv / "bin" / "python"
-    run(str(venv_python), "-m", "pip", "install", "--no-deps", str(wheel))
+    run(str(venv_python), "-m", "pip", "install", str(wheel))
     script = (
         "import json, sysconfig; from breadboard.product.harness.templates import "
         "load_minimal_harness, minimal_template_path, minimal_template_text; "

--- a/tests/product/harness/test_templates.py
+++ b/tests/product/harness/test_templates.py
@@ -43,45 +43,40 @@ def test_checked_in_template_is_exact_minimal_canonical_model() -> None:
     assert harness.as_dict() == document
 
 def test_wheel_import_loads_template_from_distribution_data_root(tmp_path: Path) -> None:
-    wheelhouse = tmp_path / "wheelhouse"
-    outside_repo = tmp_path / "outside-repo"
-    wheelhouse.mkdir()
-    outside_repo.mkdir()
+    wheelhouse, outside_repo = tmp_path / "wheelhouse", tmp_path / "outside-repo"
+    for directory in (wheelhouse, outside_repo):
+        directory.mkdir()
     environment = os.environ.copy()
     environment.pop("PYTHONPATH", None)
     environment["PYTHONNOUSERSITE"] = "1"
 
     def run(*command: str) -> str:
-        process = subprocess.run(
+        return subprocess.run(
             command,
             cwd=outside_repo,
             env=environment,
-            check=False,
+            check=True,
             capture_output=True,
             text=True,
-        )
-        assert process.returncode == 0, process.stderr
-        return process.stdout
+        ).stdout
 
     run(sys.executable, "-m", "pip", "wheel", "--no-deps", "--no-build-isolation",
         "--wheel-dir", str(wheelhouse), str(ROOT))
     wheel = next(wheelhouse.glob("*.whl"))
-    venv = tmp_path / "venv"
-    run(sys.executable, "-m", "venv", str(venv))
-    venv_python = venv / "bin" / "python"
-    run(str(venv_python), "-m", "pip", "install", str(wheel))
+    install_root = tmp_path / "install"
+    run(sys.executable, "-m", "pip", "install", "--no-deps",
+        "--target", str(install_root), str(wheel))
     script = (
-        "import json, sysconfig; from breadboard.product.harness.templates import "
+        f"import sys; sys.path.insert(0, {str(install_root)!r}); import json; "
+        "from breadboard.product.harness.templates import "
         "load_minimal_harness, minimal_template_path, minimal_template_text; "
-        "print(json.dumps({'data_root': sysconfig.get_path('data'), 'path': str(minimal_template_path()), "
+        "print(json.dumps({'path': str(minimal_template_path()), "
         "'text': minimal_template_text(), 'document': load_minimal_harness().as_dict()}))"
     )
-    payload = json.loads(run(str(venv_python), "-I", "-c", script))
+    payload = json.loads(run(sys.executable, "-I", "-c", script))
     expected_text = TEMPLATE.read_text(encoding="utf-8")
     expected_installed_path = (
-        Path(payload["data_root"])
-        / "agent_configs/templates/minimal_harness.v3.yaml"
-    )
+        install_root / "agent_configs/templates/minimal_harness.v3.yaml")
     assert Path(payload["path"]) == expected_installed_path
     assert payload["text"] == expected_text
     assert payload["document"] == yaml.safe_load(expected_text)

--- a/tests/product/harness/test_validate.py
+++ b/tests/product/harness/test_validate.py
@@ -135,6 +135,12 @@ def test_json_depth_boundary_is_stable() -> None:
         "/dossier/bad" + "/0" * 99, "json_depth",
         "JSON paths must not exceed 100 segments")
     assert validate_harness_definition(_definition(dossier={"bad": rejected})) == (expected,)
+    very_deep: object = None
+    for _ in range(1200):
+        very_deep = [very_deep]
+    with pytest.raises(HarnessDefinitionValidationError) as raised:
+        HarnessDefinition.from_mapping(_definition(dossier={"bad": very_deep}))
+    assert raised.value.findings[0].code == "json_depth"
 @pytest.mark.parametrize(("schema_version", "version", "expected"), [
     ("bb.unknown.v9", 9, [("/schema_version", "unsupported_schema_version"),
                           ("/version", "unsupported_version")]),
@@ -160,14 +166,6 @@ def test_missing_discriminators_fail_before_schema_validation() -> None:
     assert _pairs(document) == [
         ("/schema_version", "required"), ("/version", "required")
     ]
-def test_loading_yaml_requires_a_mapping_root(tmp_path: Path) -> None:
-    path = tmp_path / "not-a-mapping.yaml"
-    path.write_text("- one\n- two\n", encoding="utf-8")
-    with pytest.raises(HarnessDefinitionValidationError) as raised:
-        load_harness_definition(path)
-    assert raised.value.findings == (
-        ValidationFinding("/", "type", "Harness definition must be a mapping"),
-    )
 def test_findings_are_immutable_and_orderable() -> None:
     later, earlier = ValidationFinding("/z", "type", "later"), ValidationFinding("/a", "required", "earlier")
     assert sorted((later, earlier)) == [earlier, later]

--- a/tests/product/harness/test_validate.py
+++ b/tests/product/harness/test_validate.py
@@ -116,12 +116,13 @@ def test_compatible_one_of_branch_exposes_leaf_findings(
     (b"x", "json_type"), (bytearray(b"x"), "json_type"), ((1,), "json_type"),
     (range(1), "json_type"), ({1}, "json_type"), (date(2026, 1, 1), "json_type"),
     (object(), "json_type"), (float("nan"), "finite"), (float("inf"), "finite"), (float("-inf"), "finite"),
-    ({1: "value"}, "json_key")])
+    pytest.param(10**5000, "integer_range", id="oversized-integer"), ({1: "value"}, "json_key")])
 def test_json_domain_preflight_rejects_adversarial_values(
     value: object, code: str
 ) -> None:
     message = {"json_type": "Value is not a JSON-domain value",
                "finite": "JSON numbers must be finite",
+               "integer_range": "JSON integers must contain at most 1000 decimal digits",
                "json_key": "Object keys must be strings"}[code]
     assert validate_harness_definition(_definition(dossier={"bad": value})) == (
         ValidationFinding("/dossier/bad", code, message),)
@@ -131,11 +132,16 @@ def test_json_domain_preflight_reports_cycle_back_edge() -> None:
     assert validate_harness_definition(_definition(dossier={"bad": cycle})) == (
         ValidationFinding("/dossier/bad/0", "json_cycle", "JSON values must not contain cycles"),
     )
+def test_json_depth_boundary_is_stable() -> None:
+    accepted, rejected = (json.loads("[" * depth + "null" + "]" * depth) for depth in (98, 99))
+    assert json.loads(HarnessDefinition.from_mapping(_definition(dossier={"bad": accepted})).canonical_json())["dossier"]["bad"] == accepted
+    assert validate_harness_definition(_definition(dossier={"bad": rejected})) == (ValidationFinding("/dossier/bad" + "/0" * 99, "json_depth", "JSON paths must not exceed 100 segments"),)
 @pytest.mark.parametrize(("schema_version", "version", "expected"), [
     ("bb.unknown.v9", 9, [("/schema_version", "unsupported_schema_version"),
                           ("/version", "unsupported_version")]),
     ("bb.harness_definition.v1", 2, [("/version", "unsupported_version")]),
     ("bb.agent_config_surface.v2", 1, [("/version", "unsupported_version")]),
+    pytest.param("bb.harness_definition.v1", 10**5000, [("/version", "integer_range")], id="oversized-version"),
     ("bb.harness_definition.v1", "1", [("/version", "unsupported_version")])])
 def test_unsupported_and_mismatched_source_pairs_fail_closed(
     schema_version: object, version: object, expected: list[tuple[str, str]]

--- a/tests/product/harness/test_validate.py
+++ b/tests/product/harness/test_validate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import copy
 import json
+import sys
 from dataclasses import FrozenInstanceError
 from datetime import date
 from pathlib import Path
@@ -122,18 +123,17 @@ def test_json_domain_preflight_rejects_adversarial_values(
 ) -> None:
     message = {"json_type": "Value is not a JSON-domain value",
                "finite": "JSON numbers must be finite",
-               "integer_range": "JSON integers must contain at most 1000 decimal digits",
+               "integer_range": "JSON integers must contain at most 640 decimal digits",
                "json_key": "Object keys must be strings"}[code]
     assert validate_harness_definition(_definition(dossier={"bad": value})) == (
         ValidationFinding("/dossier/bad", code, message),)
-def test_json_domain_preflight_reports_cycle_back_edge() -> None:
-    cycle: list[object] = []
-    cycle.append(cycle)
-    assert validate_harness_definition(_definition(dossier={"bad": cycle})) == (
-        ValidationFinding("/dossier/bad/0", "json_cycle", "JSON values must not contain cycles"),
-    )
-def test_json_depth_boundary_is_stable() -> None:
+def test_json_domain_preflight_reports_cycle_back_edge() -> None: cycle: list[object] = []; cycle.append(cycle); assert validate_harness_definition(_definition(dossier={"bad": cycle})) == (ValidationFinding("/dossier/bad/0", "json_cycle", "JSON values must not contain cycles"),)
+def test_supported_json_boundaries_are_stable(request: pytest.FixtureRequest) -> None:
     accepted, rejected = (json.loads("[" * depth + "null" + "]" * depth) for depth in (98, 99))
+    original = sys.get_int_max_str_digits(); request.addfinalizer(lambda: sys.set_int_max_str_digits(original))
+    sys.set_int_max_str_digits(640)
+    for integer in (10**640 - 1, -(10**640 - 1)): assert json.loads(HarnessDefinition.from_mapping(_definition(dossier={"bad": integer})).canonical_json())["dossier"]["bad"] == integer
+    for integer in (10**640, -(10**640)): assert validate_harness_definition(_definition(dossier={"bad": integer})) == (ValidationFinding("/dossier/bad", "integer_range", "JSON integers must contain at most 640 decimal digits"),)
     assert json.loads(HarnessDefinition.from_mapping(_definition(dossier={"bad": accepted})).canonical_json())["dossier"]["bad"] == accepted
     assert validate_harness_definition(_definition(dossier={"bad": rejected})) == (ValidationFinding("/dossier/bad" + "/0" * 99, "json_depth", "JSON paths must not exceed 100 segments"),)
 @pytest.mark.parametrize(("schema_version", "version", "expected"), [
@@ -178,8 +178,6 @@ loop: {sequence: [{mode: build}]}
     assert isinstance(loaded, HarnessDefinition)
     assert loaded["schema_version"] == "bb.harness_definition.v1"
 def test_findings_are_immutable_and_orderable() -> None:
-    later = ValidationFinding("/z", "type", "later")
-    earlier = ValidationFinding("/a", "required", "earlier")
+    later, earlier = ValidationFinding("/z", "type", "later"), ValidationFinding("/a", "required", "earlier")
     assert sorted((later, earlier)) == [earlier, later]
-    with pytest.raises(FrozenInstanceError):
-        earlier.pointer = "/changed"  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError): earlier.pointer = "/changed"  # type: ignore[misc]

--- a/tests/product/harness/test_validate.py
+++ b/tests/product/harness/test_validate.py
@@ -1,47 +1,36 @@
 from __future__ import annotations
-
 import copy
 import json
 from dataclasses import FrozenInstanceError
+from datetime import date
 from pathlib import Path
 from types import MappingProxyType
-
 import pytest
-
 from breadboard.product.harness.model import HarnessDefinition
 from breadboard.product.harness.validate import (
-    HarnessDefinitionValidationError,
-    ValidationFinding,
-    load_harness_definition,
-    parse_harness_definition,
-    validate_harness_definition,
-)
-
+    HarnessDefinitionValidationError, ValidationFinding, load_harness_definition,
+    parse_harness_definition, validate_harness_definition)
 ROOT = Path(__file__).resolve().parents[3]
 SCHEMA_PATH = ROOT / "contracts/public/schemas/bb.harness_definition.v1.schema.json"
 V2_SCHEMA_ID = "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json"
-
-
 def _definition(**updates: object) -> dict[str, object]:
     document: dict[str, object] = {
         "schema_version": "bb.harness_definition.v1",
         "version": 1,
         "workspace": {"root": "."},
-        "providers": {
-            "default_model": "main",
-            "models": [{"id": "main", "adapter": "openai"}],
-        },
+        "providers": {"default_model": "main", "models": [{"id": "main", "adapter": "openai"}]},
         "modes": [{"name": "build"}],
         "loop": {"sequence": [{"mode": "build"}]},
     }
     document.update(updates)
     return document
-
-
 def _pairs(document: object) -> list[tuple[str, str]]:
     return [(item.pointer, item.code) for item in validate_harness_definition(document)]  # type: ignore[arg-type]
-
-
+def _schema_strings(value: object) -> list[str]:
+    if isinstance(value, str): return [value]
+    if isinstance(value, dict): return [*value, *(item for child in value.values() for item in _schema_strings(child))]
+    if isinstance(value, list): return [item for child in value for item in _schema_strings(child)]
+    return []
 def test_public_schema_reuses_each_v2_property_grammar() -> None:
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     assert schema["$id"] == "https://breadboard.dev/contracts/public/schemas/bb.harness_definition.v1.schema.json"
@@ -55,7 +44,8 @@ def test_public_schema_reuses_each_v2_property_grammar() -> None:
     for name, property_schema in schema["properties"].items():
         if name not in {"schema_version", "version"}:
             assert property_schema == {"$ref": f"{V2_SCHEMA_ID}#/properties/{name}"}
-
+    surface = "\n".join(_schema_strings(schema)).casefold()
+    assert not any(token in surface for token in ("implementations/", "import_path", "agentic_coder_prototype", "breadboard.product"))
 @pytest.mark.parametrize(
     "source", [("bb.harness_definition.v1", 1), ("bb.agent_config_surface.v2", 2)]
 )
@@ -67,81 +57,90 @@ def test_sources_and_mapping_instances_round_trip_without_mutation(
     assert validate_harness_definition(MappingProxyType(document)) == ()
     assert parse_harness_definition(document).as_dict() == original
     assert document == original
-
 def test_multiple_errors_are_expanded_deduplicated_and_sorted() -> None:
     document = _definition(
-        zeta=True,
-        alpha=True,
-        workspace={},
-        providers={"models": [{"id": "main"}]},
-        modes=[{}],
-        loop={"sequence": []},
-    )
+        zeta=True, alpha=True, workspace={}, providers={"models": [{"id": "main"}]},
+        modes=[{}], loop={"sequence": []})
     findings = validate_harness_definition(document)
     assert [(item.pointer, item.code) for item in findings] == [
-        ("/alpha", "additionalProperties"),
-        ("/loop/sequence", "minItems"),
-        ("/modes/0/name", "required"),
-        ("/providers/default_model", "required"),
-        ("/providers/models/0/adapter", "required"),
-        ("/workspace/root", "required"),
-        ("/zeta", "additionalProperties"),
-    ]
+        ("/alpha", "additionalProperties"), ("/loop/sequence", "minItems"),
+        ("/modes/0/name", "required"), ("/providers/default_model", "required"),
+        ("/providers/models/0/adapter", "required"), ("/workspace/root", "required"),
+        ("/zeta", "additionalProperties")]
     assert findings == tuple(sorted(set(findings)))
-
 def test_unknown_fields_have_exact_escaped_pointers() -> None:
-    document = _definition(workspace={"root": ".", "unknown": True})
+    document = _definition()
     document["a/b~c"] = True
-    assert _pairs(document) == [
-        ("/a~1b~0c", "additionalProperties"),
-        ("/workspace/unknown", "additionalProperties"),
-    ]
-
-def test_required_errors_point_to_each_missing_field() -> None:
-    document = _definition(workspace={})
-    del document["providers"]
-    assert [item.pointer for item in validate_harness_definition(document)] == [
-        "/providers", "/workspace/root"
-    ]
-
-def test_wrong_type_is_rejected_without_coercion_or_mutation() -> None:
-    document = _definition(workspace={"root": 7})
+    assert _pairs(document) == [("/a~1b~0c", "additionalProperties")]
+@pytest.mark.parametrize(("updates", "finding"), [
+    ({"workspace": {}}, ValidationFinding(
+        "/workspace/root", "required", "'root' is a required property")),
+    ({"workspace": {"root": ".", "unknown": True}}, ValidationFinding(
+        "/workspace/unknown", "additionalProperties",
+        "Additional property 'unknown' is not allowed")),
+    ({"workspace": {"root": 7}}, ValidationFinding(
+        "/workspace/root", "type", 'Value must have type "string"')),
+    ({"loop": {"sequence": []}}, ValidationFinding(
+        "/loop/sequence", "minItems", "Array must contain at least 1 item(s)")),
+])
+def test_schema_findings_have_project_owned_exact_messages(
+    updates: dict[str, object], finding: ValidationFinding
+) -> None:
+    document = _definition(**updates)
     before = copy.deepcopy(document)
-    assert _pairs(document) == [("/workspace/root", "type")]
+    assert validate_harness_definition(document) == (finding,)
     assert document == before
-    assert document["workspace"] == {"root": 7}
-
 def test_v2_open_dynamic_maps_remain_open_through_canonical_refs() -> None:
     document = _definition(
         dossier={"arbitrary": {"nested": [1, True, None]}},
-        tools={
-            "aliases": {"author-name": "runtime-name"},
-            "dialects": {"selection": {"by_model": {"dynamic-model": ["dialect-a"]}}},
-        },
-    )
+        tools={"aliases": {"author-name": "runtime-name"},
+               "dialects": {"selection": {"by_model": {"dynamic-model": ["dialect-a"]}}}})
     assert validate_harness_definition(document) == ()
-
-@pytest.mark.parametrize(
-    ("schema_version", "version", "expected"),
-    [
-        (
-            "bb.unknown.v9",
-            9,
-            [
-                ("/schema_version", "unsupported_schema_version"),
-                ("/version", "unsupported_version"),
-            ],
-        ),
-        ("bb.harness_definition.v1", 2, [("/version", "unsupported_version")]),
-        ("bb.agent_config_surface.v2", 1, [("/version", "unsupported_version")]),
-        ("bb.harness_definition.v1", "1", [("/version", "unsupported_version")]),
-    ],
-)
+@pytest.mark.parametrize(("value", "finding"), [
+    ({}, ValidationFinding(
+        "/tools/dialects/preference/by_model/main/order", "required",
+        "'order' is a required property")),
+    ({"order": [], "a/b~c": True}, ValidationFinding(
+        "/tools/dialects/preference/by_model/main/a~1b~0c", "additionalProperties",
+        "Additional property 'a/b~c' is not allowed")),
+    ({"order": 7}, ValidationFinding(
+        "/tools/dialects/preference/by_model/main/order", "type",
+        'Value must have type "array"')),
+])
+def test_compatible_one_of_branch_exposes_leaf_findings(
+    value: object, finding: ValidationFinding
+) -> None:
+    tools = {"dialects": {"preference": {"by_model": {"main": value}}}}
+    assert validate_harness_definition(_definition(tools=tools)) == (finding,)
+@pytest.mark.parametrize(("value", "code"), [
+    (b"x", "json_type"), (bytearray(b"x"), "json_type"), ((1,), "json_type"),
+    (range(1), "json_type"), ({1}, "json_type"), (date(2026, 1, 1), "json_type"),
+    (object(), "json_type"), (float("nan"), "finite"), (float("inf"), "finite"), (float("-inf"), "finite"),
+    ({1: "value"}, "json_key")])
+def test_json_domain_preflight_rejects_adversarial_values(
+    value: object, code: str
+) -> None:
+    message = {"json_type": "Value is not a JSON-domain value",
+               "finite": "JSON numbers must be finite",
+               "json_key": "Object keys must be strings"}[code]
+    assert validate_harness_definition(_definition(dossier={"bad": value})) == (
+        ValidationFinding("/dossier/bad", code, message),)
+def test_json_domain_preflight_reports_cycle_back_edge() -> None:
+    cycle: list[object] = []
+    cycle.append(cycle)
+    assert validate_harness_definition(_definition(dossier={"bad": cycle})) == (
+        ValidationFinding("/dossier/bad/0", "json_cycle", "JSON values must not contain cycles"),
+    )
+@pytest.mark.parametrize(("schema_version", "version", "expected"), [
+    ("bb.unknown.v9", 9, [("/schema_version", "unsupported_schema_version"),
+                          ("/version", "unsupported_version")]),
+    ("bb.harness_definition.v1", 2, [("/version", "unsupported_version")]),
+    ("bb.agent_config_surface.v2", 1, [("/version", "unsupported_version")]),
+    ("bb.harness_definition.v1", "1", [("/version", "unsupported_version")])])
 def test_unsupported_and_mismatched_source_pairs_fail_closed(
     schema_version: object, version: object, expected: list[tuple[str, str]]
 ) -> None:
     assert _pairs(_definition(schema_version=schema_version, version=version)) == expected
-
 def test_missing_discriminators_fail_before_schema_validation() -> None:
     document = _definition(unknown=True)
     del document["schema_version"]
@@ -149,7 +148,6 @@ def test_missing_discriminators_fail_before_schema_validation() -> None:
     assert _pairs(document) == [
         ("/schema_version", "required"), ("/version", "required")
     ]
-
 def test_loading_yaml_requires_a_mapping_root(tmp_path: Path) -> None:
     path = tmp_path / "not-a-mapping.yaml"
     path.write_text("- one\n- two\n", encoding="utf-8")
@@ -158,7 +156,6 @@ def test_loading_yaml_requires_a_mapping_root(tmp_path: Path) -> None:
     assert raised.value.findings == (
         ValidationFinding("/", "type", "Harness definition must be a mapping"),
     )
-
 def test_loading_valid_yaml_returns_canonical_model(tmp_path: Path) -> None:
     path = tmp_path / "harness.yaml"
     path.write_text(
@@ -174,7 +171,6 @@ loop: {sequence: [{mode: build}]}
     loaded = load_harness_definition(path)
     assert isinstance(loaded, HarnessDefinition)
     assert loaded["schema_version"] == "bb.harness_definition.v1"
-
 def test_findings_are_immutable_and_orderable() -> None:
     later = ValidationFinding("/z", "type", "later")
     earlier = ValidationFinding("/a", "required", "earlier")

--- a/tests/product/harness/test_validate.py
+++ b/tests/product/harness/test_validate.py
@@ -27,16 +27,11 @@ def _definition(**updates: object) -> dict[str, object]:
     return document
 def _pairs(document: object) -> list[tuple[str, str]]:
     return [(item.pointer, item.code) for item in validate_harness_definition(document)]  # type: ignore[arg-type]
-def _schema_strings(value: object) -> list[str]:
-    if isinstance(value, str): return [value]
-    if isinstance(value, dict): return [*value, *(item for child in value.values() for item in _schema_strings(child))]
-    if isinstance(value, list): return [item for child in value for item in _schema_strings(child)]
-    return []
+def _preference(value: object) -> dict[str, object]:
+    return {"tools": {"dialects": {"preference": {"by_model": {"main": value}}}}}
 def test_public_schema_reuses_each_v2_property_grammar() -> None:
     schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     assert schema["$id"] == "https://breadboard.dev/contracts/public/schemas/bb.harness_definition.v1.schema.json"
-    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
-    assert schema["additionalProperties"] is False
     assert schema["required"] == [
         "schema_version", "version", "workspace", "providers", "modes", "loop"
     ]
@@ -45,7 +40,7 @@ def test_public_schema_reuses_each_v2_property_grammar() -> None:
     for name, property_schema in schema["properties"].items():
         if name not in {"schema_version", "version"}:
             assert property_schema == {"$ref": f"{V2_SCHEMA_ID}#/properties/{name}"}
-    surface = "\n".join(_schema_strings(schema)).casefold()
+    surface = json.dumps(schema, sort_keys=True).casefold()
     assert not any(token in surface for token in ("implementations/", "import_path", "agentic_coder_prototype", "breadboard.product"))
 @pytest.mark.parametrize(
     "source", [("bb.harness_definition.v1", 1), ("bb.agent_config_surface.v2", 2)]
@@ -83,36 +78,21 @@ def test_unknown_fields_have_exact_escaped_pointers() -> None:
         "/workspace/root", "type", 'Value must have type "string"')),
     ({"loop": {"sequence": []}}, ValidationFinding(
         "/loop/sequence", "minItems", "Array must contain at least 1 item(s)")),
+    (_preference({}), ValidationFinding(
+        "/tools/dialects/preference/by_model/main/order", "required",
+        "'order' is a required property")),
+    (_preference({"order": [], "a/b~c": True}), ValidationFinding(
+        "/tools/dialects/preference/by_model/main/a~1b~0c", "additionalProperties",
+        "Additional property 'a/b~c' is not allowed")),
+    (_preference({"order": 7}), ValidationFinding(
+        "/tools/dialects/preference/by_model/main/order", "type",
+        'Value must have type "array"')),
 ])
 def test_schema_findings_have_project_owned_exact_messages(
     updates: dict[str, object], finding: ValidationFinding
 ) -> None:
     document = _definition(**updates)
-    before = copy.deepcopy(document)
     assert validate_harness_definition(document) == (finding,)
-    assert document == before
-def test_v2_open_dynamic_maps_remain_open_through_canonical_refs() -> None:
-    document = _definition(
-        dossier={"arbitrary": {"nested": [1, True, None]}},
-        tools={"aliases": {"author-name": "runtime-name"},
-               "dialects": {"selection": {"by_model": {"dynamic-model": ["dialect-a"]}}}})
-    assert validate_harness_definition(document) == ()
-@pytest.mark.parametrize(("value", "finding"), [
-    ({}, ValidationFinding(
-        "/tools/dialects/preference/by_model/main/order", "required",
-        "'order' is a required property")),
-    ({"order": [], "a/b~c": True}, ValidationFinding(
-        "/tools/dialects/preference/by_model/main/a~1b~0c", "additionalProperties",
-        "Additional property 'a/b~c' is not allowed")),
-    ({"order": 7}, ValidationFinding(
-        "/tools/dialects/preference/by_model/main/order", "type",
-        'Value must have type "array"')),
-])
-def test_compatible_one_of_branch_exposes_leaf_findings(
-    value: object, finding: ValidationFinding
-) -> None:
-    tools = {"dialects": {"preference": {"by_model": {"main": value}}}}
-    assert validate_harness_definition(_definition(tools=tools)) == (finding,)
 @pytest.mark.parametrize(("value", "code"), [
     (b"x", "json_type"), (bytearray(b"x"), "json_type"), ((1,), "json_type"),
     (range(1), "json_type"), ({1}, "json_type"), (date(2026, 1, 1), "json_type"),
@@ -127,15 +107,34 @@ def test_json_domain_preflight_rejects_adversarial_values(
                "json_key": "Object keys must be strings"}[code]
     assert validate_harness_definition(_definition(dossier={"bad": value})) == (
         ValidationFinding("/dossier/bad", code, message),)
-def test_json_domain_preflight_reports_cycle_back_edge() -> None: cycle: list[object] = []; cycle.append(cycle); assert validate_harness_definition(_definition(dossier={"bad": cycle})) == (ValidationFinding("/dossier/bad/0", "json_cycle", "JSON values must not contain cycles"),)
-def test_supported_json_boundaries_are_stable(request: pytest.FixtureRequest) -> None:
-    accepted, rejected = (json.loads("[" * depth + "null" + "]" * depth) for depth in (98, 99))
-    original = sys.get_int_max_str_digits(); request.addfinalizer(lambda: sys.set_int_max_str_digits(original))
+def test_json_domain_preflight_reports_cycle_back_edge() -> None:
+    cycle: list[object] = []
+    cycle.append(cycle)
+    expected = ValidationFinding(
+        "/dossier/bad/0", "json_cycle", "JSON values must not contain cycles")
+    assert validate_harness_definition(_definition(dossier={"bad": cycle})) == (expected,)
+def test_integer_boundary_is_host_stable(request: pytest.FixtureRequest) -> None:
+    original = sys.get_int_max_str_digits()
+    request.addfinalizer(lambda: sys.set_int_max_str_digits(original))
     sys.set_int_max_str_digits(640)
-    for integer in (10**640 - 1, -(10**640 - 1)): assert json.loads(HarnessDefinition.from_mapping(_definition(dossier={"bad": integer})).canonical_json())["dossier"]["bad"] == integer
-    for integer in (10**640, -(10**640)): assert validate_harness_definition(_definition(dossier={"bad": integer})) == (ValidationFinding("/dossier/bad", "integer_range", "JSON integers must contain at most 640 decimal digits"),)
-    assert json.loads(HarnessDefinition.from_mapping(_definition(dossier={"bad": accepted})).canonical_json())["dossier"]["bad"] == accepted
-    assert validate_harness_definition(_definition(dossier={"bad": rejected})) == (ValidationFinding("/dossier/bad" + "/0" * 99, "json_depth", "JSON paths must not exceed 100 segments"),)
+    maximum = 10**640 - 1
+    for integer in (maximum, -maximum):
+        definition = HarnessDefinition.from_mapping(_definition(dossier={"bad": integer}))
+        assert json.loads(definition.canonical_json())["dossier"]["bad"] == integer
+    expected = ValidationFinding(
+        "/dossier/bad", "integer_range",
+        "JSON integers must contain at most 640 decimal digits")
+    for integer in (maximum + 1, -(maximum + 1)):
+        assert validate_harness_definition(_definition(dossier={"bad": integer})) == (expected,)
+def test_json_depth_boundary_is_stable() -> None:
+    accepted, rejected = (
+        json.loads("[" * depth + "null" + "]" * depth) for depth in (98, 99))
+    definition = HarnessDefinition.from_mapping(_definition(dossier={"bad": accepted}))
+    assert json.loads(definition.canonical_json())["dossier"]["bad"] == accepted
+    expected = ValidationFinding(
+        "/dossier/bad" + "/0" * 99, "json_depth",
+        "JSON paths must not exceed 100 segments")
+    assert validate_harness_definition(_definition(dossier={"bad": rejected})) == (expected,)
 @pytest.mark.parametrize(("schema_version", "version", "expected"), [
     ("bb.unknown.v9", 9, [("/schema_version", "unsupported_schema_version"),
                           ("/version", "unsupported_version")]),
@@ -147,6 +146,13 @@ def test_unsupported_and_mismatched_source_pairs_fail_closed(
     schema_version: object, version: object, expected: list[tuple[str, str]]
 ) -> None:
     assert _pairs(_definition(schema_version=schema_version, version=version)) == expected
+def test_discriminator_messages_are_canonical_for_equivalent_mappings() -> None:
+    first = _definition(schema_version={"alpha": 1, "zeta": 2})
+    second = _definition(schema_version={"zeta": 2, "alpha": 1})
+    expected = ValidationFinding(
+        "/schema_version", "unsupported_schema_version",
+        "Unsupported schema_version; expected one of 'bb.agent_config_surface.v2', 'bb.harness_definition.v1'")
+    assert validate_harness_definition(first) == validate_harness_definition(second) == (expected,)
 def test_missing_discriminators_fail_before_schema_validation() -> None:
     document = _definition(unknown=True)
     del document["schema_version"]
@@ -162,22 +168,8 @@ def test_loading_yaml_requires_a_mapping_root(tmp_path: Path) -> None:
     assert raised.value.findings == (
         ValidationFinding("/", "type", "Harness definition must be a mapping"),
     )
-def test_loading_valid_yaml_returns_canonical_model(tmp_path: Path) -> None:
-    path = tmp_path / "harness.yaml"
-    path.write_text(
-        """schema_version: bb.harness_definition.v1
-version: 1
-workspace: {root: .}
-providers: {default_model: main, models: [{id: main, adapter: openai}]}
-modes: [{name: build}]
-loop: {sequence: [{mode: build}]}
-""",
-        encoding="utf-8",
-    )
-    loaded = load_harness_definition(path)
-    assert isinstance(loaded, HarnessDefinition)
-    assert loaded["schema_version"] == "bb.harness_definition.v1"
 def test_findings_are_immutable_and_orderable() -> None:
     later, earlier = ValidationFinding("/z", "type", "later"), ValidationFinding("/a", "required", "earlier")
     assert sorted((later, earlier)) == [earlier, later]
-    with pytest.raises(FrozenInstanceError): earlier.pointer = "/changed"  # type: ignore[misc]
+    with pytest.raises(FrozenInstanceError):
+        earlier.pointer = "/changed"  # type: ignore[misc]

--- a/tests/product/harness/test_validate.py
+++ b/tests/product/harness/test_validate.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from types import MappingProxyType
+
+import pytest
+
+from breadboard.product.harness.model import HarnessDefinition
+from breadboard.product.harness.validate import (
+    HarnessDefinitionValidationError,
+    ValidationFinding,
+    load_harness_definition,
+    parse_harness_definition,
+    validate_harness_definition,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_PATH = ROOT / "contracts/public/schemas/bb.harness_definition.v1.schema.json"
+V2_SCHEMA_ID = "https://breadboard.dev/contracts/kernel/schemas/bb.agent_config_surface.v2.schema.json"
+
+
+def _definition(**updates: object) -> dict[str, object]:
+    document: dict[str, object] = {
+        "schema_version": "bb.harness_definition.v1",
+        "version": 1,
+        "workspace": {"root": "."},
+        "providers": {
+            "default_model": "main",
+            "models": [{"id": "main", "adapter": "openai"}],
+        },
+        "modes": [{"name": "build"}],
+        "loop": {"sequence": [{"mode": "build"}]},
+    }
+    document.update(updates)
+    return document
+
+
+def _pairs(document: object) -> list[tuple[str, str]]:
+    return [(item.pointer, item.code) for item in validate_harness_definition(document)]  # type: ignore[arg-type]
+
+
+def test_public_schema_reuses_each_v2_property_grammar() -> None:
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    assert schema["$id"] == "https://breadboard.dev/contracts/public/schemas/bb.harness_definition.v1.schema.json"
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["additionalProperties"] is False
+    assert schema["required"] == [
+        "schema_version", "version", "workspace", "providers", "modes", "loop"
+    ]
+    assert schema["properties"]["schema_version"] == {"const": "bb.harness_definition.v1"}
+    assert schema["properties"]["version"] == {"const": 1}
+    for name, property_schema in schema["properties"].items():
+        if name not in {"schema_version", "version"}:
+            assert property_schema == {"$ref": f"{V2_SCHEMA_ID}#/properties/{name}"}
+
+@pytest.mark.parametrize(
+    "source", [("bb.harness_definition.v1", 1), ("bb.agent_config_surface.v2", 2)]
+)
+def test_sources_and_mapping_instances_round_trip_without_mutation(
+    source: tuple[str, int],
+) -> None:
+    document = _definition(schema_version=source[0], version=source[1])
+    original = copy.deepcopy(document)
+    assert validate_harness_definition(MappingProxyType(document)) == ()
+    assert parse_harness_definition(document).as_dict() == original
+    assert document == original
+
+def test_multiple_errors_are_expanded_deduplicated_and_sorted() -> None:
+    document = _definition(
+        zeta=True,
+        alpha=True,
+        workspace={},
+        providers={"models": [{"id": "main"}]},
+        modes=[{}],
+        loop={"sequence": []},
+    )
+    findings = validate_harness_definition(document)
+    assert [(item.pointer, item.code) for item in findings] == [
+        ("/alpha", "additionalProperties"),
+        ("/loop/sequence", "minItems"),
+        ("/modes/0/name", "required"),
+        ("/providers/default_model", "required"),
+        ("/providers/models/0/adapter", "required"),
+        ("/workspace/root", "required"),
+        ("/zeta", "additionalProperties"),
+    ]
+    assert findings == tuple(sorted(set(findings)))
+
+def test_unknown_fields_have_exact_escaped_pointers() -> None:
+    document = _definition(workspace={"root": ".", "unknown": True})
+    document["a/b~c"] = True
+    assert _pairs(document) == [
+        ("/a~1b~0c", "additionalProperties"),
+        ("/workspace/unknown", "additionalProperties"),
+    ]
+
+def test_required_errors_point_to_each_missing_field() -> None:
+    document = _definition(workspace={})
+    del document["providers"]
+    assert [item.pointer for item in validate_harness_definition(document)] == [
+        "/providers", "/workspace/root"
+    ]
+
+def test_wrong_type_is_rejected_without_coercion_or_mutation() -> None:
+    document = _definition(workspace={"root": 7})
+    before = copy.deepcopy(document)
+    assert _pairs(document) == [("/workspace/root", "type")]
+    assert document == before
+    assert document["workspace"] == {"root": 7}
+
+def test_v2_open_dynamic_maps_remain_open_through_canonical_refs() -> None:
+    document = _definition(
+        dossier={"arbitrary": {"nested": [1, True, None]}},
+        tools={
+            "aliases": {"author-name": "runtime-name"},
+            "dialects": {"selection": {"by_model": {"dynamic-model": ["dialect-a"]}}},
+        },
+    )
+    assert validate_harness_definition(document) == ()
+
+@pytest.mark.parametrize(
+    ("schema_version", "version", "expected"),
+    [
+        (
+            "bb.unknown.v9",
+            9,
+            [
+                ("/schema_version", "unsupported_schema_version"),
+                ("/version", "unsupported_version"),
+            ],
+        ),
+        ("bb.harness_definition.v1", 2, [("/version", "unsupported_version")]),
+        ("bb.agent_config_surface.v2", 1, [("/version", "unsupported_version")]),
+        ("bb.harness_definition.v1", "1", [("/version", "unsupported_version")]),
+    ],
+)
+def test_unsupported_and_mismatched_source_pairs_fail_closed(
+    schema_version: object, version: object, expected: list[tuple[str, str]]
+) -> None:
+    assert _pairs(_definition(schema_version=schema_version, version=version)) == expected
+
+def test_missing_discriminators_fail_before_schema_validation() -> None:
+    document = _definition(unknown=True)
+    del document["schema_version"]
+    del document["version"]
+    assert _pairs(document) == [
+        ("/schema_version", "required"), ("/version", "required")
+    ]
+
+def test_loading_yaml_requires_a_mapping_root(tmp_path: Path) -> None:
+    path = tmp_path / "not-a-mapping.yaml"
+    path.write_text("- one\n- two\n", encoding="utf-8")
+    with pytest.raises(HarnessDefinitionValidationError) as raised:
+        load_harness_definition(path)
+    assert raised.value.findings == (
+        ValidationFinding("/", "type", "Harness definition must be a mapping"),
+    )
+
+def test_loading_valid_yaml_returns_canonical_model(tmp_path: Path) -> None:
+    path = tmp_path / "harness.yaml"
+    path.write_text(
+        """schema_version: bb.harness_definition.v1
+version: 1
+workspace: {root: .}
+providers: {default_model: main, models: [{id: main, adapter: openai}]}
+modes: [{name: build}]
+loop: {sequence: [{mode: build}]}
+""",
+        encoding="utf-8",
+    )
+    loaded = load_harness_definition(path)
+    assert isinstance(loaded, HarnessDefinition)
+    assert loaded["schema_version"] == "bb.harness_definition.v1"
+
+def test_findings_are_immutable_and_orderable() -> None:
+    later = ValidationFinding("/z", "type", "later")
+    earlier = ValidationFinding("/a", "required", "earlier")
+    assert sorted((later, earlier)) == [earlier, later]
+    with pytest.raises(FrozenInstanceError):
+        earlier.pointer = "/changed"  # type: ignore[misc]


### PR DESCRIPTION
## Scope
Implements packet `bb-06u.2` (NS01) at packet hash `sha256:4ad60e581d7ea839f8e2aad058c875e6ffe21d6d0dbcfea9e3a9fe6a8af859a5`:
- immutable, mapping-like Harness Definition author model with exact supported-JSON round trips and deterministic canonical JSON
- stable detached-snapshot construction; stored content is the same content validated, with copying bounded before the public depth limit
- strict pointer-sorted validator for canonical `bb.harness_definition.v1`/1 and known legacy `bb.agent_config_surface.v2`/2
- project-owned exact diagnostics, compatible combinator leaf expansion, escaped pointers, JSON-domain/cycle/finite-number/host-stable bounded-integer/depth rejection
- public Draft 2020-12 schema reusing the frozen V2 nested grammar by canonical refs
- 15-line canonical minimal template and hermetic dependency-resolution-free isolated non-editable wheel resource loading
- actual minimal and complex V2 fixture behavior locks

Non-goals remain lock generation, execution, new top-level concepts, activation, and score promotion.

Compat reviewed: non-breaking. The new V3 template and author module do not alter existing V1/V2 runtime projections or compatibility fixtures.

Frozen base: `fd320bcab313653dbaa731522720441351adea80`
Final candidate head: `a20987ef6ac3bb789b7d42091ab6ec0d6d81dac8`
Tree-equivalent reviewed code head: `5455dee0b77f2b6c7281a1846bf5c9ec5e160347`; `a20987ef` is an empty compatibility-acknowledgement commit.
Packet size: 9 files, +799/-1 = 800 changed lines (within 20-file/800-line gate).

Exact code verification: complete harness packet 43 passed, including isolated `--no-deps --target` wheel install/import, stable mutation-on-read snapshot construction, 1,200-level fail-closed depth handling, equivalent-discriminator diagnostics, configured-low-limit ±640-digit canonicalization, and exact JSON depth boundary. Standards and Spec reviews approved the exact tree with zero P0/P1/P2/Q; final GitHub checks are pending.