### PR TITLE
NS02: effective Harness Lock and explanation compiler

### DIFF
--- a/agentic_coder_prototype/compilation/v2_loader.py
+++ b/agentic_coder_prototype/compilation/v2_loader.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Union
 
 from jsonschema import Draft202012Validator
 from breadboard.product.harness.compile import HarnessCompilation, compile_harness_definition
-from breadboard.product.harness.validate import parse_harness_definition
 
 from .effective_config_graph import sha256_json
 
@@ -381,7 +380,6 @@ def _config_view_from_compilation(compilation: HarnessCompilation, config_path: 
     effective_doc = compilation.resolved_author_dict()
     surface_schema_version = _surface_schema_version(effective_doc)
     if surface_schema_version == "bb.harness_definition.v1":
-        parse_harness_definition(effective_doc)
         runtime_doc = _normalize_for_runtime(effective_doc)
     elif surface_schema_version == "bb.agent_config_surface.v2":
         _validate_v2(effective_doc)
@@ -539,7 +537,6 @@ def load_agent_config(config_path_str: str) -> Dict[str, Any]:
 
     surface_schema_version = _surface_schema_version(doc)
     if surface_schema_version == "bb.harness_definition.v1":
-        parse_harness_definition(doc)
         legacy_doc = _normalize_for_runtime(doc)
     elif surface_schema_version == "bb.agent_config_surface.v2":
         _validate_v2(doc)

--- a/agentic_coder_prototype/compilation/v2_loader.py
+++ b/agentic_coder_prototype/compilation/v2_loader.py
@@ -7,11 +7,13 @@ import os
 from collections.abc import Iterator, Mapping
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, Union
 
 from jsonschema import Draft202012Validator
+from breadboard.product.harness.compile import HarnessCompilation, compile_harness_definition
+from breadboard.product.harness.validate import parse_harness_definition
 
-from .effective_config_graph import compile_effective_config_graph, sha256_json
+from .effective_config_graph import sha256_json
 
 _VALID_CONFIG_AUTHORITIES = {"config", "parity", "effective"}
 
@@ -96,6 +98,19 @@ def _load_yaml(path: Union[str, Path]) -> Dict[str, Any]:
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f) or {}
 
+def _load_config_ref(parent_source_ref: str, declared_ref: str) -> tuple[str, Dict[str, Any]]:
+    ref_path = Path(declared_ref)
+    resolved = ref_path.resolve() if ref_path.is_absolute() else (Path(parent_source_ref).parent / ref_path).resolve()
+    document = _load_yaml(resolved)
+    if not isinstance(document, dict):
+        raise ValueError(f"extended agent config must be a mapping: {resolved}")
+    return str(resolved), document
+
+def _compile_config(raw: object, config_path: Path) -> HarnessCompilation:
+    if not isinstance(raw, dict):
+        raise ValueError("agent config must be a mapping")
+    return compile_harness_definition(raw, source_ref=str(config_path.resolve()), load_ref=_load_config_ref)
+
 
 
 def _repo_root() -> Path:
@@ -122,6 +137,8 @@ def _surface_schema_version(doc: Mapping[str, Any]) -> str:
         return "bb.agent_config_surface.v1"
     if schema_version == "bb.agent_config_surface.v2":
         return "bb.agent_config_surface.v2"
+    if schema_version == "bb.harness_definition.v1":
+        return "bb.harness_definition.v1"
     raise ValueError(f"unsupported agent config surface schema_version: {schema_version}")
 
 def _has_agent_config_version_2(doc: Mapping[str, Any]) -> bool:
@@ -358,157 +375,33 @@ def _validate_schema_less_v2_compatibility(doc: Dict[str, Any]) -> None:
             _compat_number(tier, "timeout_seconds", f"{path}.timeout_seconds", positive=True)
             _compat_bool(tier, "hard_fail", f"{path}.hard_fail")
 
-def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Merge two dicts recursively. Lists/tuples are replaced, not merged.
-    Scalars replace.
-    """
-    out: Dict[str, Any] = dict(base)
-    for k, v in (override or {}).items():
-        if k not in out:
-            out[k] = v
-            continue
-        if isinstance(out[k], dict) and isinstance(v, dict):
-            out[k] = _deep_merge(out[k], v)
-        else:
-            out[k] = v
-    return out
 
 
-def _resolve_extends(doc: Dict[str, Any], config_path: Path) -> Dict[str, Any]:
-    """Resolve one or more levels of `extends` declarations.
-
-    Supports single string or list for `extends`, and resolves nested bases
-    recursively so that the final document contains all inherited sections
-    (e.g., `version`, `tools`, `modes`, `loop`).
-    """
-    extends_val = doc.get("extends")
-    if not extends_val:
-        return doc
-
-    base_docs: List[Dict[str, Any]] = []
-    if isinstance(extends_val, (list, tuple)):
-        paths = list(extends_val)
-    else:
-        paths = [extends_val]
-
-    for rel in paths:
-        base_path = (config_path.parent / str(rel)).resolve()
-        base_raw = _load_yaml(base_path)
-        # Recursively resolve base's own extends if present
-        base_resolved = _resolve_extends(base_raw, base_path) if isinstance(base_raw, dict) and base_raw.get("extends") else base_raw
-        base_docs.append(base_resolved)
-
-    merged: Dict[str, Any] = {}
-    for b in base_docs:
-        merged = _deep_merge(merged, b)
-    merged = _deep_merge(merged, {k: v for k, v in doc.items() if k != "extends"})
-    return merged
-
-
-def _extends_paths(doc: Mapping[str, Any]) -> list[str]:
-    extends_val = doc.get("extends")
-    if not extends_val:
-        return []
-    if isinstance(extends_val, (list, tuple)):
-        return [str(item) for item in extends_val]
-    return [str(extends_val)]
-
-
-def _config_graph_layers(doc: Dict[str, Any], config_path: Path, *, _seen: tuple[Path, ...] = ()) -> list[Dict[str, Any]]:
-    layers: list[Dict[str, Any]] = []
-    _append_config_graph_layers(doc, config_path, layers, _seen=_seen)
-    return layers
-
-
-def _append_config_graph_layers(
-    doc: Dict[str, Any],
-    config_path: Path,
-    layers: list[Dict[str, Any]],
-    *,
-    _seen: tuple[Path, ...] = (),
-) -> None:
-    resolved_path = config_path.resolve()
-    if resolved_path in _seen:
-        chain = " -> ".join(str(path) for path in (*_seen, resolved_path))
-        raise ValueError(f"cyclic config extends chain: {chain}")
-
-    for rel in _extends_paths(doc):
-        base_path = (config_path.parent / rel).resolve()
-        base_raw = _load_yaml(base_path)
-        _append_config_graph_layers(base_raw, base_path, layers, _seen=(*_seen, resolved_path))
-
-    layer_values = {key: value for key, value in doc.items() if key not in {"extends", "dossier"}}
-    order = len(layers)
-    layers.append(
-        {
-            "layer_id": f"agent-config:{order:04d}:{config_path.name}",
-            "source_kind": "project",
-            "scope": "agent",
-            "precedence": order * 10,
-            "source_ref": str(config_path),
-            "layer_hash": sha256_json(layer_values),
-            "values": layer_values,
-        }
-    )
-
-
-def _effective_values_to_dict(effective_values: list[Mapping[str, Any]]) -> Dict[str, Any]:
-    out: Dict[str, Any] = {}
-    for item in effective_values:
-        dotted_path = str(item.get("path") or "")
-        if not dotted_path:
-            continue
-        current: Dict[str, Any] = out
-        parts = dotted_path.split(".")
-        for part in parts[:-1]:
-            next_value = current.get(part)
-            if not isinstance(next_value, dict):
-                next_value = {}
-                current[part] = next_value
-            current = next_value
-        current[parts[-1]] = copy.deepcopy(item.get("value"))
-    return out
-
-
-def build_config_view(config_path_str: str) -> ConfigView:
-    """Build the v2 ConfigView foundation without changing legacy defaults."""
-
-    config_path = _resolve_config_path(config_path_str)
-    raw = _load_yaml(config_path)
-    if not isinstance(raw, dict):
-        raise ValueError("agent config must be a mapping")
-
-    effective_doc = _resolve_extends(raw, config_path) if raw.get("extends") else copy.deepcopy(raw)
+def _config_view_from_compilation(compilation: HarnessCompilation, config_path: Path) -> ConfigView:
+    effective_doc = compilation.resolved_author_dict()
     surface_schema_version = _surface_schema_version(effective_doc)
-    if surface_schema_version == "bb.agent_config_surface.v2":
+    if surface_schema_version == "bb.harness_definition.v1":
+        parse_harness_definition(effective_doc)
+        runtime_doc = _normalize_for_runtime(effective_doc)
+    elif surface_schema_version == "bb.agent_config_surface.v2":
         _validate_v2(effective_doc)
         runtime_doc = _normalize_for_runtime(effective_doc)
-    else:
-        if _has_agent_config_version_2(effective_doc):
-            if _env_truthy("AGENT_SCHEMA_V2_ENABLED"):
-                _validate_schema_less_v2_compatibility(effective_doc)
-                runtime_doc = _normalize_for_runtime(effective_doc)
-            else:
-                _validate_agent_config_surface(effective_doc, "bb.agent_config_surface.v1")
-                runtime_doc = effective_doc
+    elif _has_agent_config_version_2(effective_doc):
+        if _env_truthy("AGENT_SCHEMA_V2_ENABLED"):
+            _validate_schema_less_v2_compatibility(effective_doc)
+            runtime_doc = _normalize_for_runtime(effective_doc)
         else:
+            _validate_agent_config_surface(effective_doc, "bb.agent_config_surface.v1")
             runtime_doc = effective_doc
+    else:
+        runtime_doc = effective_doc
+    return ConfigView(runtime_doc, graph=compilation.lock.as_dict(), config_path=config_path)
 
-    layers = _config_graph_layers(raw, config_path)
-    graph = compile_effective_config_graph(
-        graph_id=f"agent_config:{config_path.stem}",
-        layers=layers,
-        migrations=[
-            {
-                "migration_id": "agent-config-yaml-to-effective-config-graph-v1",
-                "from_version": "agent-config-yaml",
-                "to_version": "bb.effective_config_graph.v1",
-                "applied": True,
-            }
-        ],
-    )
-    return ConfigView(runtime_doc, graph=graph, config_path=config_path)
+def build_config_view(config_path_str: str) -> ConfigView:
+    """Compile one product-owned result and adapt it to the legacy read-only view."""
+    config_path = _resolve_config_path(config_path_str)
+    compilation = _compile_config(_load_yaml(config_path), config_path)
+    return _config_view_from_compilation(compilation, config_path)
 
 
 def load_agent_config_view(config_path_str: str) -> ConfigView:
@@ -639,14 +532,16 @@ def load_agent_config(config_path_str: str) -> Dict[str, Any]:
     """
     config_path = _resolve_config_path(config_path_str)
     raw = _load_yaml(config_path)
