### PR TITLE
NS06: integration boundary P3 hardening

### DIFF
--- a/breadboard/product/integrations/capture.py
+++ b/breadboard/product/integrations/capture.py
@@ -6,7 +6,7 @@ from hashlib import sha256
 from importlib import metadata
 import json
 from pathlib import Path
-from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence, runtime_checkable
+from typing import Any, Callable, Iterable, Mapping, Protocol, runtime_checkable
 
 from .catalog import (
     IntegrationDescriptor,
@@ -14,6 +14,7 @@ from .catalog import (
     ProjectDeclarationError,
     ProbeReport,
     probe_for,
+    _valid_sha256,
 )
 
 _CAPTURE_GROUP = "breadboard.capture_adapters"
@@ -41,7 +42,7 @@ class ProjectCaptureDeclaration:
             raise ProjectDeclarationError("local capture declaration requires adapter, source, and source_sha256")
         if not isinstance(grants, (list, tuple, set)) or not grants or not all(isinstance(item, str) and item for item in grants):
             raise ProjectDeclarationError("local capture declaration requires explicit grants")
-        if not digest.startswith("sha256:") or len(digest) != 71:
+        if not _valid_sha256(digest):
             raise ProjectDeclarationError("local capture declaration requires a sha256 source hash")
         return cls(adapter_id, source_path, digest, tuple(sorted(set(grants))))
 
@@ -78,7 +79,7 @@ class CaptureIntegrationAdapter:
     ) -> None:
         if not adapter_id or not callable(implementation) and not callable(getattr(implementation, "capture", None)):
             raise IncompatibleAdapterError("capture adapter must expose capture()")
-        if not _valid_hash(source_sha256):
+        if not _valid_sha256(source_sha256):
             raise IncompatibleAdapterError("capture adapter source hash is required")
         self.adapter_id = adapter_id
         self.implementation = implementation
