### PR TITLE
Remove stale product TUI setup paths

### DIFF
--- a/docs/getting-started/INSTALL_AND_DEV_QUICKSTART.md
+++ b/docs/getting-started/INSTALL_AND_DEV_QUICKSTART.md
@@ -72,19 +72,6 @@ make setup-tui          # retained legacy contract-harness profile
 make setup-all          # full bootstrap + confidence pass
 ```
 
-### Via the Python engine CLI (if already installed)
-
-```bash
-breadboard setup
-breadboard setup --sdk-hello-live
-breadboard setup --all-checks
-breadboard setup --profile engine
-breadboard setup --profile tui
-```
-
-The retained `tui` profile name means the in-repo legacy contract harness, not
-the standalone BreadBoard product TUI.
-
 ### Bootstrap flags
 
 ```bash

--- a/docs/getting-started/INSTALL_AND_DEV_QUICKSTART.md
+++ b/docs/getting-started/INSTALL_AND_DEV_QUICKSTART.md
@@ -39,18 +39,19 @@ package is now a compatibility shim that resolves to `breadboard_engine`
 bash scripts/dev/bootstrap_first_time.sh
 ```
 
-Engine-only (if `tui_skeleton` sources are absent or not needed):
+Engine-only (skip the TypeScript SDK and legacy contract harness):
 
 ```bash
 bash scripts/dev/bootstrap_first_time.sh --profile engine
 ```
 
-What it does:
+The default full profile:
 
 - creates or reuses `.venv` (prefers `uv` when available)
-- installs Python dependencies from `requirements.txt`
-- builds `sdk/ts` and `tui_skeleton` when sources are present
-- installs the local `breadboard`/`bb` CLI wrapper
+- installs Python dependencies and the Python-owned `breadboard` engine CLI
+- builds `sdk/ts` and the legacy `tui_skeleton` contract harness when present
+- does not install `bb`; obtain the product TUI separately from
+  [`kmccleary3301/breadboard-tui`](https://github.com/kmccleary3301/breadboard-tui)
 - runs the first-time setup doctor
 
 The script is incremental on repeat runs:
@@ -67,11 +68,11 @@ make setup-fast         # full bootstrap, skip doctor checks
 make setup-engine       # engine only
 make setup-fast-engine  # engine only, skip doctor checks
 make setup-refresh-python   # force Python dependency reinstall in existing .venv
-make setup-tui          # TUI side only
+make setup-tui          # retained legacy contract-harness profile
 make setup-all          # full bootstrap + confidence pass
 ```
 
-### Via the CLI wrapper (if already installed)
+### Via the Python engine CLI (if already installed)
 
 ```bash
 breadboard setup
@@ -80,6 +81,9 @@ breadboard setup --all-checks
 breadboard setup --profile engine
 breadboard setup --profile tui
 ```
+
+The retained `tui` profile name means the in-repo legacy contract harness, not
+the standalone BreadBoard product TUI.
 
 ### Bootstrap flags
 
@@ -93,7 +97,7 @@ bash scripts/dev/bootstrap_first_time.sh --recreate-venv
 # Force reinstall Python dependencies
 bash scripts/dev/bootstrap_first_time.sh --refresh-python-deps
 
-# Skip one side if you only need engine or only TUI
+# Skip Python or Node/legacy-harness setup
 bash scripts/dev/bootstrap_first_time.sh --skip-node
 bash scripts/dev/bootstrap_first_time.sh --skip-python
 

--- a/docs/quickstarts/FIRST_RUN_5_MIN.md
+++ b/docs/quickstarts/FIRST_RUN_5_MIN.md
@@ -20,18 +20,19 @@ From the repo root:
 bash scripts/dev/bootstrap_first_time.sh
 ```
 
-Engine-only (if you don't need the TUI):
+Engine-only (skip the TypeScript SDK and legacy contract harness):
 
 ```bash
 bash scripts/dev/bootstrap_first_time.sh --profile engine
 ```
 
-What this does:
+The default full profile:
 
 - creates or reuses `.venv` (prefers `uv` when available)
-- installs Python dependencies from `requirements.txt`
-- builds `sdk/ts` and `tui_skeleton`
-- installs the local `breadboard`/`bb` CLI wrapper
+- installs Python dependencies and the Python-owned `breadboard` engine CLI
+- builds `sdk/ts` and the legacy `tui_skeleton` contract harness
+- does not install `bb`; obtain the product TUI separately from
+  [`kmccleary3301/breadboard-tui`](https://github.com/kmccleary3301/breadboard-tui)
 - runs first-time doctor
 
 Subsequent runs are incremental—Python and Node installs are skipped when lockfiles and outputs are unchanged.
@@ -44,7 +45,7 @@ Subsequent runs are incremental—Python and Node installs are skipped when lock
 python scripts/dev/first_time_doctor.py --strict
 ```
 