-
-    # Prefer resolving extends first (so child files inherit version/mode/loop)
-    doc = _resolve_extends(raw, config_path) if (isinstance(raw, dict) and raw.get("extends")) else raw
+    compilation = _compile_config(raw, config_path)
+    doc = compilation.resolved_author_dict()
 
 
 
     surface_schema_version = _surface_schema_version(doc)
-    if surface_schema_version == "bb.agent_config_surface.v2":
+    if surface_schema_version == "bb.harness_definition.v1":
+        parse_harness_definition(doc)
+        legacy_doc = _normalize_for_runtime(doc)
+    elif surface_schema_version == "bb.agent_config_surface.v2":
         _validate_v2(doc)
         legacy_doc = _normalize_for_runtime(doc)
     else:
@@ -672,7 +567,7 @@ def load_agent_config(config_path_str: str) -> Dict[str, Any]:
     if authority == "config":
         return legacy_doc
 
-    view = build_config_view(str(config_path))
+    view = _config_view_from_compilation(compilation, config_path)
     effective_doc = view.as_dict()
     if legacy_doc != effective_doc:
         _log_config_divergence(config_path, legacy_doc, effective_doc, logger=active_logger)

--- a/breadboard/product/harness/compile.py
+++ b/breadboard/product/harness/compile.py
@@ -1,0 +1,261 @@
+"""Deterministic product-owned Harness Definition compilation."""
+from __future__ import annotations
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import PurePath
+from typing import Any
+from .explain import HarnessExplanation
+from .lock import EffectiveHarnessLock, _copy, graph_content_hash, sha256_json
+from .model import HarnessDefinition
+LoadReference = Callable[[str, str], tuple[str, Mapping[str, Any]]]
+class HarnessCompileError(ValueError):
+    """Raised before a compilation exists when an input cannot be resolved."""
+@dataclass(frozen=True, slots=True, init=False)
+class HarnessCompilation:
+    """One immutable authority projected as values, lock, and explanation."""
+    lock: EffectiveHarnessLock
+    explanation: HarnessExplanation
+    _effective: Mapping[str, Any] = field(repr=False)
+    _resolved_author: Mapping[str, Any] = field(repr=False)
+    @classmethod
+    def _create(cls, effective: Mapping[str, Any], author: Mapping[str, Any],
+                lock: EffectiveHarnessLock, explanation: HarnessExplanation):
+        instance = object.__new__(cls)
+        object.__setattr__(instance, "lock", lock)
+        object.__setattr__(instance, "explanation", explanation)
+        object.__setattr__(instance, "_effective", _copy(effective, freeze=True))
+        object.__setattr__(instance, "_resolved_author", _copy(author, freeze=True))
+        return instance
+    def as_dict(self) -> dict[str, Any]:
+        return _copy(self._effective, freeze=False)
+    def resolved_author_dict(self) -> dict[str, Any]:
+        return _copy(self._resolved_author, freeze=False)
+def _mapping(value: Mapping[str, Any], label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise HarnessCompileError(f"{label} must be a mapping")
+    try:
+        return _copy(value, freeze=False)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise HarnessCompileError(f"{label} is not canonical JSON: {error}") from None
+def _refs(document: Mapping[str, Any], source_ref: str) -> tuple[str, ...]:
+    if "extends" not in document:
+        return ()
+    declared = document["extends"]
+    values = declared if isinstance(declared, (list, tuple)) else (declared,)
+    refs: list[str] = []
+    for value in values:
+        if not isinstance(value, str) or not value.strip():
+            raise HarnessCompileError(f"invalid reference declared by {source_ref}")
+        refs.append(value)
+    return tuple(refs)
+def _runtime_values(document: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in document.items()
+            if key not in {"extends", "dossier"}}
+def _merge(current: Any, sources: Any, incoming: Any, layer_id: str) -> tuple[Any, Any]:
+    if isinstance(incoming, Mapping):
+        values = dict(current) if isinstance(current, Mapping) else {}
+        provenance = dict(sources) if isinstance(sources, Mapping) else {}
+        for key in sorted(incoming):
+            values[key], provenance[key] = _merge(
+                values.get(key), provenance.get(key), incoming[key], layer_id)
+        return values, provenance
+    return _copy(incoming, freeze=False), layer_id
+def _flatten(values: Any, sources: Any, prefix: str = "") -> list[tuple[str, Any, str]]:
+    if isinstance(sources, str):
+        return [(prefix, _copy(values, freeze=False), sources)]
+    rows: list[tuple[str, Any, str]] = []
+    if isinstance(values, Mapping):
+        for key in sorted(values):
+            path = f"{prefix}.{key}" if prefix else key
+            rows.extend(_flatten(values[key],
+                                 sources.get(key) if isinstance(sources, Mapping) else None,
+                                 path))
+    return rows
+def _kind(value: Any) -> str:
+    if value is None:
+        return "null"
+    if type(value) is bool:
+        return "boolean"
+    if type(value) in (int, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, Mapping):
+        return "object"
+    return "array"
+def _summary(values: Mapping[str, Any], extends_chain: Sequence[str]) -> dict[str, Any]:
+    providers = values.get("providers")
+    modes = values.get("modes")
+    prompts = values.get("prompts")
+    mode_rows = modes if isinstance(modes, list) else []
+    tools = {tool for mode in mode_rows if isinstance(mode, Mapping)
+             for tool in mode.get("tools_enabled", ())
+             if isinstance(tool, str)}
+    def strings(value: Any) -> list[str]:
+        if isinstance(value, str):
+            return [value] if value else []
+        if isinstance(value, Mapping):
+            return [item for key in sorted(value) for item in strings(value[key])]
+        if isinstance(value, list):
+            return [item for child in value for item in strings(child)]
+        return []
+    return {
+        "provider_default_model": str(providers.get("default_model", ""))
+        if isinstance(providers, Mapping) else "",
+        "mode_ids": sorted(str(mode["name"]) for mode in mode_rows
+                           if isinstance(mode, Mapping) and "name" in mode),
+        "tool_count": len(tools), "prompt_files": sorted(strings(prompts)),
+        "extends_chain": list(extends_chain),
+    }
+def compile_harness_definition(
+    definition: Mapping[str, Any] | HarnessDefinition, *, source_ref: str,
+    load_ref: LoadReference | None = None, defaults: Mapping[str, Any] | None = None,
+    overlays: Sequence[Mapping[str, Any]] = (),
+) -> HarnessCompilation:
+    """Resolve, merge, hash, and freeze one Harness Definition."""
+    if not isinstance(source_ref, str) or not source_ref.strip():
+        raise HarnessCompileError("source_ref must be a non-empty string")
+    root = _mapping(definition.as_dict() if isinstance(definition, HarnessDefinition)
+                    else definition, "definition")
+    layers: list[tuple[dict[str, Any], dict[str, Any], dict[str, Any] | None]] = []
+    extends_chain: list[str] = []
+    source_hashes = {source_ref: sha256_json(root)}
+    source_number = 0
+
+    def add_source(document: dict[str, Any], ref: str) -> None:
+        nonlocal source_number
+        name = PurePath(ref).name or "source"
+        record = {
+            "host_visible": True, "layer_hash": sha256_json(document),
+            "layer_id": f"agent-config:{source_number:04d}:{name}",
+            "model_visible": True, "scope": "agent", "source_kind": "project",
+            "source_ref": ref,
+        }
+        source_number += 1
+        layers.append((record, _runtime_values(document),
+                       {key: value for key, value in document.items() if key != "extends"}))
+
+    def visit(document: dict[str, Any], ref: str, stack: tuple[str, ...]) -> None:
+        for declared in _refs(document, ref):
+            if load_ref is None:
+                raise HarnessCompileError(f"no loader for reference {declared!r} from {ref!r}")
+            try:
+                resolved, loaded = load_ref(ref, declared)
+            except (FileNotFoundError, KeyError):
+                raise HarnessCompileError(
+                    f"missing reference {declared!r} from {ref!r}") from None
+            except Exception:
+                raise HarnessCompileError(
+                    f"failed to load reference {declared!r} from {ref!r}") from None
+            if not isinstance(resolved, str) or not resolved.strip():
+                raise HarnessCompileError("loader returned an invalid resolved reference")
+            child = _mapping(loaded, f"reference {resolved!r}")
+            digest = sha256_json(child)
+            prior = source_hashes.setdefault(resolved, digest)
+            if prior != digest:
+                raise HarnessCompileError(f"inconsistent content for resolved reference {resolved!r}")
+            if resolved in stack:
+                raise HarnessCompileError(
+                    "cyclic reference: " + " -> ".join((*stack, resolved)))
+            extends_chain.append(resolved)
+            visit(child, resolved, (*stack, resolved))
+        add_source(document, ref)
+
+    if defaults is not None:
+        default = _mapping(defaults, "defaults")
+        layers.append(({
+            "host_visible": True, "layer_hash": sha256_json(default),
+            "layer_id": "harness-default:0000", "model_visible": True,
+            "scope": "agent", "source_kind": "default", "source_ref": None,
+        }, _runtime_values(default), None))
+    visit(root, source_ref, (source_ref,))
+    for index, overlay in enumerate(overlays):
+        value = _mapping(overlay, f"overlay {index}")
+        layers.append(({
+            "host_visible": True, "layer_hash": sha256_json(value),
+            "layer_id": f"harness-overlay:{index:04d}", "model_visible": True,
+            "scope": "agent", "source_kind": "runtime", "source_ref": f"overlay:{index}",
+        }, _runtime_values(value), None))
+
+    effective: Any = {}
+    provenance: Any = {}
+    author: Any = {}
+    author_sources: Any = {}
+    diagnostics: list[dict[str, Any]] = []
+    source_layers: list[dict[str, Any]] = []
+    for precedence, (record, values, authored) in enumerate(layers):
+        record["precedence"] = precedence * 10
+        source_layers.append(record)
+        if authored is not None:
+            author, author_sources = _merge(
+                author, author_sources, authored, record["layer_id"])
+        before = {path: source for path, _, source in _flatten(effective, provenance)}
+        effective, provenance = _merge(effective, provenance, values, record["layer_id"])
+        after = {path: source for path, _, source in _flatten(effective, provenance)}
+        if record["source_kind"] == "default":
+            diagnostics.extend(_effect(path, "info", "defaulted", record["layer_id"])
+                               for path, source in after.items()
+                               if source == record["layer_id"])
+        diagnostics.extend(_override(path, source, record["layer_id"])
+                           for path, source in before.items()
+                           if after.get(path) != source)
+
+    rows = _flatten(effective, provenance)
+    effective_values = [{
+        "env_gate_ids": [], "path": path, "source_layer_id": source,
+        "value": value, "value_kind": _kind(value), "visibility": "model-visible",
+    } for path, value, source in rows]
+    for path, value, source in rows:
+        diagnostics.append(_effect(path, "info", "selected", source))
+        if (path == "capabilities" or path.startswith("capabilities.")
+                or ".capabilities." in path or path.endswith(".capabilities")):
+            effect = "capability_enabled" if value is True else "capability_configured"
+            diagnostics.append(_effect(path, "info", effect, source))
+            if value is False:
+                diagnostics.append(_effect(
+                    path, "warning", "capability_disabled", source, blocker=True))
+
+    graph = {
+        "effective_values": effective_values, "env_gates": [], "graph_hash": None,
+        "graph_id": f"agent_config:{PurePath(source_ref).stem or 'harness'}",
+        "merge_policy": {"conflict_resolution": "highest-precedence",
+                         "policy_id": "precedence_order_deep_merge",
+                         "strategy": "deep-merge"},
+        "migrations": [{"applied": True, "from_version": "agent-config-yaml",
+                        "migration_id": "agent-config-yaml-to-effective-config-graph-v1",
+                        "to_version": "bb.effective_config_graph.v1"}],
+        "schema_version": "bb.effective_config_graph.v1", "source_layers": source_layers,
+        "visibility": {"host_only_paths": [], "model_visible_paths": [row[0] for row in rows],
+                       "redacted_paths": []},
+    }
+    graph["graph_hash"] = graph_content_hash(graph)
+    surface = effective.get("schema_version")
+    if surface not in {"bb.agent_config_surface.v1", "bb.agent_config_surface.v2"}:
+        surface = "bb.agent_config_surface.v1"
+    explanation_record = {
+        "schema_version": "bb.config_explanation.v1",
+        "explanation_id": "harness_explanation:" + sha256_json(source_ref)[7:23],
+        "config_path": source_ref, "config_sha256": sha256_json(author),
+        "generated_at_utc": "1970-01-01T00:00:00Z",
+        "surface_schema_version": surface, "resolved_summary": _summary(effective, extends_chain),
+        "fields": [{"classification": "operational", "consumer_ref": None,
+                    "path": path, "source_layer": source}
+                   for path, _, source in rows],
+        "diagnostics": sorted(diagnostics, key=lambda item: (item["path"], item["message"])),
+        "ok": True,
+    }
+    return HarnessCompilation._create(
+        effective, author, EffectiveHarnessLock._from_record(graph),
+        HarnessExplanation._from_record(explanation_record))
+
+
+def _effect(path: str, severity: str, effect: str, source: str,
+            *, blocker: bool = False) -> dict[str, Any]:
+    label = "blocker" if blocker else "effect"
+    return {"severity": severity, "class": "other", "path": path,
+            "message": f"{label}={effect}; source={source}"}
+
+
+def _override(path: str, source: str, winner: str) -> dict[str, Any]:
+    return {"severity": "info", "class": "other", "path": path,
+            "message": f"effect=overridden; source={source}; winner={winner}"}

--- a/breadboard/product/harness/compile.py
+++ b/breadboard/product/harness/compile.py
@@ -58,8 +58,11 @@ def _metadata_leaf(value: Any) -> bool:
 def _merge(current: Any, sources: Any, incoming: Any, layer_id: str,
            *, metadata: bool = True) -> tuple[Any, Any]:
     if metadata and _metadata_leaf(incoming):
-        meta = {key: _copy(value, freeze=False) for key, value in incoming.items()
-                if key != "value"}
+        meta = {key: _copy(value, freeze=False) for key, value in incoming.items() if key != "value"}
+        if "env_name" in meta and (not isinstance(meta["env_name"], str) or not meta["env_name"]):
+            raise HarnessCompileError("env_name metadata must be a non-empty string")
+        if "env_satisfied" in meta and type(meta["env_satisfied"]) is not bool:
+            raise HarnessCompileError("env_satisfied metadata must be a boolean")
         return _copy(incoming["value"], freeze=False), (layer_id, meta)
     if isinstance(incoming, Mapping):
         if not incoming and (not isinstance(current, Mapping) or not current):
@@ -129,20 +132,19 @@ def compile_harness_definition(
     extends_chain: list[str] = []
     source_hashes = {source_ref: sha256_json(root)}
     source_number = 0
-
     def add_source(document: dict[str, Any], ref: str) -> None:
         nonlocal source_number
         name = PurePath(ref).name or "source"
+        values = _runtime_values(document)
         record = {
-            "host_visible": True, "layer_hash": sha256_json(document),
+            "host_visible": True, "layer_hash": sha256_json(values),
             "layer_id": f"agent-config:{source_number:04d}:{name}",
             "model_visible": True, "scope": "agent", "source_kind": "project",
             "source_ref": ref,
         }
         source_number += 1
-        layers.append((record, _runtime_values(document),
+        layers.append((record, values,
                        {key: value for key, value in document.items() if key != "extends"}))
-
     def visit(document: dict[str, Any], ref: str, stack: tuple[str, ...]) -> None:
         for declared in _refs(document, ref):
             if load_ref is None:
@@ -170,20 +172,20 @@ def compile_harness_definition(
         add_source(document, ref)
 
     if defaults is not None:
-        default = _mapping(defaults, "defaults")
+        default = _runtime_values(_mapping(defaults, "defaults"))
         layers.append(({
             "host_visible": True, "layer_hash": sha256_json(default),
             "layer_id": "harness-default:0000", "model_visible": True,
             "scope": "agent", "source_kind": "default", "source_ref": None,
-        }, _runtime_values(default), None))
+        }, default, None))
     visit(root, source_ref, (source_ref,))
     for index, overlay in enumerate(overlays):
-        value = _mapping(overlay, f"overlay {index}")
+        value = _runtime_values(_mapping(overlay, f"overlay {index}"))
         layers.append(({
             "host_visible": True, "layer_hash": sha256_json(value),
             "layer_id": f"harness-overlay:{index:04d}", "model_visible": True,
             "scope": "agent", "source_kind": "runtime", "source_ref": f"overlay:{index}",
-        }, _runtime_values(value), None))
+        }, value, None))
 
     effective: Any = {}
     provenance: Any = {}
