### PR TITLE
Promote BreadBoard TUI 0.1.0-rc.2 authority

### DIFF
--- a/config/product/tui-release.json
+++ b/config/product/tui-release.json
@@ -3,9 +3,9 @@
   "status": "primary",
   "repository": "https://github.com/kmccleary3301/breadboard-tui",
   "defaultBranch": "main",
-  "sourceCommit": "bc1ef04b40aef375c3986918398b72a83a2a2ab6",
-  "sourceTree": "3095a0ad152c8c5e84e3049b8f22da79325a815b",
-  "productVersion": "0.1.0-rc.1",
+  "sourceCommit": "7e3e1b2b9bbca97af94901984d12e826219872b3",
+  "sourceTree": "c18fedf5eb8e2c0dc9da8eaf10a03ac89a8227b0",
+  "productVersion": "0.1.0-rc.2",
   "binary": "bb",
   "upstream": {
     "repository": "https://github.com/can1357/oh-my-pi",


### PR DESCRIPTION
## Change

Advance the monorepo's canonical product-TUI authority contract to the shipped downstream candidate:

- product `0.1.0-rc.2`
- source commit `7e3e1b2b9bbca97af94901984d12e826219872b3`
- source tree `c18fedf5eb8e2c0dc9da8eaf10a03ac89a8227b0`

OMP v18.0.0, SDK 0.3.0, backend provenance, engine API range, and the non-distributable legacy harness role are unchanged.

Release: https://github.com/kmccleary3301/breadboard-tui/releases/tag/product/breadboard-tui-v0.1.0-rc.2-canonical

## Verification

- canonical TUI authority test: 1 passed
- JSON parse: passed
- release artifact digest: `744cd0bbd49ebd71e8acf9e6706b20588e21d280d72be1f4834a81ed3c86390e`
- downloaded release binary `--version` and `--smoke-test`: passed
- downstream hosted main CI, fork audit, and Nix CI: passed