### PR TITLE
fix(build): include dependency locks in source distributions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -251,7 +251,11 @@ def _target() -> dict[str, str]:
 class SdistWithSourceIdentity(_sdist):
     def make_release_tree(self, base_dir: str, files: list[str]) -> None:
         repository, commit, tree = _source_identity()
-        super().make_release_tree(base_dir, files)
+        release_files = list(files)
+        for dependency_lock in ("requirements.txt", "requirements_web.txt"):
+            if dependency_lock not in release_files:
+                release_files.append(dependency_lock)
+        super().make_release_tree(base_dir, release_files)
         path = Path(base_dir) / "breadboard_engine" / _SOURCE_IDENTITY_FILENAME
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(

--- a/tests/test_provider_differential_f6.py
+++ b/tests/test_provider_differential_f6.py
@@ -310,6 +310,32 @@ def test_wheel_provenance_uses_embedded_sdist_source_identity(
         "b" * 40,
     )
 
+def test_sdist_includes_dependency_locks(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(setuptools, "setup", lambda **_kwargs: None)
+    namespace = runpy.run_path(str(ROOT / "setup.py"), run_name="bb_setup_test")
+    captured_files: list[str] = []
+    monkeypatch.setattr(
+        namespace["_sdist"],
+        "make_release_tree",
+        lambda _command, _base_dir, files: captured_files.extend(files),
+    )
+    namespace["SdistWithSourceIdentity"].make_release_tree.__globals__[
+        "_source_identity"
+    ] = lambda: (
+        "https://github.com/kmccleary3301/breadboard.git",
+        "a" * 40,
+        "b" * 40,
+    )
+    command = namespace["SdistWithSourceIdentity"](setuptools.Distribution())
+
+    command.make_release_tree(str(tmp_path / "release"), ["setup.py"])
+
+    assert "requirements.txt" in captured_files
+    assert "requirements_web.txt" in captured_files
+
 def test_wheel_provenance_validates_before_populating_build_output(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Problem
Building a wheel from the canonical sdist failed because `requirements.txt` and `requirements_web.txt` were absent while provenance hashing requires both files.

## Fix
- include both dependency locks in `SdistWithSourceIdentity.make_release_tree`
- add a focused regression for the sdist file set

## Evidence
- focused provenance tests: 2 passed
- exact-head clean sdist build: passed
- exact-head wheel-from-sdist build: passed

## Rollback
Revert this PR merge commit; no runtime or public API behavior changes.