### PR TITLE
fix(tui): preserve cached session metadata across sparse refreshes

### DIFF
--- a/tui_skeleton/src/cache/sessionCache.ts
+++ b/tui_skeleton/src/cache/sessionCache.ts
@@ -98,6 +98,7 @@ export const rememberSession = async (
     model: options.model ?? (summary.metadata?.model as string | undefined) ?? previous?.model,
     loggingDir: summary.logging_dir ?? previous?.loggingDir ?? null,
     mode: summary.mode ?? previous?.mode,
+    metadata: normalizeMetadata(summary.metadata ?? previous?.metadata ?? null),
     draft: previous?.draft ?? null,
   }
   cache.sessions[entry.sessionId] = entry

--- a/tui_skeleton/src/commands/repl/__tests__/controllerRecentSessions.test.ts
+++ b/tui_skeleton/src/commands/repl/__tests__/controllerRecentSessions.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { ReplSessionController } from "../controller.js"
-import { rememberSession } from "../../../cache/sessionCache.js"
+import { loadSessionCache, rememberSession } from "../../../cache/sessionCache.js"
 
 const previousCacheEnv = process.env.BREADBOARD_SESSION_CACHE
 
@@ -55,6 +55,26 @@ describe("recent session re-entry helpers", () => {
       "backend-session:backend",
       "cached-session:cache",
     ])
+
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it("preserves metadata across sparse session refreshes", async () => {
+    const dir = await withTempSessionCache()
+    await rememberSession({
+      session_id: "sparse-session",
+      status: "running",
+      metadata: { model: "cached-model", name: "Cached session" },
+    })
+    await rememberSession({
+      session_id: "sparse-session",
+      status: "paused",
+    })
+
+    expect((await loadSessionCache()).sessions["sparse-session"]?.metadata).toEqual({
+      model: "cached-model",
+      name: "Cached session",
+    })
 
     await rm(dir, { recursive: true, force: true })
   })


### PR DESCRIPTION
Closes bb-nzhu.

PR #62 made session refreshes tolerant of sparse canonical summaries, but `rememberSession()` stopped writing `CachedSessionEntry.metadata`. A rich summary followed by a sparse refresh therefore discarded the cached metadata object.

This restores the prior metadata contract while retaining sparse-summary fallback behavior.

Checks:
- `tui_skeleton/node_modules/.bin/tsc --noEmit -p tui_skeleton/tsconfig.json`
- `npm run -s test -- src/commands/repl/__tests__/controllerRecentSessions.test.ts` (4 passed)
- full TUI suite (220 files, 1134 tests passed)