@@ -246,8 +248,8 @@ def compile_harness_definition(
     redacted_paths = [row["path"] for row in effective_values
                       if row["visibility"] == "redacted"]
     graph = {
-        "effective_values": effective_values, "env_gates": list(env_gates.values()),
-        "graph_hash": None,
+        "effective_values": effective_values,
+        "env_gates": [env_gates[key] for key in sorted(env_gates)], "graph_hash": None,
         "graph_id": f"agent_config:{PurePath(source_ref).stem or 'harness'}",
         "merge_policy": {"conflict_resolution": "highest-precedence",
                          "policy_id": "precedence_order_deep_merge",

--- a/breadboard/product/harness/compile.py
+++ b/breadboard/product/harness/compile.py
@@ -7,6 +7,7 @@ from typing import Any
 from .explain import HarnessExplanation
 from .lock import EffectiveHarnessLock, _copy, graph_content_hash, sha256_json
 from .model import HarnessDefinition
+from .validate import HarnessDefinitionValidationError, parse_harness_definition
 LoadReference = Callable[[str, str], tuple[str, Mapping[str, Any]]]
 class HarnessCompileError(ValueError):
     """Raised before a compilation exists when an input cannot be resolved."""
@@ -51,19 +52,30 @@ def _refs(document: Mapping[str, Any], source_ref: str) -> tuple[str, ...]:
 def _runtime_values(document: Mapping[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in document.items()
             if key not in {"extends", "dossier"}}
-def _merge(current: Any, sources: Any, incoming: Any, layer_id: str) -> tuple[Any, Any]:
+def _metadata_leaf(value: Any) -> bool:
+    return isinstance(value, Mapping) and "value" in value and (
+        "env_name" in value or "env_satisfied" in value)
+def _merge(current: Any, sources: Any, incoming: Any, layer_id: str,
+           *, metadata: bool = True) -> tuple[Any, Any]:
+    if metadata and _metadata_leaf(incoming):
+        meta = {key: _copy(value, freeze=False) for key, value in incoming.items()
+                if key != "value"}
+        return _copy(incoming["value"], freeze=False), (layer_id, meta)
     if isinstance(incoming, Mapping):
+        if not incoming and (not isinstance(current, Mapping) or not current):
+            return {}, (layer_id, {})
         values = dict(current) if isinstance(current, Mapping) else {}
         provenance = dict(sources) if isinstance(sources, Mapping) else {}
         for key in sorted(incoming):
             values[key], provenance[key] = _merge(
-                values.get(key), provenance.get(key), incoming[key], layer_id)
+                values.get(key), provenance.get(key), incoming[key], layer_id,
+                metadata=metadata)
         return values, provenance
-    return _copy(incoming, freeze=False), layer_id
-def _flatten(values: Any, sources: Any, prefix: str = "") -> list[tuple[str, Any, str]]:
-    if isinstance(sources, str):
-        return [(prefix, _copy(values, freeze=False), sources)]
-    rows: list[tuple[str, Any, str]] = []
+    return _copy(incoming, freeze=False), (layer_id, {})
+def _flatten(values: Any, sources: Any, prefix: str = "") -> list[tuple[str, Any, str, dict[str, Any]]]:
+    if isinstance(sources, tuple):
+        return [(prefix, _copy(values, freeze=False), sources[0], sources[1])]
+    rows: list[tuple[str, Any, str, dict[str, Any]]] = []
     if isinstance(values, Mapping):
         for key in sorted(values):
             path = f"{prefix}.{key}" if prefix else key
@@ -71,26 +83,21 @@ def _flatten(values: Any, sources: Any, prefix: str = "") -> list[tuple[str, Any
                                  sources.get(key) if isinstance(sources, Mapping) else None,
                                  path))
     return rows
+def _source_rows(sources: Any, prefix: str = "") -> list[tuple[str, str]]:
+    if isinstance(sources, tuple):
+        return [(prefix, sources[0])]
+    return [(item) for key in sorted(sources) for item in _source_rows(
+        sources[key], f"{prefix}.{key}" if prefix else key)] if isinstance(sources, Mapping) else []
 def _kind(value: Any) -> str:
-    if value is None:
-        return "null"
-    if type(value) is bool:
-        return "boolean"
-    if type(value) in (int, float):
-        return "number"
-    if isinstance(value, str):
-        return "string"
-    if isinstance(value, Mapping):
-        return "object"
-    return "array"
+    kind = type(value)
+    return ("null" if value is None else "boolean" if kind is bool
+            else "number" if kind in (int, float) else "string"
+            if isinstance(value, str) else "object" if isinstance(value, Mapping) else "array")
 def _summary(values: Mapping[str, Any], extends_chain: Sequence[str]) -> dict[str, Any]:
-    providers = values.get("providers")
-    modes = values.get("modes")
-    prompts = values.get("prompts")
+    providers, modes, prompts = (values.get(key) for key in ("providers", "modes", "prompts"))
     mode_rows = modes if isinstance(modes, list) else []
     tools = {tool for mode in mode_rows if isinstance(mode, Mapping)
-             for tool in mode.get("tools_enabled", ())
-             if isinstance(tool, str)}
+             for tool in mode.get("tools_enabled", ()) if isinstance(tool, str)}
     def strings(value: Any) -> list[str]:
         if isinstance(value, str):
             return [value] if value else []
@@ -99,12 +106,13 @@ def _summary(values: Mapping[str, Any], extends_chain: Sequence[str]) -> dict[st
         if isinstance(value, list):
             return [item for child in value for item in strings(child)]
         return []
+    packs = prompts.get("packs") if isinstance(prompts, Mapping) else None
     return {
         "provider_default_model": str(providers.get("default_model", ""))
         if isinstance(providers, Mapping) else "",
         "mode_ids": sorted(str(mode["name"]) for mode in mode_rows
                            if isinstance(mode, Mapping) and "name" in mode),
-        "tool_count": len(tools), "prompt_files": sorted(strings(prompts)),
+        "tool_count": len(tools), "prompt_files": sorted(set(strings(packs))),
         "extends_chain": list(extends_chain),
     }
 def compile_harness_definition(
@@ -188,10 +196,10 @@ def compile_harness_definition(
         source_layers.append(record)
         if authored is not None:
             author, author_sources = _merge(
-                author, author_sources, authored, record["layer_id"])
-        before = {path: source for path, _, source in _flatten(effective, provenance)}
+                author, author_sources, authored, record["layer_id"], metadata=False)
+        before = dict(_source_rows(provenance))
         effective, provenance = _merge(effective, provenance, values, record["layer_id"])
-        after = {path: source for path, _, source in _flatten(effective, provenance)}
+        after = dict(_source_rows(provenance))
         if record["source_kind"] == "default":
             diagnostics.extend(_effect(path, "info", "defaulted", record["layer_id"])
                                for path, source in after.items()
@@ -200,12 +208,32 @@ def compile_harness_definition(
                            for path, source in before.items()
                            if after.get(path) != source)
 
+    if author.get("schema_version") == "bb.harness_definition.v1":
+        try:
+            parse_harness_definition(author)
+        except HarnessDefinitionValidationError as error:
+            raise HarnessCompileError(f"invalid Harness Definition: {error}") from None
     rows = _flatten(effective, provenance)
-    effective_values = [{
-        "env_gate_ids": [], "path": path, "source_layer_id": source,
-        "value": value, "value_kind": _kind(value), "visibility": "model-visible",
-    } for path, value, source in rows]
-    for path, value, source in rows:
+    if not rows or any(not path for path, *_ in rows):
+        raise HarnessCompileError("effective configuration must contain at least one value")
+    env_gates: dict[str, dict[str, Any]] = {}
+    effective_values: list[dict[str, Any]] = []
+    for path, value, source, metadata in rows:
+        env_name = metadata.get("env_name")
+        redacted = bool(env_name) or _looks_secret(path)
+        gate_ids = [f"env.{env_name}"] if env_name else []
+        if env_name:
+            env_gates[gate_ids[0]] = {"env_name": str(env_name), "gate_id": gate_ids[0],
+                                     "required": True,
+                                     "satisfied": bool(metadata.get("env_satisfied", False))}
+        effective_values.append({
+            "env_gate_ids": gate_ids, "path": path, "source_layer_id": source,
+            "value": (f"secret://env/{env_name}" if env_name else
+                      "secret://redacted/" + path.replace(".", "/")) if redacted else value,
+            "value_kind": "secret-ref" if redacted else _kind(value),
+            "visibility": "redacted" if redacted else "model-visible",
+        })
+    for path, value, source, _ in rows:
         diagnostics.append(_effect(path, "info", "selected", source))
         if (path == "capabilities" or path.startswith("capabilities.")
                 or ".capabilities." in path or path.endswith(".capabilities")):
@@ -215,8 +243,11 @@ def compile_harness_definition(
                 diagnostics.append(_effect(
                     path, "warning", "capability_disabled", source, blocker=True))
 
+    redacted_paths = [row["path"] for row in effective_values
+                      if row["visibility"] == "redacted"]
     graph = {
-        "effective_values": effective_values, "env_gates": [], "graph_hash": None,
+        "effective_values": effective_values, "env_gates": list(env_gates.values()),
+        "graph_hash": None,
         "graph_id": f"agent_config:{PurePath(source_ref).stem or 'harness'}",
         "merge_policy": {"conflict_resolution": "highest-precedence",
                          "policy_id": "precedence_order_deep_merge",
@@ -225,8 +256,10 @@ def compile_harness_definition(
                         "migration_id": "agent-config-yaml-to-effective-config-graph-v1",
                         "to_version": "bb.effective_config_graph.v1"}],
         "schema_version": "bb.effective_config_graph.v1", "source_layers": source_layers,
-        "visibility": {"host_only_paths": [], "model_visible_paths": [row[0] for row in rows],
-                       "redacted_paths": []},
+        "visibility": {"host_only_paths": [],
+                       "model_visible_paths": [row["path"] for row in effective_values
+                                               if row["visibility"] == "model-visible"],
+                       "redacted_paths": redacted_paths},
     }
     graph["graph_hash"] = graph_content_hash(graph)
     surface = effective.get("schema_version")
@@ -240,15 +273,18 @@ def compile_harness_definition(
         "surface_schema_version": surface, "resolved_summary": _summary(effective, extends_chain),
         "fields": [{"classification": "operational", "consumer_ref": None,
                     "path": path, "source_layer": source}
-                   for path, _, source in rows],
+                   for path, _, source, _ in rows],
         "diagnostics": sorted(diagnostics, key=lambda item: (item["path"], item["message"])),
         "ok": True,
     }
     return HarnessCompilation._create(
         effective, author, EffectiveHarnessLock._from_record(graph),
         HarnessExplanation._from_record(explanation_record))
-
-
+def _looks_secret(path: str) -> bool:
+    segments = (part.replace("-", "_") for part in path.lower().split("."))
+    return any(part in {"api_key", "apikey", "password", "secret", "token"}
+               or "api_key" in part or "apikey" in part
+               or part.endswith(("_password", "_secret", "_token")) for part in segments)
 def _effect(path: str, severity: str, effect: str, source: str,
             *, blocker: bool = False) -> dict[str, Any]:
     label = "blocker" if blocker else "effect"

--- a/breadboard/product/harness/explain.py
+++ b/breadboard/product/harness/explain.py
@@ -1,0 +1,11 @@
+"""Immutable explanation projection for one harness compilation."""
+
+from __future__ import annotations
+
+from .lock import _FrozenRecord
+
+
+class HarnessExplanation(_FrozenRecord):
+    """Recursively immutable ``bb.config_explanation.v1`` record."""
+
+    __slots__ = ()

--- a/breadboard/product/harness/lock.py
+++ b/breadboard/product/harness/lock.py
@@ -1,0 +1,76 @@
+"""Immutable effective-lock records and their canonical hash encoding."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any
+
+
+def _copy(value: Any, *, freeze: bool) -> Any:
+    if isinstance(value, Mapping):
+        if any(type(key) is not str for key in value):
+            raise TypeError("JSON object keys must be strings")
+        copied = {key: _copy(item, freeze=freeze) for key, item in value.items()}
+        return MappingProxyType(copied) if freeze else copied
+    if isinstance(value, (list, tuple)):
+        copied = [_copy(item, freeze=freeze) for item in value]
+        return tuple(copied) if freeze else copied
+    json.dumps(value, allow_nan=False)
+    return value
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Return the frozen graph records' canonical UTF-8 encoding."""
+    plain = _copy(value, freeze=False)
+    text = json.dumps(plain, allow_nan=False, ensure_ascii=False, indent=2,
+                      separators=(",", ": "), sort_keys=True) + "\n"
+    return text.encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def sha256_json(value: Any) -> str:
+    return sha256_bytes(canonical_json_bytes(value))
+
+
+def graph_content_hash(record: Mapping[str, Any]) -> str:
+    preimage = _copy(record, freeze=False)
+    preimage["graph_hash"] = None
+    return sha256_json(preimage)
+
+
+@dataclass(frozen=True, slots=True, init=False)
+class _FrozenRecord(Mapping[str, Any]):
+    _record: Mapping[str, Any] = field(repr=False)
+
+    @classmethod
+    def _from_record(cls, record: Mapping[str, Any]):
+        instance = object.__new__(cls)
+        object.__setattr__(instance, "_record", _copy(record, freeze=True))
+        return instance
+
+    def __getitem__(self, key: str) -> Any:
+        return self._record[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._record)
+
+    def __len__(self) -> int:
+        return len(self._record)
+
+    def as_dict(self) -> dict[str, Any]:
+        return _copy(self._record, freeze=False)
+
+    def canonical_json(self) -> str:
+        return canonical_json_bytes(self._record).decode("utf-8")
+
+
+class EffectiveHarnessLock(_FrozenRecord):
+    """Recursively immutable ``bb.effective_config_graph.v1`` record."""
+    __slots__ = ()

--- a/contracts/public/schemas/bb.effective_harness_lock.v1.schema.json
+++ b/contracts/public/schemas/bb.effective_harness_lock.v1.schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://breadboard.dev/contracts/public/schemas/bb.effective_harness_lock.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.effective_config_graph.v1.schema.json",
+  "description": "Public validation projection for the frozen Effective Harness Lock record role. Instances retain schema_version bb.effective_config_graph.v1.",
+  "title": "BreadBoard Effective Harness Lock V1"
+}

--- a/contracts/public/schemas/bb.harness_explanation_report.v1.schema.json
+++ b/contracts/public/schemas/bb.harness_explanation_report.v1.schema.json
@@ -1,0 +1,7 @@
+{
+  "$id": "https://breadboard.dev/contracts/public/schemas/bb.harness_explanation_report.v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "https://breadboard.dev/contracts/kernel/schemas/bb.config_explanation.v1.schema.json",
+  "description": "Public validation projection for the frozen explanation/effective-graph report role. Instances retain schema_version bb.config_explanation.v1.",
+  "title": "BreadBoard Harness Explanation Report V1"
+}

--- a/tests/product/harness/test_compile.py
+++ b/tests/product/harness/test_compile.py
@@ -1,21 +1,17 @@
 from __future__ import annotations
-
 import json
 from pathlib import Path
 from typing import Any
-
 import pytest
 from jsonschema import Draft202012Validator
 from referencing import Registry, Resource
 from agentic_coder_prototype.compilation.v2_loader import load_agent_config_view
-
+from agentic_coder_prototype.compilation.effective_config_graph import finalize_effective_config_graph
 from breadboard.product.harness.compile import (
     HarnessCompileError,
     compile_harness_definition,
 )
-
 ROOT = Path(__file__).resolve().parents[3]
-
 def _schema_errors(schema_name: str, record: dict[str, Any]) -> list[str]:
     directories = (ROOT / "contracts/public/schemas", ROOT / "contracts/kernel/schemas")
     schemas: dict[str, dict[str, Any]] = {}
@@ -28,7 +24,6 @@ def _schema_errors(schema_name: str, record: dict[str, Any]) -> list[str]:
                 registry = registry.with_resource(schema["$id"], Resource.from_contents(schema))
     return [error.message for error in
             Draft202012Validator(schemas[schema_name], registry=registry).iter_errors(record)]
-
 def test_recursive_merge_is_deterministic_and_keeps_author_dossier() -> None:
     documents = {
         ("root", "base"): ("base", {"extends": "deep", "nested": {"left": 1},
@@ -41,20 +36,18 @@ def test_recursive_merge_is_deterministic_and_keeps_author_dossier() -> None:
     first = compile_harness_definition(source, source_ref="root", load_ref=load)
     second = compile_harness_definition(
         dict(reversed(tuple(source.items()))), source_ref="root", load_ref=load)
-    assert first.lock.canonical_json() == second.lock.canonical_json()
-    assert first.lock["graph_hash"] == second.lock["graph_hash"]
+    changed = compile_harness_definition({**source, "dossier": {"owner": "changed"}}, source_ref="root", load_ref=load)
+    assert first.lock.canonical_json() == second.lock.canonical_json() == changed.lock.canonical_json()
     assert [layer["layer_id"] for layer in first.lock["source_layers"]] == [
         "agent-config:0000:deep", "agent-config:0001:base", "agent-config:0002:root"]
     assert first.as_dict() == {"items": [2],
                                "nested": {"deep": True, "left": 1, "right": 2}}
     assert first.resolved_author_dict()["dossier"] == {"owner": "root"}
     assert "extends" not in first.resolved_author_dict()
-
 @pytest.mark.parametrize("extends", ["", 3, [None]])
 def test_invalid_references_are_rejected(extends: Any) -> None:
     with pytest.raises(HarnessCompileError, match="invalid reference"):
         compile_harness_definition({"extends": extends}, source_ref="root")
-
 def test_missing_cyclic_and_inconsistent_references_are_rejected() -> None:
     with pytest.raises(HarnessCompileError, match="missing reference"):
         compile_harness_definition(
@@ -69,7 +62,6 @@ def test_missing_cyclic_and_inconsistent_references_are_rejected() -> None:
         compile_harness_definition(
             {"extends": ["a", "b"]}, source_ref="root",
             load_ref=lambda _parent, ref: ("same", {"selected": ref}))
-
 def test_lock_and_explanation_match_public_projection_schemas() -> None:
     compiled = compile_harness_definition({
         "schema_version": "bb.harness_definition.v1", "version": 1,
@@ -83,7 +75,6 @@ def test_lock_and_explanation_match_public_projection_schemas() -> None:
     assert _schema_errors(
         "bb.harness_explanation_report.v1.schema.json",
         compiled.explanation.as_dict()) == []
-
 def test_invalid_and_empty_definitions_fail_before_lock() -> None:
     with pytest.raises(HarnessCompileError, match="invalid Harness Definition"):
         compile_harness_definition(
@@ -91,7 +82,11 @@ def test_invalid_and_empty_definitions_fail_before_lock() -> None:
             source_ref="root")
     with pytest.raises(HarnessCompileError, match="must contain at least one value"):
         compile_harness_definition({}, source_ref="root")
-
+    for metadata in ({"env_name": ""}, {"env_name": 0},
+                     {"env_name": "TOKEN", "env_satisfied": "false"}):
+        with pytest.raises(HarnessCompileError, match="metadata"):
+            compile_harness_definition(
+                {"credential": {"value": "raw", **metadata}}, source_ref="root")
 def test_empty_mapping_remains_an_explained_lock_value() -> None:
     scalar = compile_harness_definition({"tools": 1}, source_ref="root")
     empty = compile_harness_definition({"tools": {}}, source_ref="root")
@@ -100,7 +95,6 @@ def test_empty_mapping_remains_an_explained_lock_value() -> None:
     assert (row["path"], row["value"], row["value_kind"]) == ("tools", {}, "object")
     assert empty.explanation["fields"][0]["path"] == "tools"
     assert scalar.lock["graph_hash"] != empty.lock["graph_hash"]
-
 def test_legacy_loader_adapter_accepts_canonical_harness_definition(
     tmp_path: Path,
 ) -> None:
@@ -115,12 +109,16 @@ def test_legacy_loader_adapter_accepts_canonical_harness_definition(
     assert view.as_dict()["providers"]["default_model"] == "mock/reference"
     assert view.graph["schema_version"] == "bb.effective_config_graph.v1"
     path.write_text(
-        "providers: {api_key: raw-secret}\ncredential:\n"
-        "  value: raw-env\n  env_name: TOKEN\n  env_satisfied: true\n",
+        "providers: {api_key: raw-secret}\n"
+        "a: {value: raw-z, env_name: Z}\nb: {value: raw-a, env_name: A, env_satisfied: true}\n",
         encoding="utf-8")
     secret_view = load_agent_config_view(str(path))
-    assert "raw-secret" not in json.dumps(secret_view.graph)
-    assert secret_view.graph["visibility"]["redacted_paths"] == [
-        "credential", "providers.api_key"]
-    assert secret_view.graph["env_gates"][0]["gate_id"] == "env.TOKEN"
+    payload = json.dumps(secret_view.graph)
+    rows = {row["path"]: row for row in secret_view.graph["effective_values"]}
+    assert not any(secret in payload for secret in ("raw-secret", "raw-z", "raw-a"))
+    assert rows["a"] == {"env_gate_ids": ["env.Z"], "path": "a", "source_layer_id": "agent-config:0000:harness.yaml", "value": "secret://env/Z", "value_kind": "secret-ref", "visibility": "redacted"}
+    assert rows["providers.api_key"]["value"] == "secret://redacted/providers/api_key"
+    assert secret_view.graph["visibility"]["redacted_paths"] == ["a", "b", "providers.api_key"]
+    assert secret_view.graph["env_gates"] == [{"env_name": "A", "gate_id": "env.A", "required": True, "satisfied": True}, {"env_name": "Z", "gate_id": "env.Z", "required": True, "satisfied": False}]
+    assert finalize_effective_config_graph(secret_view.graph)["graph_hash"] == secret_view.graph["graph_hash"]
     assert _schema_errors("bb.effective_harness_lock.v1.schema.json", secret_view.graph) == []

--- a/tests/product/harness/test_compile.py
+++ b/tests/product/harness/test_compile.py
@@ -29,7 +29,6 @@ def _schema_errors(schema_name: str, record: dict[str, Any]) -> list[str]:
     return [error.message for error in
             Draft202012Validator(schemas[schema_name], registry=registry).iter_errors(record)]
 
-
 def test_recursive_merge_is_deterministic_and_keeps_author_dossier() -> None:
     documents = {
         ("root", "base"): ("base", {"extends": "deep", "nested": {"left": 1},
@@ -51,12 +50,10 @@ def test_recursive_merge_is_deterministic_and_keeps_author_dossier() -> None:
     assert first.resolved_author_dict()["dossier"] == {"owner": "root"}
     assert "extends" not in first.resolved_author_dict()
 
-
 @pytest.mark.parametrize("extends", ["", 3, [None]])
 def test_invalid_references_are_rejected(extends: Any) -> None:
     with pytest.raises(HarnessCompileError, match="invalid reference"):
         compile_harness_definition({"extends": extends}, source_ref="root")
-
 
 def test_missing_cyclic_and_inconsistent_references_are_rejected() -> None:
     with pytest.raises(HarnessCompileError, match="missing reference"):
@@ -73,17 +70,36 @@ def test_missing_cyclic_and_inconsistent_references_are_rejected() -> None:
             {"extends": ["a", "b"]}, source_ref="root",
             load_ref=lambda _parent, ref: ("same", {"selected": ref}))
 
-
 def test_lock_and_explanation_match_public_projection_schemas() -> None:
-    compiled = compile_harness_definition(
-        {"schema_version": "bb.harness_definition.v1", "version": 1},
-        source_ref="/config/harness.yaml")
+    compiled = compile_harness_definition({
+        "schema_version": "bb.harness_definition.v1", "version": 1,
+        "workspace": {"root": "."},
+        "providers": {"default_model": "mock/reference",
+                      "models": [{"id": "mock/reference", "adapter": "mock_chat"}]},
+        "modes": [{"name": "respond"}], "loop": {"sequence": [{"mode": "respond"}]},
+    }, source_ref="/config/harness.yaml")
     assert _schema_errors(
         "bb.effective_harness_lock.v1.schema.json", compiled.lock.as_dict()) == []
     assert _schema_errors(
         "bb.harness_explanation_report.v1.schema.json",
         compiled.explanation.as_dict()) == []
 
+def test_invalid_and_empty_definitions_fail_before_lock() -> None:
+    with pytest.raises(HarnessCompileError, match="invalid Harness Definition"):
+        compile_harness_definition(
+            {"schema_version": "bb.harness_definition.v1", "version": 1},
+            source_ref="root")
+    with pytest.raises(HarnessCompileError, match="must contain at least one value"):
+        compile_harness_definition({}, source_ref="root")
+
+def test_empty_mapping_remains_an_explained_lock_value() -> None:
+    scalar = compile_harness_definition({"tools": 1}, source_ref="root")
+    empty = compile_harness_definition({"tools": {}}, source_ref="root")
+    row = empty.lock["effective_values"][0]
+    assert empty.as_dict() == {"tools": {}}
+    assert (row["path"], row["value"], row["value_kind"]) == ("tools", {}, "object")
+    assert empty.explanation["fields"][0]["path"] == "tools"
+    assert scalar.lock["graph_hash"] != empty.lock["graph_hash"]
 
 def test_legacy_loader_adapter_accepts_canonical_harness_definition(
     tmp_path: Path,
@@ -98,3 +114,13 @@ def test_legacy_loader_adapter_accepts_canonical_harness_definition(
     view = load_agent_config_view(str(path))
     assert view.as_dict()["providers"]["default_model"] == "mock/reference"
     assert view.graph["schema_version"] == "bb.effective_config_graph.v1"
+    path.write_text(
+        "providers: {api_key: raw-secret}\ncredential:\n"
+        "  value: raw-env\n  env_name: TOKEN\n  env_satisfied: true\n",
+        encoding="utf-8")
+    secret_view = load_agent_config_view(str(path))
+    assert "raw-secret" not in json.dumps(secret_view.graph)
+    assert secret_view.graph["visibility"]["redacted_paths"] == [
+        "credential", "providers.api_key"]
+    assert secret_view.graph["env_gates"][0]["gate_id"] == "env.TOKEN"
+    assert _schema_errors("bb.effective_harness_lock.v1.schema.json", secret_view.graph) == []

--- a/tests/product/harness/test_compile.py
+++ b/tests/product/harness/test_compile.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from agentic_coder_prototype.compilation.v2_loader import load_agent_config_view
+
+from breadboard.product.harness.compile import (
+    HarnessCompileError,
+    compile_harness_definition,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+
+def _schema_errors(schema_name: str, record: dict[str, Any]) -> list[str]:
+    directories = (ROOT / "contracts/public/schemas", ROOT / "contracts/kernel/schemas")
+    schemas: dict[str, dict[str, Any]] = {}
+    registry = Registry()
+    for directory in directories:
+        for path in directory.glob("*.json"):
+            schema = json.loads(path.read_text(encoding="utf-8"))
+            schemas[path.name] = schema
+            if isinstance(schema.get("$id"), str):
+                registry = registry.with_resource(schema["$id"], Resource.from_contents(schema))
+    return [error.message for error in
+            Draft202012Validator(schemas[schema_name], registry=registry).iter_errors(record)]
+
+
+def test_recursive_merge_is_deterministic_and_keeps_author_dossier() -> None:
+    documents = {
+        ("root", "base"): ("base", {"extends": "deep", "nested": {"left": 1},
+                                    "items": [1], "dossier": {"owner": "base"}}),
+        ("base", "deep"): ("deep", {"nested": {"deep": True}, "items": [0]}),
+    }
+    load = lambda parent, declared: documents[(parent, declared)]
+    source = {"extends": "base", "nested": {"right": 2}, "items": [2],
+              "dossier": {"owner": "root"}}
+    first = compile_harness_definition(source, source_ref="root", load_ref=load)
+    second = compile_harness_definition(
+        dict(reversed(tuple(source.items()))), source_ref="root", load_ref=load)
+    assert first.lock.canonical_json() == second.lock.canonical_json()
+    assert first.lock["graph_hash"] == second.lock["graph_hash"]
+    assert [layer["layer_id"] for layer in first.lock["source_layers"]] == [
+        "agent-config:0000:deep", "agent-config:0001:base", "agent-config:0002:root"]
+    assert first.as_dict() == {"items": [2],
+                               "nested": {"deep": True, "left": 1, "right": 2}}
+    assert first.resolved_author_dict()["dossier"] == {"owner": "root"}
+    assert "extends" not in first.resolved_author_dict()
+
+
+@pytest.mark.parametrize("extends", ["", 3, [None]])
+def test_invalid_references_are_rejected(extends: Any) -> None:
+    with pytest.raises(HarnessCompileError, match="invalid reference"):
+        compile_harness_definition({"extends": extends}, source_ref="root")
+
+
+def test_missing_cyclic_and_inconsistent_references_are_rejected() -> None:
+    with pytest.raises(HarnessCompileError, match="missing reference"):
+        compile_harness_definition(
+            {"extends": "missing"}, source_ref="root",
+            load_ref=lambda _parent, _ref: (_ for _ in ()).throw(KeyError()))
+    cyclic = {"root": {"extends": "base"}, "base": {"extends": "root"}}
+    with pytest.raises(HarnessCompileError, match="cyclic reference"):
+        compile_harness_definition(
+            cyclic["root"], source_ref="root",
+            load_ref=lambda _parent, ref: (ref, cyclic[ref]))
+    with pytest.raises(HarnessCompileError, match="inconsistent content"):
+        compile_harness_definition(
+            {"extends": ["a", "b"]}, source_ref="root",
+            load_ref=lambda _parent, ref: ("same", {"selected": ref}))
+
+
+def test_lock_and_explanation_match_public_projection_schemas() -> None:
+    compiled = compile_harness_definition(
+        {"schema_version": "bb.harness_definition.v1", "version": 1},
+        source_ref="/config/harness.yaml")
+    assert _schema_errors(
+        "bb.effective_harness_lock.v1.schema.json", compiled.lock.as_dict()) == []
+    assert _schema_errors(
+        "bb.harness_explanation_report.v1.schema.json",
+        compiled.explanation.as_dict()) == []
+
+
+def test_legacy_loader_adapter_accepts_canonical_harness_definition(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "harness.yaml"
+    path.write_text(
+        "schema_version: bb.harness_definition.v1\nversion: 1\n"
+        "workspace: {root: .}\n"
+        "providers: {default_model: mock/reference, models: [{id: mock/reference, adapter: mock_chat}]}\n"
+        "modes: [{name: respond}]\nloop: {sequence: [{mode: respond}]}\n",
+        encoding="utf-8")
+    view = load_agent_config_view(str(path))
+    assert view.as_dict()["providers"]["default_model"] == "mock/reference"
+    assert view.graph["schema_version"] == "bb.effective_config_graph.v1"

--- a/tests/product/harness/test_explain.py
+++ b/tests/product/harness/test_explain.py
@@ -4,7 +4,6 @@ import pytest
 
 from breadboard.product.harness.compile import compile_harness_definition
 
-
 def test_explanation_accounts_for_winners_effects_and_blockers() -> None:
     compiled = compile_harness_definition(
         {"capabilities": {"read": True}, "limit": 1, "dossier": {"note": "hidden"}},
@@ -29,6 +28,18 @@ def test_explanation_accounts_for_winners_effects_and_blockers() -> None:
     assert winners == locked
     assert "dossier.note" not in winners
 
+def test_prompt_summary_includes_only_concrete_pack_files() -> None:
+    summary = compile_harness_definition({
+        "prompts": {
+            "environment": {"format": "xml"},
+            "injection": {"system_order": ["environment", "pack"]},
+            "packs": {"base": {"system": "prompts/system.md",
+                               "builder": "prompts/builder.md",
+                               "compact": "prompts/system.md"}},
+            "tool_prompt_mode": "none",
+        },
+    }, source_ref="root").explanation["resolved_summary"]
+    assert summary["prompt_files"] == ("prompts/builder.md", "prompts/system.md")
 
 def test_explanation_is_frozen_and_detached() -> None:
     explanation = compile_harness_definition({"value": 1}, source_ref="root").explanation

--- a/tests/product/harness/test_explain.py
+++ b/tests/product/harness/test_explain.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from breadboard.product.harness.compile import compile_harness_definition
+
+
+def test_explanation_accounts_for_winners_effects_and_blockers() -> None:
+    compiled = compile_harness_definition(
+        {"capabilities": {"read": True}, "limit": 1, "dossier": {"note": "hidden"}},
+        source_ref="root.yaml",
+        defaults={"capabilities": {"read": False}, "limit": 0},
+        overlays=({"capabilities": {"write": False}, "limit": 2},),
+    )
+    explanation = compiled.explanation
+    assert explanation["schema_version"] == "bb.config_explanation.v1"
+    assert explanation["ok"] is True
+    assert not any(row["severity"] == "error" for row in explanation["diagnostics"])
+    messages = {row["message"] for row in explanation["diagnostics"]}
+    assert {
+        "effect=defaulted; source=harness-default:0000",
+        "effect=overridden; source=harness-default:0000; winner=agent-config:0000:root.yaml",
+        "effect=capability_enabled; source=agent-config:0000:root.yaml",
+        "blocker=capability_disabled; source=harness-overlay:0000",
+    } <= messages
+    winners = {row["path"]: row["source_layer"] for row in explanation["fields"]}
+    locked = {row["path"]: row["source_layer_id"]
+              for row in compiled.lock["effective_values"]}
+    assert winners == locked
+    assert "dossier.note" not in winners
+
+
+def test_explanation_is_frozen_and_detached() -> None:
+    explanation = compile_harness_definition({"value": 1}, source_ref="root").explanation
+    with pytest.raises(TypeError):
+        explanation["resolved_summary"]["tool_count"] = 3  # type: ignore[index]
+    detached = explanation.as_dict()
+    detached["fields"].clear()
+    assert explanation["fields"]

--- a/tests/product/harness/test_lock.py
+++ b/tests/product/harness/test_lock.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from breadboard.product.harness.compile import compile_harness_definition
+from breadboard.product.harness.lock import graph_content_hash
+
+
+def test_lock_is_frozen_detached_and_self_hashing() -> None:
+    compiled = compile_harness_definition(
+        {"nested": {"value": 1}, "items": ["a"]}, source_ref="/cfg/root.yaml")
+    lock = compiled.lock
+    assert lock["schema_version"] == "bb.effective_config_graph.v1"
+    assert graph_content_hash(lock) == lock["graph_hash"]
+    with pytest.raises(TypeError):
+        lock["visibility"]["model_visible_paths"] = []  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        lock["effective_values"].append({})  # type: ignore[union-attr]
+    detached = lock.as_dict()
+    detached["effective_values"][0]["value"] = "changed"
+    assert detached != lock.as_dict()
+
+
+def test_one_field_mutation_is_local_to_value_and_content_hashes() -> None:
+    first = compile_harness_definition(
+        {"a": 1, "b": 2}, source_ref="/cfg/root.yaml").lock.as_dict()
+    second = compile_harness_definition(
+        {"a": 9, "b": 2}, source_ref="/cfg/root.yaml").lock.as_dict()
+    assert first["effective_values"][1] == second["effective_values"][1]
+    left, right = first["effective_values"][0], second["effective_values"][0]
+    assert {key: value for key, value in left.items() if key != "value"} == {
+        key: value for key, value in right.items() if key != "value"}
+    assert first["source_layers"][0]["layer_hash"] != second["source_layers"][0]["layer_hash"]
+    assert first["graph_hash"] != second["graph_hash"]


### PR DESCRIPTION
## Scope
Implements packet `bb-06u.3` (NS02) at packet hash `sha256:033b6cf4db97c40147000257648517df7ce97abb9ce0cfa0d0c1b7f31d6dbf43`:
- one product-owned deterministic compilation result for effective runtime values, immutable `bb.effective_config_graph.v1` lock, and provenance-rich `bb.config_explanation.v1` explanation
- recursive `extends`, defaults, overlays, deep mapping merge/list replacement, runtime-layer/source hashes, graph hash, diagnostics, blocker/effect provenance, and frozen detached outputs
- canonical Harness Definition validation fails inside the product compiler before lock construction
- secret-shaped and validated `env_name` metadata leaves retain frozen graph redaction/env-gate semantics; invalid env metadata fails before lock
- env gates normalize by frozen `gate_id` order before hashing; focused parity regression re-finalizes the record through the frozen normalizer
- empty mappings remain explicit object-valued lock/explanation rows; rowless inputs fail closed
- prompt summary includes only concrete prompt-pack files
- legacy `v2_loader` remains an internal adapter and consumes the single product compilation result
- public schema projections retain frozen record roles and IDs

## Exact candidate
- Base: `2599e33b816ddcab13fab1490719dc502ff19003`
- Head: `189c548c7ab05627a8696834062521b269222c1d`
- Packet: 9 files, +650/-150 = 800; exactly within the 20-file/800-line hard gate

## Verification
- Focused exact-head tests: `267 passed, 22 skipped`
- Canonical CLI smoke: `Valid harness config: agent_configs/templates/minimal_harness.v3.yaml`
- Public contracts: 45 operations, 6 bindings each, non-active
- Surface inventory: fixed point
- Axis smoke: `passed=true`, all ten axes smoke-passed with null scores and `score_promoted=false`
- Round-1 and round-2 independent findings were remediated. Final round-3 exact-head Standards and Spec approval and refreshed CI are pending; merge remains gated on both zero-finding verdicts and required checks.