-Verify the installed product catalog:
+Verify the installed engine catalog:
 
 ```bash
 breadboard --json system describe

--- a/scripts/dev/bootstrap_first_time.sh
+++ b/scripts/dev/bootstrap_first_time.sh
@@ -11,7 +11,7 @@ RUN_SDK_HELLO_LIVE=0
 SKIP_PYTHON=0
 SKIP_NODE=0
 RECREATE_VENV=0
-HAS_TUI_SOURCE=0
+HAS_LEGACY_TUI_HARNESS=0
 HAS_TS_SDK_SOURCE=0
 REFRESH_PYTHON_DEPS=0
 
@@ -29,7 +29,7 @@ Options:
   --sdk-hello-live  Run live python+ts SDK hello verification after setup.
   --no-doctor       Skip first-time doctor checks.
   --skip-python     Skip Python venv + dependency install.
-  --skip-node       Skip Node deps + TUI build.
+  --skip-node       Skip Node dependencies and legacy contract-harness build.
   --recreate-venv   Remove and recreate .venv.
   --refresh-python-deps
                    Force reinstall of Python dependencies even if unchanged.
@@ -96,7 +96,7 @@ if [[ ! -f "${ROOT_DIR}/requirements.txt" || ! -f "${ROOT_DIR}/sdk/ts/package.js
 fi
 
 if [[ -f "${ROOT_DIR}/tui_skeleton/package.json" ]]; then
-  HAS_TUI_SOURCE=1
+  HAS_LEGACY_TUI_HARNESS=1
 fi
 if [[ -f "${ROOT_DIR}/sdk/ts/package.json" ]]; then
   HAS_TS_SDK_SOURCE=1
@@ -118,11 +118,11 @@ case "${PROFILE}" in
     ;;
 esac
 
-if [[ "${PROFILE}" == "full" && "${HAS_TUI_SOURCE}" == "0" ]]; then
+if [[ "${PROFILE}" == "full" && "${HAS_LEGACY_TUI_HARNESS}" == "0" ]]; then
   echo "[bootstrap] note: tui_skeleton/package.json not found; downgrading profile full -> engine"
   SKIP_NODE=1
   EFFECTIVE_PROFILE="engine"
-elif [[ "${PROFILE}" == "tui" && "${HAS_TUI_SOURCE}" == "0" ]]; then
+elif [[ "${PROFILE}" == "tui" && "${HAS_LEGACY_TUI_HARNESS}" == "0" ]]; then
   echo "[bootstrap] tui profile requested, but tui_skeleton/package.json is missing." >&2
   echo "[bootstrap] if this is an engine-only checkout, use --profile engine." >&2
   exit 2
@@ -354,7 +354,7 @@ install_node_deps_and_build() {
       "${ROOT_DIR}/sdk/ts/package-lock.json" \
       "${ROOT_DIR}/sdk/ts/tsconfig.json"
   fi
-  if [[ "${HAS_TUI_SOURCE}" == "1" ]]; then
+  if [[ "${HAS_LEGACY_TUI_HARNESS}" == "1" ]]; then
     npm_ci_if_needed "${ROOT_DIR}/tui_skeleton" "tui_skeleton"
     npm_build_if_needed \
       "${ROOT_DIR}/tui_skeleton" \
@@ -415,7 +415,7 @@ fi
 if [[ "${SKIP_NODE}" == "0" ]]; then
   install_node_deps_and_build
 else
-  echo "[bootstrap] skipping node/tui setup"
+  echo "[bootstrap] skipping Node and legacy contract-harness setup"
 fi
 
 if [[ "${RUN_DOCTOR}" == "1" ]]; then
@@ -460,6 +460,6 @@ fi
 echo "  4) Run the canonical product TUI from its standalone repository:"
 echo "     bb"
 echo "     Source: https://github.com/kmccleary3301/breadboard-tui"
-if [[ "${SKIP_NODE}" == "0" && "${HAS_TUI_SOURCE}" == "1" ]]; then
+if [[ "${SKIP_NODE}" == "0" && "${HAS_LEGACY_TUI_HARNESS}" == "1" ]]; then
   echo "     The in-repo tui_skeleton build is a legacy contract harness only."
 fi

--- a/scripts/dev/devx_smoke.sh
+++ b/scripts/dev/devx_smoke.sh
@@ -7,7 +7,7 @@ PROFILE="full"
 SKIP_ONBOARDING_CONTRACT=0
 SKIP_QUICKSTART_HELPER=0
 BREADBOARD_OK=1
-HAS_TUI_SOURCE=0
+HAS_LEGACY_TUI_HARNESS=0
 DOCTOR_FIRST_TIME_OK=0
 SETUP_PROFILE_OK=0
 
@@ -74,7 +74,7 @@ fi
 echo "[devx-smoke] profile=${PROFILE}"
 
 if [[ -f "${ROOT_DIR}/tui_skeleton/package.json" ]]; then
-  HAS_TUI_SOURCE=1
+  HAS_LEGACY_TUI_HARNESS=1
 fi
 
 if ! breadboard --help >/tmp/breadboard_devx_help.txt 2>&1; then
@@ -92,13 +92,13 @@ fi
 
 echo "[devx-smoke] first-time doctor profiles"
 python scripts/dev/first_time_doctor.py --profile engine --strict
-if [[ "${PROFILE}" == "full" && "${HAS_TUI_SOURCE}" == "1" && "${BREADBOARD_OK}" == "1" ]]; then
+if [[ "${PROFILE}" == "full" && "${HAS_LEGACY_TUI_HARNESS}" == "1" && "${BREADBOARD_OK}" == "1" ]]; then
   if python scripts/dev/first_time_doctor.py --profile full --strict; then
     python scripts/dev/first_time_doctor.py --profile tui --strict
   else
     echo "[devx-smoke] warning: full profile strict doctor failed; continuing with engine-first checks"
   fi
-elif [[ "${PROFILE}" == "full" && "${HAS_TUI_SOURCE}" == "1" ]]; then
+elif [[ "${PROFILE}" == "full" && "${HAS_LEGACY_TUI_HARNESS}" == "1" ]]; then
   echo "[devx-smoke] skipping full/tui doctor profiles: breadboard CLI is unavailable"
 fi
 
@@ -113,7 +113,7 @@ if [[ "${BREADBOARD_OK}" == "1" ]]; then
   if [[ "${DOCTOR_FIRST_TIME_OK}" == "1" ]]; then
     echo "[devx-smoke] doctor first-time command variants"
     breadboard doctor --first-time --first-time-profile engine
-    if [[ "${PROFILE}" == "full" && "${HAS_TUI_SOURCE}" == "1" ]]; then
+    if [[ "${PROFILE}" == "full" && "${HAS_LEGACY_TUI_HARNESS}" == "1" ]]; then
       breadboard doctor --first-time --first-time-profile full
       breadboard doctor --first-time --first-time-profile tui
     fi
@@ -124,7 +124,7 @@ if [[ "${BREADBOARD_OK}" == "1" ]]; then
   if [[ "${SETUP_PROFILE_OK}" == "1" ]]; then
     echo "[devx-smoke] setup profile passthrough"
     breadboard setup --profile engine --skip-node --no-doctor
-    if [[ "${PROFILE}" == "full" && "${HAS_TUI_SOURCE}" == "1" ]]; then
+    if [[ "${PROFILE}" == "full" && "${HAS_LEGACY_TUI_HARNESS}" == "1" ]]; then
       breadboard setup --profile tui --skip-python --no-doctor
     fi
   else

--- a/scripts/dev/devx_smoke.sh
+++ b/scripts/dev/devx_smoke.sh
@@ -8,8 +8,6 @@ SKIP_ONBOARDING_CONTRACT=0
 SKIP_QUICKSTART_HELPER=0
 BREADBOARD_OK=1
 HAS_LEGACY_TUI_HARNESS=0
-DOCTOR_FIRST_TIME_OK=0
-SETUP_PROFILE_OK=0
 
 usage() {
   cat <<'EOF'
@@ -81,14 +79,6 @@ if ! breadboard --help >/tmp/breadboard_devx_help.txt 2>&1; then
   BREADBOARD_OK=0
 fi
 
-if [[ "${BREADBOARD_OK}" == "1" ]]; then
-  if breadboard doctor --help 2>/tmp/breadboard_doctor_help.err | grep -q -- "--first-time"; then
-    DOCTOR_FIRST_TIME_OK=1
-  fi
-  if breadboard setup --help 2>/tmp/breadboard_setup_help.err | grep -q -- "--profile"; then
-    SETUP_PROFILE_OK=1
-  fi
-fi
 
 echo "[devx-smoke] first-time doctor profiles"
 python scripts/dev/first_time_doctor.py --profile engine --strict
@@ -109,28 +99,7 @@ else
   echo "[devx-smoke] quickstart helper skipped (--skip-quickstart-helper)"
 fi
 
-if [[ "${BREADBOARD_OK}" == "1" ]]; then
-  if [[ "${DOCTOR_FIRST_TIME_OK}" == "1" ]]; then
-    echo "[devx-smoke] doctor first-time command variants"
-    breadboard doctor --first-time --first-time-profile engine
-    if [[ "${PROFILE}" == "full" && "${HAS_LEGACY_TUI_HARNESS}" == "1" ]]; then
-      breadboard doctor --first-time --first-time-profile full
-      breadboard doctor --first-time --first-time-profile tui
-    fi
-  else
-    echo "[devx-smoke] skipping doctor --first-time variants: CLI does not support these flags"
-  fi
-
-  if [[ "${SETUP_PROFILE_OK}" == "1" ]]; then
-    echo "[devx-smoke] setup profile passthrough"
-    breadboard setup --profile engine --skip-node --no-doctor
-    if [[ "${PROFILE}" == "full" && "${HAS_LEGACY_TUI_HARNESS}" == "1" ]]; then
-      breadboard setup --profile tui --skip-python --no-doctor
-    fi
-  else
-    echo "[devx-smoke] skipping setup --profile passthrough: CLI does not support this command/flags"
-  fi
-else
+if [[ "${BREADBOARD_OK}" == "0" ]]; then
   echo "[devx-smoke] breadboard CLI unavailable; validating bootstrap script directly"
   bash scripts/dev/bootstrap_first_time.sh --profile engine --no-doctor
 fi

--- a/scripts/dev/quickstart_first_time.py
+++ b/scripts/dev/quickstart_first_time.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 
+CliProbe = tuple[bool, str]
+
 
 def _venv_python_path() -> Path:
     unix = ROOT_DIR / ".venv" / "bin" / "python"
@@ -18,7 +20,7 @@ def _venv_python_path() -> Path:
     return unix if unix.exists() else windows
 
 
-def _breadboard_cli_usable() -> tuple[bool, str]:
+def _breadboard_cli_usable() -> CliProbe:
     override = os.environ.get("BREADBOARD_QUICKSTART_ASSUME_CLI")
     if override:
         normalized = override.strip().lower()
@@ -46,7 +48,7 @@ def _breadboard_cli_usable() -> tuple[bool, str]:
     return True, cli
 
 
-def _bb_cli_usable() -> tuple[bool, str]:
+def _bb_cli_usable() -> CliProbe:
     override = os.environ.get("BREADBOARD_QUICKSTART_ASSUME_BB")
     if override:
         normalized = override.strip().lower()
@@ -74,9 +76,12 @@ def _bb_cli_usable() -> tuple[bool, str]:
     return True, cli
 
 
-def _cli_capabilities() -> dict:
-    breadboard_ok, breadboard_detail = _breadboard_cli_usable()
-    bb_ok, bb_detail = _bb_cli_usable()
+def _cli_capabilities_from(
+    breadboard: CliProbe,
+    bb: CliProbe,
+) -> dict[str, bool | str]:
+    breadboard_ok, breadboard_detail = breadboard
+    bb_ok, bb_detail = bb
     return {
         "breadboard_available": breadboard_ok,
         "system_health_supported": breadboard_ok,
@@ -86,11 +91,17 @@ def _cli_capabilities() -> dict:
     }
 
 
-def _build_payload(include_advanced: bool) -> dict:
+def _cli_capabilities() -> dict[str, bool | str]:
+    return _cli_capabilities_from(_breadboard_cli_usable(), _bb_cli_usable())
+
+
+def _build_payload(include_advanced: bool) -> dict[str, object]:
     has_legacy_tui_harness = (ROOT_DIR / "tui_skeleton" / "package.json").exists()
     venv_python = str(_venv_python_path())
-    cli_ok, cli_detail = _breadboard_cli_usable()
-    bb_ok, bb_detail = _bb_cli_usable()
+    breadboard_probe = _breadboard_cli_usable()
+    bb_probe = _bb_cli_usable()
+    cli_ok, cli_detail = breadboard_probe
+    bb_ok, bb_detail = bb_probe
 
     actions = [
         {"step": "bootstrap", "command": "bash scripts/dev/bootstrap_first_time.sh"},
@@ -145,7 +156,7 @@ def _build_payload(include_advanced: bool) -> dict:
         "breadboard_cli_detail": cli_detail,
         "bb_cli_usable": bb_ok,
         "bb_cli_detail": bb_detail,
-        "cli_capabilities": _cli_capabilities(),
+        "cli_capabilities": _cli_capabilities_from(breadboard_probe, bb_probe),
         "recommended_actions": actions,
     }
 

--- a/tests/test_devx_first_time_scripts.py
+++ b/tests/test_devx_first_time_scripts.py
@@ -5,6 +5,10 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
+from scripts.dev import quickstart_first_time
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -78,6 +82,33 @@ def test_quickstart_separates_engine_cli_from_product_tui() -> None:
     assert all("breadboard run" not in command for command in commands)
     assert all("breadboard ui" not in command for command in commands)
     assert all(action["step"] != "tui" for action in actions)
+
+
+def test_quickstart_payload_uses_one_consistent_cli_probe_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"breadboard": 0, "bb": 0}
+
+    def probe_breadboard() -> tuple[bool, str]:
+        calls["breadboard"] += 1
+        return calls["breadboard"] == 1, f"breadboard-call-{calls['breadboard']}"
+
+    def probe_bb() -> tuple[bool, str]:
+        calls["bb"] += 1
+        return calls["bb"] == 1, f"bb-call-{calls['bb']}"
+
+    monkeypatch.setattr(quickstart_first_time, "_breadboard_cli_usable", probe_breadboard)
+    monkeypatch.setattr(quickstart_first_time, "_bb_cli_usable", probe_bb)
+
+    payload = quickstart_first_time._build_payload(include_advanced=False)
+    capabilities = payload["cli_capabilities"]
+
+    assert calls == {"breadboard": 1, "bb": 1}
+    assert isinstance(capabilities, dict)
+    assert payload["breadboard_cli_usable"] is capabilities["breadboard_available"] is True
+    assert payload["bb_cli_usable"] is capabilities["bb_available"] is True
+    assert payload["breadboard_cli_detail"] == capabilities["detail"] == "breadboard-call-1"
+    assert payload["bb_cli_detail"] == capabilities["bb_detail"] == "bb-call-1"
 
 
 def test_quickstart_first_time_include_advanced_contains_engine_full_pass_step() -> None:


### PR DESCRIPTION
## Problem

The canonical migration left documentation and dev smoke branches for `breadboard setup` and `breadboard doctor` commands that the Python engine/harness CLI does not expose. Those paths blurred the now-explicit authority split: `bb` is the standalone product TUI; `breadboard` is the Python engine/harness CLI.

## Changes

- remove unsupported Python CLI setup examples from the active install/dev quickstart
- delete dead setup/doctor feature probes and invocation branches from `devx_smoke.sh`
- retain the direct first-time doctor scripts, legacy contract-harness profile checks, quickstart helper, and bootstrap fallback

## Verification

- shell syntax checks passed
- focused onboarding/product-authority tests: 9 passed
- strict onboarding contract: 46/46 passed
- independent final review: APPROVE