### PR TITLE
Make the legacy LineEditor timing test deterministic

### DIFF
--- a/tui_skeleton/src/repl/components/__tests__/LineEditor.test.tsx
+++ b/tui_skeleton/src/repl/components/__tests__/LineEditor.test.tsx
@@ -47,16 +47,28 @@ describe("LineEditor", () => {
 
   it("keeps slowly typed literal CSI-u text as normal input", async () => {
     const handleChange = vi.fn()
-    const { stdin } = render(
+    const view = render(
       <LineEditor value="first line" cursor={10} focus placeholder="test" onChange={handleChange} onSubmit={() => {}} />,
     )
     await flush()
-    for (const char of "[13;2u") {
-      stdin.write(char)
-      await flush()
+
+    view.stdin.write("[")
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    view.stdin.write("1")
+    await vi.waitFor(() => expect(handleChange).toHaveBeenLastCalledWith("first line[1", 12))
+
+    for (const [char, expectedValue, expectedCursor] of [
+      ["3", "first line[13", 13],
+      [";", "first line[13;", 14],
+      ["2", "first line[13;2", 15],
+      ["u", "first line[13;2u", 16],
+    ] as const) {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      view.stdin.write(char)
+      await vi.waitFor(() => expect(handleChange).toHaveBeenLastCalledWith(expectedValue, expectedCursor))
     }
-    await flush()
-    expect(handleChange).toHaveBeenLastCalledWith("first line[13;2u", 16)
+
+    view.unmount()
   })
 
   it("routes fake clipboard images to attachment handling on Ctrl+V", async () => {

--- a/tui_skeleton/src/repl/components/__tests__/LineEditor.test.tsx
+++ b/tui_skeleton/src/repl/components/__tests__/LineEditor.test.tsx
@@ -68,7 +68,6 @@ describe("LineEditor", () => {
       await vi.waitFor(() => expect(handleChange).toHaveBeenLastCalledWith(expectedValue, expectedCursor))
     }
 
-    view.unmount()
   })
 
   it("routes fake clipboard images to attachment handling on Ctrl+V", async () => {


### PR DESCRIPTION
## Problem\n\nPost-merge main CI run 32605196002 failed on macOS because the "slowly typed literal CSI-u" test used zero-delay timer flushes as a proxy for processed, slow input. Under suite load, the first buffered `[` was not present in the last observed callback. The same PR head had passed the macOS matrix, establishing a timing-dependent test rather than a product regression.\n\n## Fix\n\n- use a real interval longer than the input processor 12 ms burst threshold\n- wait for each observable editor state before sending the next character\n- preserve the Ink test library shared stdin lifecycle between cases\n\nAn initial teardown attempt proved invalid on the macOS runner: unmounting the view closed the shared stdin before the following clipboard case. Run 32605621584 caught that directly; b8d593d4 removes the teardown while retaining observable-state synchronization.\n\n## Evidence\n\n- CI-matched Node 20 focused file: 5/5 passed\n- focused scenario stress: 40/40 passed\n- complete legacy contract harness: 220 files / 1,135 tests passed\n\nNo runtime code changed.