@@ -165,6 +166,3 @@ def resolve_local_capture_declaration(
         raise ProjectDeclarationError("local adapter source hash does not match declaration")
     return selected
 
-
-def _valid_hash(value: Any) -> bool:
-    return isinstance(value, str) and len(value) == 71 and value.startswith("sha256:") and all(char in "0123456789abcdef" for char in value[7:])

--- a/breadboard/product/integrations/capture.py
+++ b/breadboard/product/integrations/capture.py
@@ -165,4 +165,3 @@ def resolve_local_capture_declaration(
     if selected.source_sha256 != parsed.source_sha256:
         raise ProjectDeclarationError("local adapter source hash does not match declaration")
     return selected
-

--- a/breadboard/product/integrations/catalog.py
+++ b/breadboard/product/integrations/catalog.py
@@ -17,6 +17,10 @@ _KIND_VALUES = {"provider_adapter", "tool_executor", "host_driver", "capture_ada
 _HASH_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 _ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
 _SCHEMA_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _valid_sha256(value: object) -> bool:
+    return isinstance(value, str) and _HASH_RE.fullmatch(value) is not None
 _RFC3339_RE = re.compile(
     r"^(?P<year>[0-9]{4})-(?P<month>[0-9]{2})-(?P<day>[0-9]{2})[Tt]"
     r"(?P<hour>[0-9]{2}):(?P<minute>[0-9]{2}):(?P<second>[0-9]{2})(?:\.[0-9]+)?"
@@ -112,7 +116,7 @@ class IntegrationDescriptor:
         if self.configuration_schema_id is not None and not _SCHEMA_ID_RE.fullmatch(self.configuration_schema_id):
             raise IntegrationError("invalid configuration schema id")
         _validate_metadata_arrays(self.capabilities, self.effects, self.permissions, self.secret_reference_names)
-        if self.probe_evidence_sha256 is not None and not _HASH_RE.fullmatch(self.probe_evidence_sha256):
+        if self.probe_evidence_sha256 is not None and not _valid_sha256(self.probe_evidence_sha256):
             raise IntegrationError("probe evidence must be a sha256 digest")
 
     def to_record(self) -> dict[str, Any]:
@@ -299,6 +303,7 @@ def probe_for(
     permissions: Iterable[str] | None = None,
     error: str | None = None,
 ) -> ProbeReport:
+    error = error or ("descriptor unavailable" if descriptor.status == "unavailable" else None)
     status = "unavailable" if error else descriptor.status
     report = ProbeReport(
         "bb.capability_probe_report.v1",

--- a/breadboard/product/integrations/host.py
+++ b/breadboard/product/integrations/host.py
@@ -1,7 +1,7 @@
 """Host/sandbox adapter for the frozen integration catalog port."""
 from __future__ import annotations
 
-from typing import Any, Iterable, Mapping, Protocol, runtime_checkable
+from typing import Any, Iterable, Protocol, runtime_checkable
 
 from .catalog import IntegrationDescriptor, ProbeReport, probe_for
 

--- a/breadboard/product/integrations/object_store.py
+++ b/breadboard/product/integrations/object_store.py
@@ -1,7 +1,7 @@
 """Artifact/object-store adapter for the frozen integration catalog port."""
 from __future__ import annotations
 
-from typing import Any, Iterable, Mapping, Protocol, runtime_checkable
+from typing import Any, Iterable, Protocol, runtime_checkable
 
 from .catalog import IntegrationDescriptor, ProbeReport, probe_for
 

--- a/breadboard/product/integrations/provider.py
+++ b/breadboard/product/integrations/provider.py
@@ -1,7 +1,7 @@
 """Provider runtime adapter for the frozen integration catalog port."""
 from __future__ import annotations
 
-from typing import Any, Mapping, Protocol, Sequence, runtime_checkable
+from typing import Any, Mapping, Protocol, runtime_checkable
 
 from agentic_coder_prototype.provider.routing import ProviderDescriptor
 from agentic_coder_prototype.provider.runtime import ProviderResult, ProviderRuntime, ProviderRuntimeContext

--- a/tests/product/integrations/test_catalog.py
+++ b/tests/product/integrations/test_catalog.py
@@ -5,6 +5,7 @@ import json
 import pytest
 from jsonschema import Draft202012Validator
 from breadboard.product.integrations import CaptureIntegrationAdapter, IncompatibleAdapterError, IntegrationCatalog, IntegrationDescriptor, IntegrationError, ProbeReport, ProjectDeclarationError, internal_capture_adapters, load_capture_entry_points, resolve_local_capture_declaration
+from breadboard.product.integrations.catalog import probe_for
 
 
 def test_internal_and_external_adapters(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -24,6 +25,7 @@ def test_local_declaration_is_hash_and_grant_bound(tmp_path: Path) -> None:
     declaration = {"adapter_id": "local", "source_path": "adapter.py", "source_sha256": digest, "grants": ["capture"]}
     assert resolve_local_capture_declaration(declaration, project_root=str(tmp_path), adapter=adapter) is adapter
     with pytest.raises(ProjectDeclarationError): resolve_local_capture_declaration({**declaration, "grants": []}, project_root=str(tmp_path), adapter=adapter)
+    with pytest.raises(ProjectDeclarationError): resolve_local_capture_declaration({**declaration, "source_sha256": "sha256:" + "g" * 64}, project_root=str(tmp_path), adapter=adapter)
 
 
 def test_probe_identity_and_timestamp_fail_closed() -> None:
@@ -34,6 +36,13 @@ def test_probe_identity_and_timestamp_fail_closed() -> None:
         def __init__(self) -> None: self.descriptor = descriptor
         def probe(self) -> ProbeReport: return ProbeReport("bb.capability_probe_report.v1", "probe:x", "tool:x", "host_driver", "impl", "available", checked_at_utc="now")
     assert IntegrationCatalog([Bad()]).probe("tool:x").status == "unavailable"
+
+
+def test_unavailable_descriptor_probe_has_stable_error() -> None:
+    descriptor = IntegrationDescriptor("bb.integration_descriptor.v1", "tool:x", "tool_executor", "v1", "impl", status="unavailable")
+    report = probe_for(descriptor)
+    assert report.status == "unavailable"
+    assert report.error == "descriptor unavailable"
 
 
 @pytest.mark.parametrize("checked_at_utc", ["0000-01-01T00:00:00Z", "2026-07-21T12:34:56Z", "2026-07-21t12:34:56z", "2016-12-31T23:59:60Z", "2017-01-01T00:59:60+01:00", "2026-07-21T12:34:56+05:30"])
@@ -84,10 +93,11 @@ def test_capture_adapter_batches_register_atomically(tmp_path: Path, monkeypatch
     assert catalog.list() == []
 
 
-def test_records_match_public_schemas_and_traversal_is_rejected(tmp_path: Path) -> None:
+def test_records_match_public_schemas_and_traversal_is_rejected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
     catalog = IntegrationCatalog(internal_capture_adapters())
     for name, record in (("bb.integration_descriptor.v1", catalog.list()[0].to_record()), ("bb.capability_probe_report.v1", catalog.probe("capture:json").to_record())):
-        schema = json.load(open("contracts/public/schemas/" + name + ".schema.json"))
+        schema = json.loads((Path(__file__).resolve().parents[3] / "contracts/public/schemas" / f"{name}.schema.json").read_text())
         assert list(Draft202012Validator(schema).iter_errors(record)) == []
     declaration = {"adapter_id": "local", "source_path": "../adapter.py", "source_sha256": "sha256:" + "0" * 64, "grants": ["capture"]}
     with pytest.raises(ProjectDeclarationError): resolve_local_capture_declaration(declaration, project_root=str(tmp_path), adapter=internal_capture_adapters()[0])


### PR DESCRIPTION
Tracker: bb-06u.31

Closes all retained NS06 integration-boundary P3 findings on exact base e1f5d84e:
- stable error for unavailable descriptors
- one shared strict SHA-256 validator across descriptors, declarations, and adapters
- cwd-independent schema validation
- unused integration imports removed
- existing RFC3339, unique metadata, and atomic batch registration locks retained

Exact head: c0a326a12
Scope: 6 files, +25/-13
Verification: 82 focused integration/public/CLI tests passed; immutable ten-axis smoke passed all ten (smoke-only, no score); exact-head independent review CLEAN; git diff --check clean.