### PR TITLE
C1: close checkpoint findings cycle two

### DIFF
--- a/breadboard/product/cli/harness.py
+++ b/breadboard/product/cli/harness.py
@@ -6,7 +6,7 @@ from typing import Any,Mapping
 import yaml
 from breadboard.product.harness.compile import HarnessCompilation,compile_harness_definition
 from breadboard.product.harness.lock import EffectiveHarnessLock,sha256_json
-from breadboard.product.harness.validate import HarnessDefinitionValidationError,load_harness_definition
+from breadboard.product.harness.validate import HarnessDefinitionValidationError,load_harness_definition,parse_harness_definition,validate_harness_document_domain
 from .result import CliResult,EXIT_LOCK_DRIFT,from_exception,portable_ref
 from .system import resource_path
 FALLBACK="""schema_version: bb.agent_config_surface.v2
@@ -22,13 +22,22 @@ def _template(n):
 def _doc(p):
     x=yaml.safe_load(p.read_text())
     if not isinstance(x,dict):raise ValueError("harness definition must be a mapping")
+    if findings:=validate_harness_document_domain(x):raise HarnessDefinitionValidationError(findings)
     return x
-def _loadref(parent,decl,w):
-    p=Path(parent); base=p if p.is_absolute() else w/p; target=(base.parent/decl).resolve(); return _ref(target,w),_doc(target)
-def _compile(p,w):return compile_harness_definition(load_harness_definition(p),source_ref=_ref(p,w),load_ref=lambda parent,decl:_loadref(parent,decl,w))
+def _compile(p,w):
+    source_ref=_ref(p,w); paths={source_ref:p}
+    def load_ref(parent,decl):
+        target=(paths[parent].parent/decl).resolve()
+        resolved=_ref(target,w)
+        if resolved in paths and paths[resolved]!=target:raise ValueError(f"reference identity collision: {resolved}")
+        paths[resolved]=target
+        return resolved,_doc(target)
+    compiled=compile_harness_definition(_doc(p),source_ref=source_ref,load_ref=load_ref)
+    parse_harness_definition(compiled.resolved_author_dict())
+    return compiled
 def _lockpath(p,out=None):
     if out:
-        q=Path(out).expanduser(); return q if q.suffix==".json" else q/f"{p.stem}.lock.json"
+        q=Path(out).expanduser(); return q if q.is_file() or q.suffix==".json" else q/f"{p.stem}.lock.json"
     return p.with_name(p.stem+".lock.json")
 def _meta(p):return p.with_name("."+p.name+".meta.json")
 def _write(p,x):p.parent.mkdir(parents=True,exist_ok=True); p.write_text(json.dumps(x,sort_keys=True,indent=2)+"\n")
@@ -56,10 +65,13 @@ def lock(a):
             if not target.exists() or not _meta(target).exists():return CliResult.failure(["harness","lock"],5,"lock_missing","lock is missing","harness.lock")
             if json.loads(target.read_text())!=c.lock.as_dict() or json.loads(_meta(target).read_text())!=meta:return CliResult.failure(["harness","lock"],5,"lock_drift","harness definition changed after lock","harness.lock",next_actions=[f"breadboard harness lock {_ref(p,w)}"])
             return CliResult.success(["harness","lock"],{"path":_ref(target,w),"graph_hash":meta["graph_hash"],"checked":True},[_ref(target,w)],{"graph":meta["graph_hash"]},stage="harness.lock")
-        _write(target,c.lock.as_dict()); _write(_meta(target),meta); return CliResult.success(["harness","lock"],{"path":_ref(target,w),"graph_hash":meta["graph_hash"]},[_ref(target,w)],{"graph":meta["graph_hash"],"source":meta["source_sha256"]},[f"breadboard harness run {_ref(p,w)} --local"],"harness.lock")
+        _write(target,c.lock.as_dict()); _write(_meta(target),meta)
+        next_action=f"breadboard harness run {shlex.quote(str(p))} --local"
+        if target.resolve()!=_lockpath(p).resolve():next_action+=f" --lock {shlex.quote(str(target.resolve()))}"
+        return CliResult.success(["harness","lock"],{"path":_ref(target,w),"graph_hash":meta["graph_hash"]},[_ref(target,w)],{"graph":meta["graph_hash"],"source":meta["source_sha256"]},[next_action],"harness.lock")
     except Exception as e:return from_exception(["harness","lock"],e,"harness.lock")
-def load_lock(p,w):
-    t=p if p.name.endswith(".lock.json") else _lockpath(p)
+def load_lock(p,w,*,explicit=False):
+    t=p if explicit or p.name.endswith(".lock.json") else _lockpath(p)
     if not t.exists():raise FileNotFoundError(f"lock is missing: {_ref(t,w)}")
     if not _meta(t).exists():raise ValueError("lock metadata is missing; lock must be regenerated")
     return EffectiveHarnessLock._from_record(json.loads(t.read_text())),_meta(t)
@@ -108,8 +120,11 @@ def _local_server()->Iterator[str]:
 def run(a):
     p,w=_p(a),_w(a)
     try:
-        lock,mp=load_lock(p,w); c=_compile(p,w); m=json.loads(mp.read_text())
-        if m.get("source_sha256")!=sha256_json(c.resolved_author_dict()) or m.get("graph_hash")!=lock["graph_hash"] or c.lock.as_dict()!=lock.as_dict():return CliResult.failure(["harness","run"],5,"lock_drift","mutable harness definition cannot run without a fresh lock","harness.run",next_actions=[f"breadboard harness lock {_ref(p,w)}"])
+        lock_argument=getattr(a,"lock",None); lock_path=Path(lock_argument).expanduser().resolve() if lock_argument else p
+        lock,mp=load_lock(lock_path,w,explicit=bool(lock_argument)); c=_compile(p,w); m=json.loads(mp.read_text())
+        lock_action=f"breadboard harness lock {shlex.quote(str(p))}"
+        if lock_argument:lock_action+=f" --out {shlex.quote(str(lock_path))}"
+        if m.get("source_sha256")!=sha256_json(c.resolved_author_dict()) or m.get("graph_hash")!=lock["graph_hash"] or c.lock.as_dict()!=lock.as_dict():return CliResult.failure(["harness","run"],5,"lock_drift","mutable harness definition cannot run without a fresh lock","harness.run",next_actions=[lock_action])
         a._effective_lock=lock;a._workspace=w
         if getattr(a,"local",False):
             try:

--- a/breadboard/product/cli/main.py
+++ b/breadboard/product/cli/main.py
@@ -111,7 +111,7 @@ def _harness(ns):
         x=s.add_parser(n);x.add_argument("PATH");
         if n=="explain":x.add_argument("--strict",action="store_true")
         if n=="lock":x.add_argument("--out");x.add_argument("--check",action="store_true")
-        if n=="run":t=x.add_mutually_exclusive_group(required=True);t.add_argument("--server");t.add_argument("--local",action="store_true");x.add_argument("--task")
+        if n=="run":t=x.add_mutually_exclusive_group(required=True);t.add_argument("--server");t.add_argument("--local",action="store_true");x.add_argument("--task");x.add_argument("--lock")
         x.set_defaults(handler=fn)
 def _harness_lock(ns):
     p=ns.add_parser("harness-lock",help="inspect effective harness locks");_common(p);s=p.add_subparsers(dest="command",required=True);x=s.add_parser("get");x.add_argument("PATH");x.set_defaults(handler=harness.get_lock)

--- a/breadboard/product/harness/validate.py
+++ b/breadboard/product/harness/validate.py
@@ -122,6 +122,13 @@ def _json_findings(
     return [ValidationFinding(
         _pointer(path), "json_type", "Value is not a JSON-domain value"
     )]
+def validate_harness_document_domain(
+    document: object,
+) -> tuple[ValidationFinding, ...]:
+    """Validate JSON-domain invariants before recursive composition."""
+    return tuple(sorted(set(_json_findings(document))))
+
+
 def _required_properties(error: ValidationError) -> list[str]:
     if not isinstance(error.validator_value, list) or not isinstance(error.instance, Mapping):
         return []

--- a/breadboard/product/integrations/catalog.py
+++ b/breadboard/product/integrations/catalog.py
@@ -70,6 +70,14 @@ class ProjectDeclarationError(IntegrationError):
     """Raised when a project integration declaration cannot be trusted."""
 
 
+def _validate_metadata_arrays(*groups: object) -> None:
+    for group in groups:
+        if not isinstance(group, (list, tuple)) or any(not isinstance(value, str) or not value.strip() for value in group):
+            raise IntegrationError("integration metadata must contain non-empty strings")
+        if len(set(group)) != len(group):
+            raise IntegrationError("integration metadata must contain unique strings")
+
+
 @runtime_checkable
 class IntegrationAdapter(Protocol):
     descriptor: "IntegrationDescriptor"
@@ -103,9 +111,7 @@ class IntegrationDescriptor:
             raise IntegrationError("invalid integration descriptor")
         if self.configuration_schema_id is not None and not _SCHEMA_ID_RE.fullmatch(self.configuration_schema_id):
             raise IntegrationError("invalid configuration schema id")
-        for value in (*self.capabilities, *self.effects, *self.permissions, *self.secret_reference_names):
-            if not isinstance(value, str) or not value.strip():
-                raise IntegrationError("integration metadata must contain non-empty strings")
+        _validate_metadata_arrays(self.capabilities, self.effects, self.permissions, self.secret_reference_names)
         if self.probe_evidence_sha256 is not None and not _HASH_RE.fullmatch(self.probe_evidence_sha256):
             raise IntegrationError("probe evidence must be a sha256 digest")
 
@@ -145,6 +151,7 @@ class ProbeReport:
             raise IntegrationError("invalid capability probe subject")
         if not _is_rfc3339_timestamp(self.checked_at_utc):
             raise IntegrationError("capability probe must include an RFC3339 checked_at_utc")
+        _validate_metadata_arrays(self.capabilities, self.effects, self.permissions)
         if self.status not in {"available", "unavailable"}:
             raise IntegrationError("invalid capability probe status")
         if self.status == "available" and self.error is not None:
@@ -184,18 +191,30 @@ class IntegrationCatalog:
 
     def __init__(self, adapters: Iterable[IntegrationAdapter] = ()) -> None:
         self._adapters: dict[str, IntegrationAdapter] = {}
-        for adapter in adapters:
-            self.register(adapter)
+        self._register_many(adapters)
 
-    def register(self, adapter: IntegrationAdapter) -> IntegrationDescriptor:
+    @staticmethod
+    def _validate_adapter(adapter: IntegrationAdapter) -> IntegrationDescriptor:
         descriptor = getattr(adapter, "descriptor", None)
         probe = getattr(adapter, "probe", None)
         if not isinstance(descriptor, IntegrationDescriptor) or not callable(probe):
             raise IncompatibleAdapterError("adapter must expose a descriptor and probe()")
-        if descriptor.integration_id in self._adapters:
-            raise IntegrationError(f"integration already registered: {descriptor.integration_id}")
-        self._adapters[descriptor.integration_id] = adapter
         return descriptor
+
+    def _register_many(self, adapters: Iterable[IntegrationAdapter]) -> list[IntegrationDescriptor]:
+        pending: dict[str, IntegrationAdapter] = {}
+        descriptors: list[IntegrationDescriptor] = []
+        for adapter in adapters:
+            descriptor = self._validate_adapter(adapter)
+            if descriptor.integration_id in self._adapters or descriptor.integration_id in pending:
+                raise IntegrationError(f"integration already registered: {descriptor.integration_id}")
+            pending[descriptor.integration_id] = adapter
+            descriptors.append(descriptor)
+        self._adapters.update(pending)
+        return descriptors
+
+    def register(self, adapter: IntegrationAdapter) -> IntegrationDescriptor:
+        return self._register_many((adapter,))[0]
 
     def list(self, *, kind: str | None = None) -> list[IntegrationDescriptor]:
         values = (adapter.descriptor for adapter in self._adapters.values())
@@ -240,10 +259,7 @@ class IntegrationCatalog:
     def load_capture_adapters(self, *, group: str = "breadboard.capture_adapters") -> list[IntegrationDescriptor]:
         from .capture import load_capture_entry_points
 
-        adapters = load_capture_entry_points(group=group)
-        for adapter in adapters:
-            self.register(adapter)
-        return [adapter.descriptor for adapter in adapters]
+        return self._register_many(load_capture_entry_points(group=group))
 
     def preflight(
         self,
@@ -254,16 +270,15 @@ class IntegrationCatalog:
     ) -> list[IntegrationDescriptor]:
         from .capture import resolve_local_capture_declaration
 
-        resolved: list[IntegrationDescriptor] = []
-        for declaration in declarations:
-            adapter = resolve_local_capture_declaration(
+        resolved = [
+            resolve_local_capture_declaration(
                 declaration,
                 project_root=project_root,
                 adapters=adapters,  # type: ignore[arg-type]
             )
-            self.register(adapter)
-            resolved.append(adapter.descriptor)
-        return resolved
+            for declaration in declarations
+        ]
+        return self._register_many(resolved)
 
 
 def _now() -> str:

--- a/scripts/authoring/validate_lane.py
+++ b/scripts/authoring/validate_lane.py
@@ -54,25 +54,6 @@ CHECK_IDS = (
     "metadata_non_normative",
 )
 REQUIRED_SCOPE_KEYS = {"config_id", "lane_id", "run_id", "target_version", "provider_model", "sandbox_mode"}
-INVENTORY_COMPARE_FIELDS = (
-    "config_id",
-    "claim_id",
-    "kind",
-    "status",
-    "points",
-    "target_family",
-    "target_version",
-    "run_id",
-    "provider_model",
-    "sandbox_mode",
-    "builder",
-    "ct",
-    "reverify_command",
-    "artifact_roles",
-    "ledger_feature_ids",
-    "score_row_id",
-    "artifacts_root",
-)
 
 
 def _manifest_flow_style_errors(node: yaml.Node, pointer: str = "") -> list[str]:
@@ -298,7 +279,7 @@ def _inventory_check(lane_def: Mapping[str, Any], inventory_lane: Mapping[str, A
         generated = generate_lane_inventory.lane_inventory_row(lane_def)
     except Exception as exc:
         return _fail("inventory_row_consistent", f"unable to generate inventory row: {exc}")
-    mismatches = [field for field in INVENTORY_COMPARE_FIELDS if generated.get(field) != inventory_lane.get(field)]
+    mismatches = generate_lane_inventory.lane_row_mismatches(generated, inventory_lane)
     if mismatches:
         return _fail("inventory_row_consistent", "inventory mismatches: " + ", ".join(mismatches))
     return _pass("inventory_row_consistent", "generated lane inventory fields match canonical inventory row")

--- a/scripts/e4_parity/generate_lane_inventory.py
+++ b/scripts/e4_parity/generate_lane_inventory.py
@@ -299,19 +299,29 @@ def build_inventory(lane_defs: Mapping[str, Mapping[str, Any]]) -> dict[str, Any
     }
 
 
+def lane_row_mismatches(
+    generated: Mapping[str, Any],
+    canonical: Mapping[str, Any],
+) -> list[str]:
+    missing = object()
+    return [
+        field
+        for field in sorted(set(generated) | set(canonical))
+        if generated.get(field, missing) != canonical.get(field, missing)
+    ]
+
+
 def compare_with_canonical(generated: Mapping[str, Any], canonical: Mapping[str, Any]) -> dict[str, Any]:
     generated_rows = {row["lane_id"]: row for row in generated.get("lanes", []) if isinstance(row, Mapping)}
     canonical_rows = {row["lane_id"]: row for row in canonical.get("lanes", []) if isinstance(row, Mapping)}
-    required_fields = ("config_id", "claim_id", "kind", "status", "points", "target_family", "target_version", "run_id", "provider_model", "sandbox_mode", "builder", "ct", "reverify_command", "artifact_roles", "ledger_feature_ids", "score_row_id")
     errors: list[str] = []
     for lane_id, generated_row in sorted(generated_rows.items()):
         canonical_row = canonical_rows.get(lane_id)
         if canonical_row is None:
             errors.append(f"canonical inventory missing lane {lane_id}")
             continue
-        for field in required_fields:
-            if generated_row.get(field) != canonical_row.get(field):
-                errors.append(f"{lane_id}.{field} mismatch")
+        for field in lane_row_mismatches(generated_row, canonical_row):
+            errors.append(f"{lane_id}.{field} mismatch")
     for lane_id in sorted(set(canonical_rows) - set(generated_rows)):
         errors.append(f"lane_def missing canonical lane {lane_id}")
     return {

--- a/tests/e4_parity/test_generate_lane_inventory.py
+++ b/tests/e4_parity/test_generate_lane_inventory.py
@@ -146,6 +146,11 @@ def test_build_inventory_sorts_lane_defs() -> None:
         pytest.param("run_id", "different-run", id="run-id"),
         pytest.param("provider_model", "different/model", id="provider-model"),
         pytest.param("sandbox_mode", "different sandbox", id="sandbox-mode"),
+        pytest.param("evidence_status", "accepted", id="evidence-status"),
+        pytest.param("phase", "P8", id="phase"),
+        pytest.param("primitives", ["different"], id="primitives"),
+        pytest.param("comparator_id", "different-comparator", id="comparator-id"),
+        pytest.param("artifacts_root", "different/root", id="artifacts-root"),
     ],
 )
 def test_compare_with_canonical_reports_field_mismatch(field: str, canonical_value: object) -> None:
@@ -156,6 +161,16 @@ def test_compare_with_canonical_reports_field_mismatch(field: str, canonical_val
 
     assert report["ok"] is False
     assert report["errors"] == [f"oh_my_pi_p9_demo.{field} mismatch"]
+
+
+def test_compare_with_canonical_reports_unexpected_canonical_field() -> None:
+    generated = build_inventory({"demo": _lane_def()})
+    canonical_row = {**generated["lanes"][0], "future_contract_field": "unexpected"}
+
+    report = compare_with_canonical(generated, {"lanes": [canonical_row]})
+
+    assert report["ok"] is False
+    assert report["errors"] == ["oh_my_pi_p9_demo.future_contract_field mismatch"]
 
 
 def test_compare_with_canonical_accepts_matching_subset() -> None:

--- a/tests/e4_parity/test_validate_lane.py
+++ b/tests/e4_parity/test_validate_lane.py
@@ -212,6 +212,25 @@ def hermetic_accepted_lane(
         validator.generate_lane_inventory._SCORE_SUBLEDGER_CACHE = None
 
 
+def test_inventory_check_rejects_retained_evidence_status_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    generated = {"lane_id": "demo", "evidence_status": "accepted"}
+    monkeypatch.setattr(
+        validator.generate_lane_inventory,
+        "lane_inventory_row",
+        lambda _lane_def: generated,
+    )
+
+    check = validator._inventory_check(
+        {},
+        {**generated, "evidence_status": "blocked"},
+    )
+
+    assert check["status"] == "failed"
+    assert check["detail"] == "inventory mismatches: evidence_status"
+
+
 @pytest.mark.parametrize(
     ("ok", "failed_check"),
     [

--- a/tests/product/integrations/test_catalog.py
+++ b/tests/product/integrations/test_catalog.py
@@ -52,6 +52,38 @@ def test_configuration_schema_id_is_colon_free() -> None:
     with pytest.raises(IntegrationError): IntegrationDescriptor("bb.integration_descriptor.v1", "tool:x", "tool_executor", "v1", "impl", (), "schema:v1")
 
 
+def test_public_metadata_arrays_are_non_empty_and_unique() -> None:
+    with pytest.raises(IntegrationError): IntegrationDescriptor("bb.integration_descriptor.v1", "tool:x", "tool_executor", "v1", "impl", capabilities=("same", "same"))
+    with pytest.raises(IntegrationError): IntegrationDescriptor("bb.integration_descriptor.v1", "tool:x", "tool_executor", "v1", "impl", secret_reference_names=("TOKEN", "TOKEN"))
+    for values in (("",), ("same", "same")):
+        with pytest.raises(IntegrationError): ProbeReport("bb.capability_probe_report.v1", "probe:x", "tool:x", "tool_executor", "impl", "available", capabilities=values, checked_at_utc="2026-07-21T00:00:00Z")
+        with pytest.raises(IntegrationError): ProbeReport("bb.capability_probe_report.v1", "probe:x", "tool:x", "tool_executor", "impl", "available", effects=values, checked_at_utc="2026-07-21T00:00:00Z")
+        with pytest.raises(IntegrationError): ProbeReport("bb.capability_probe_report.v1", "probe:x", "tool:x", "tool_executor", "impl", "available", permissions=values, checked_at_utc="2026-07-21T00:00:00Z")
+
+
+def test_capture_adapter_batches_register_atomically(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    existing = internal_capture_adapters()[0]
+    added = CaptureIntegrationAdapter("added", lambda value: value, source_sha256="sha256:" + "a" * 64)
+    catalog = IntegrationCatalog([existing])
+    monkeypatch.setattr("breadboard.product.integrations.capture.load_capture_entry_points", lambda group: [added, existing])
+    with pytest.raises(IntegrationError): catalog.load_capture_adapters()
+    assert [item.integration_id for item in catalog.list()] == [existing.descriptor.integration_id]
+
+    first_source = tmp_path / "first.py"; first_source.write_text("first\n")
+    second_source = tmp_path / "second.py"; second_source.write_text("second\n")
+    first_digest = "sha256:" + sha256(first_source.read_bytes()).hexdigest()
+    second_digest = "sha256:" + sha256(second_source.read_bytes()).hexdigest()
+    first = CaptureIntegrationAdapter("first", lambda value: value, source_sha256=first_digest)
+    second = CaptureIntegrationAdapter("second", lambda value: value, source_sha256=second_digest)
+    declarations = [
+        {"adapter_id": "first", "source_path": "first.py", "source_sha256": first_digest, "grants": ["capture"]},
+        {"adapter_id": "second", "source_path": "second.py", "source_sha256": "sha256:" + "f" * 64, "grants": ["capture"]},
+    ]
+    catalog = IntegrationCatalog()
+    with pytest.raises(ProjectDeclarationError): catalog.preflight(declarations, project_root=str(tmp_path), adapters={"first": first, "second": second})
+    assert catalog.list() == []
+
+
 def test_records_match_public_schemas_and_traversal_is_rejected(tmp_path: Path) -> None:
     catalog = IntegrationCatalog(internal_capture_adapters())
     for name, record in (("bb.integration_descriptor.v1", catalog.list()[0].to_record()), ("bb.capability_probe_report.v1", catalog.probe("capture:json").to_record())):

--- a/tests/test_breadboard_cli_g2.py
+++ b/tests/test_breadboard_cli_g2.py
@@ -73,6 +73,75 @@ def test_harness_init_produces_a_valid_explainable_bundle_without_overwriting(
     assert {path: path.read_bytes() for path in before} == before
 
 
+def test_json_harness_explain_validates_resolved_legacy_surface(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    harness_path = tmp_path / "invalid.yaml"
+    harness = yaml.safe_load(
+        (Path(__file__).resolve().parents[1] / "agent_configs/templates/minimal_harness.v2.yaml").read_text()
+    )
+    del harness["providers"]["models"][0]["adapter"]
+    harness_path.write_text(yaml.safe_dump(harness))
+
+    exit_code, stdout, stderr = _invoke(
+        ["--json", "harness", "explain", str(harness_path)],
+        capsys,
+    )
+
+    assert exit_code == 2, stderr
+    result = json.loads(stdout)
+    assert "/providers/models/0/adapter" in result["error"]["message"]
+
+
+def test_json_harness_explain_rejects_recursive_yaml_alias(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    harness_path = tmp_path / "recursive.yaml"
+    harness_path.write_text(
+        "schema_version: bb.agent_config_surface.v2\n"
+        "version: 2\n"
+        "dossier: &recursive\n"
+        "  self: *recursive\n"
+    )
+
+    exit_code, stdout, stderr = _invoke(
+        ["--json", "harness", "explain", str(harness_path)],
+        capsys,
+    )
+
+    assert exit_code == 2, stderr
+    assert "json_cycle" in json.loads(stdout)["error"]["message"]
+
+
+def test_harness_extends_resolve_from_external_source_directory(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    workspace = tmp_path / "workspace"
+    external = tmp_path / "external"
+    workspace.mkdir()
+    external.mkdir()
+    nested = external / "nested"
+    nested.mkdir()
+    template = yaml.safe_load(
+        (Path(__file__).resolve().parents[1] / "agent_configs/templates/minimal_harness.v3.yaml").read_text()
+    )
+    (external / "base.yaml").write_text(yaml.safe_dump(template))
+    (nested / "child.yaml").write_text(yaml.safe_dump({**template, "extends": "../base.yaml"}))
+
+    exit_code, stdout, stderr = _invoke(
+        ["--json", "harness", "--workspace", str(workspace), "explain", str(nested / "child.yaml")],
+        capsys,
+    )
+
+    assert exit_code == 0, stderr
+    result = json.loads(stdout)
+    assert result["data"]["resolved_summary"]["extends_chain"] == ["base.yaml"]
+    assert str(tmp_path) not in stdout
+
+
 def test_lane_init_produces_a_loader_valid_manifest_without_overwriting(tmp_path: Path, capsys, monkeypatch) -> None:
     out_dir = tmp_path / "lane"
 

--- a/tests/test_breadboard_cli_harness_run.py
+++ b/tests/test_breadboard_cli_harness_run.py
@@ -101,6 +101,52 @@ def test_harness_run_submits_task_once_and_reports_completed_session(
     ]
 
 
+def test_harness_run_consumes_custom_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    harness_path = tmp_path / "minimal_harness.v2.yaml"
+    prompt_path = tmp_path / "prompts" / "minimal_system.md"
+    prompt_path.parent.mkdir()
+    harness_path.write_bytes(HARNESS_PATH.read_bytes())
+    prompt_path.write_bytes((HARNESS_PATH.parent / "prompts" / "minimal_system.md").read_bytes())
+    custom_lock = tmp_path / "locks" / "effective.json"
+    assert breadboard_cli.main(["--json", "harness", "lock", str(harness_path), "--out", str(custom_lock)]) == 0
+    lock_result = capsys.readouterr()
+    assert f"--lock {custom_lock}" in lock_result.out
+    assert not harness_path.with_name(harness_path.stem + ".lock.json").exists()
+    extensionless_lock = custom_lock.with_suffix(".lock")
+    custom_lock.rename(extensionless_lock)
+    custom_lock.with_name(f".{custom_lock.name}.meta.json").rename(
+        extensionless_lock.with_name(f".{extensionless_lock.name}.meta.json")
+    )
+    custom_lock = extensionless_lock
+    _RunClient.calls = []
+    monkeypatch.setattr(breadboard_sdk, "BreadboardClient", _RunClient)
+
+    exit_code = breadboard_cli.main(
+        ["harness", "run", str(harness_path), "--lock", str(custom_lock), "--server", "https://breadboard.test/api"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0, captured.err
+    assert "session-g3" in captured.out
+    harness_path.write_text(harness_path.read_text().replace("mock/reference", "mock/changed"))
+    exit_code = breadboard_cli.main(
+        ["harness", "run", str(harness_path), "--lock", str(custom_lock), "--server", "https://breadboard.test/api"]
+    )
+    captured = capsys.readouterr()
+    assert exit_code == 5
+    assert f"breadboard harness lock {harness_path} --out {custom_lock}" in captured.err
+    capsys.readouterr()
+    assert breadboard_cli.main(
+        ["harness", "lock", str(harness_path), "--out", str(custom_lock)]
+    ) == 0
+    capsys.readouterr()
+    assert custom_lock.is_file()
+
+
 
 def test_harness_run_rejects_event_stream_eof_before_terminal_event(
     locked_harness: Path,


### PR DESCRIPTION
## Summary
- route Harness Definition loading through one extends-aware compiler path with recursive-domain and resolved-schema validation
- make custom lock consumption/recovery exact-path safe, including extensionless files
- fail closed on malformed integration metadata and compare complete E4 lane inventory rows

## Evidence
- 376 product/CLI/lane tests passed
- axis smoke: passed=true, score_promoted=false, failed_checks=[]
- clean installed-wheel journey: init -> custom extensionless lock -> local completed Session -> artifact verify
- independent exact-head review: zero actionable P0-P3 findings

Closes bb-06u.33