### PR TITLE
Complete installed BreadBoard reconnect journey

### DIFF
--- a/agent_configs/templates/daily_driver.v1.yaml
+++ b/agent_configs/templates/daily_driver.v1.yaml
@@ -21,6 +21,12 @@ prompts:
     base:
       system: prompts/daily_driver_system.md
 
+# Todo state is part of the ordinary coding workflow and its durable transcript.
+features:
+  todos:
+    enabled: true
+    strict: true
+
 # The packaged runtime registry supplies these ordinary coding tools.
 tools:
   mark_task_complete: true

--- a/agent_configs/templates/daily_driver.v1.yaml
+++ b/agent_configs/templates/daily_driver.v1.yaml
@@ -12,6 +12,8 @@ providers:
   models:
     - id: mock/reference
       adapter: mock_chat
+    - id: cli_mock/reference
+      adapter: cli_mock_chat
 
 # Prompt files are package resources and immutable inputs to the effective lock.
 prompts:

--- a/breadboard_engine/agent_llm_openai.py
+++ b/breadboard_engine/agent_llm_openai.py
@@ -5421,10 +5421,19 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
             return self._execute_todo_tool("todo.list", args)
         if name in {"create_file_from_block", "Write"}:
             path = self._normalize_workspace_path(
-                str(args.get("file_name") or args.get("filePath") or args.get("path") or "")
+                str(
+                    args.get("file_name")
+                    or args.get("filePath")
+                    or args.get("path")
+                    or ""
+                )
             )
             content = str(args.get("content", ""))
-            return self._ray_get(self.sandbox.write_text.remote(path, content))
+            return (
+                {"error": "private workspace storage is unavailable to model tools"}
+                if self._private_workspace_path(path)
+                else self._ray_get(self.sandbox.write_text.remote(path, content))
+            )
         if name == "mark_task_complete":
             return {"action": "complete"}
         if name.startswith("todo."):

--- a/breadboard_engine/agent_llm_openai.py
+++ b/breadboard_engine/agent_llm_openai.py
@@ -5240,7 +5240,9 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
                 "__mvi_text_output": "Plan updated",
             }
         if normalized == "create_file_from_block":
-            target = self._normalize_workspace_path(str(args.get("file_name", "")))
+            target = self._normalize_workspace_path(
+                str(args.get("file_name") or args.get("filePath") or args.get("path") or "")
+            )
             content = str(args.get("content", ""))
             return (
                 {"error": "private workspace storage is unavailable to model tools"} if self._private_workspace_path(target) else self._ray_get(self.sandbox.write_text.remote(target, content)))
@@ -5418,7 +5420,9 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
         if name == "todoread":
             return self._execute_todo_tool("todo.list", args)
         if name in {"create_file_from_block", "Write"}:
-            path = self._normalize_workspace_path(str(args.get("file_name", "")))
+            path = self._normalize_workspace_path(
+                str(args.get("file_name") or args.get("filePath") or args.get("path") or "")
+            )
             content = str(args.get("content", ""))
             return self._ray_get(self.sandbox.write_text.remote(path, content))
         if name == "mark_task_complete":

--- a/breadboard_engine/api/cli_bridge/events.py
+++ b/breadboard_engine/api/cli_bridge/events.py
@@ -46,6 +46,7 @@ def replay_retention_facts(
     retained = [event for event in events if event.stable_cursor and event.seq is not None]
     first = retained[0] if retained else None
     head = retained[-1] if retained and retained[-1].seq == head_sequence else None
+    virtual_head_retained = head_sequence > 0 and persisted_head_event_id is not None
     retained_history = (
         "partial" if retained_history_partial or (head_sequence and first is None) else "complete"
     )
@@ -55,8 +56,13 @@ def replay_retention_facts(
             "maxAgeMs": REPLAY_RETENTION_MAX_AGE_MS,
             "configurationDigest": replay_configuration_digest(),
         },
-        "earliestRetainedSequence": first.seq if first is not None else None,
-        "earliestRetainedEventId": first.event_id if first is not None else None,
+        "earliestRetainedSequence": (
+            first.seq if first is not None else head_sequence if virtual_head_retained else None
+        ),
+        "earliestRetainedEventId": (
+            first.event_id if first is not None
+            else persisted_head_event_id if virtual_head_retained else None
+        ),
         "headSequence": head_sequence,
         "headEventId": (
             head.event_id

--- a/breadboard_engine/api/cli_bridge/registry/persistence.py
+++ b/breadboard_engine/api/cli_bridge/registry/persistence.py
@@ -333,15 +333,6 @@ class PersistenceMixin:
 
     @staticmethod
     def _durable_replay_head(record: SessionRecord) -> tuple[int, str | None]:
-        for event in reversed(record.event_log):
-            if (
-                event.stable_cursor
-                and event.seq == record.event_seq
-                and record.event_seq > 0
-            ):
-                return record.event_seq, event.event_id
-        if record.event_seq > 0 and record.replay_head_event_id:
-            return record.event_seq, record.replay_head_event_id
         for envelope in reversed(record.terminal_event_envelopes):
             sequence = envelope.get("seq")
             event_id = envelope.get("id")

--- a/breadboard_engine/api/cli_bridge/registry/persistence.py
+++ b/breadboard_engine/api/cli_bridge/registry/persistence.py
@@ -421,6 +421,7 @@ class PersistenceMixin:
                 "event_head_id": durable_head_event_id,
                 "model": _retained_model_id(metadata.get("model")),
                 "config_path": str(metadata.get("config_path") or ""),
+                "workspace": str(metadata.get("workspace") or ""),
                 "model_role_lock": role_lock,
                 "active_model_role": str(active_role) if active_role else None,
                 "permission_mode": (
@@ -566,6 +567,8 @@ class PersistenceMixin:
             metadata["model"] = model
         if session.get("config_path"):
             metadata["config_path"] = str(session["config_path"])
+        if session.get("workspace"):
+            metadata["workspace"] = str(session["workspace"])
         permission_mode = str(session.get("permission_mode") or "").strip().lower()
         if permission_mode in {"prompt", "ask", "interactive", "configured"}:
             metadata["permission_mode"] = permission_mode

--- a/breadboard_engine/api/cli_bridge/registry/persistence.py
+++ b/breadboard_engine/api/cli_bridge/registry/persistence.py
@@ -411,6 +411,12 @@ class PersistenceMixin:
                 "config_path": str(metadata.get("config_path") or ""),
                 "model_role_lock": role_lock,
                 "active_model_role": str(active_role) if active_role else None,
+                "permission_mode": (
+                    str(metadata.get("permission_mode") or "").strip().lower()
+                    if str(metadata.get("permission_mode") or "").strip().lower()
+                    in {"prompt", "ask", "interactive", "configured"}
+                    else None
+                ),
             },
             "turns": turns,
             "submissions": submissions,
@@ -538,6 +544,9 @@ class PersistenceMixin:
             metadata["model"] = model
         if session.get("config_path"):
             metadata["config_path"] = str(session["config_path"])
+        permission_mode = str(session.get("permission_mode") or "").strip().lower()
+        if permission_mode in {"prompt", "ask", "interactive", "configured"}:
+            metadata["permission_mode"] = permission_mode
         role_lock = session.get("model_role_lock")
         if role_lock is not None:
             if not isinstance(role_lock, dict):
@@ -569,6 +578,7 @@ class PersistenceMixin:
             replay_history_partial=bool(persisted_event_seq),
             replay_head_event_id=persisted_head_event_id,
             metadata=metadata,
+            loaded_from_retained_state=True,
         )
         for item in payload.get("turns") or []:
             turn = TurnRecord(

--- a/breadboard_engine/api/cli_bridge/registry/persistence.py
+++ b/breadboard_engine/api/cli_bridge/registry/persistence.py
@@ -252,6 +252,7 @@ class PersistenceMixin:
         record: SessionRecord,
         *,
         terminal_event: SessionEvent | None = None,
+        cursor_event: SessionEvent | None = None,
     ) -> None:
         async with self._lock:
             if self._records.get(record.session_id) is not record:
@@ -260,33 +261,50 @@ class PersistenceMixin:
                 )
             if terminal_event is not None and self._state_root is None:
                 raise RuntimeError("durable terminal retention is unavailable")
-            retained: Dict[str, Any] | None = None
+            head_event = terminal_event or cursor_event
             resolution_turn: TurnRecord | None = None
             resolution_was_committed = False
-            if terminal_event is not None:
-                candidate = self._retained_terminal_envelope(terminal_event)
-                if candidate is not None and not any(
-                    item.get("id") == candidate.get("id")
-                    for item in record.terminal_event_envelopes
-                ):
-                    retained = candidate
-                    record.terminal_event_envelopes.append(candidate)
-                if terminal_event.turn_id is not None:
-                    resolution_turn = record.turns_by_id.get(terminal_event.turn_id)
-                    if (
-                        resolution_turn is None
-                        or resolution_turn.terminal_outcome is None
-                    ):
-                        raise RuntimeError(
-                            "terminal event does not resolve an admitted turn"
-                        )
-                    resolution_was_committed = (
-                        resolution_turn.terminal_resolution_committed
-                    )
-                    resolution_turn.terminal_resolution_committed = True
+            if terminal_event is not None and terminal_event.turn_id is not None:
+                resolution_turn = record.turns_by_id.get(terminal_event.turn_id)
+                if resolution_turn is None or resolution_turn.terminal_outcome is None:
+                    raise RuntimeError("terminal event does not resolve an admitted turn")
+                resolution_was_committed = resolution_turn.terminal_resolution_committed
+
+            previous_event_seq = record.event_seq
+            previous_event_seq_value = head_event.seq if head_event is not None else None
+            if head_event is not None:
+                if head_event.seq is None:
+                    record.event_seq += 1
+                    head_event.seq = record.event_seq
+                else:
+                    record.event_seq = max(record.event_seq, int(head_event.seq))
+            candidate = (
+                self._retained_terminal_envelope(terminal_event)
+                if terminal_event is not None
+                else None
+            )
+            retained: Dict[str, Any] | None = None
+            previous_replay_head_sequence = record.replay_head_sequence
+            previous_replay_head_event_id = record.replay_head_event_id
+            if head_event is not None:
+                record.replay_head_sequence = int(head_event.seq)
+                record.replay_head_event_id = head_event.event_id
+            if candidate is not None and not any(
+                item.get("id") == candidate.get("id")
+                for item in record.terminal_event_envelopes
+            ):
+                retained = candidate
+                record.terminal_event_envelopes.append(candidate)
+            if resolution_turn is not None:
+                resolution_turn.terminal_resolution_committed = True
             try:
                 self._persist_record_locked(record)
             except Exception:
+                record.event_seq = previous_event_seq
+                if head_event is not None:
+                    head_event.seq = previous_event_seq_value
+                record.replay_head_sequence = previous_replay_head_sequence
+                record.replay_head_event_id = previous_replay_head_event_id
                 if retained is not None:
                     record.terminal_event_envelopes.remove(retained)
                 if resolution_turn is not None:
@@ -333,6 +351,8 @@ class PersistenceMixin:
 
     @staticmethod
     def _durable_replay_head(record: SessionRecord) -> tuple[int, str | None]:
+        if record.replay_head_sequence > 0 and record.replay_head_event_id:
+            return record.replay_head_sequence, record.replay_head_event_id
         for envelope in reversed(record.terminal_event_envelopes):
             sequence = envelope.get("seq")
             event_id = envelope.get("id")
@@ -388,7 +408,7 @@ class PersistenceMixin:
         if not isinstance(role_lock, dict):
             role_lock = None
         active_role = metadata.get("active_model_role")
-        durable_event_seq, durable_head_event_id = self._durable_replay_head(record)
+        durable_head_sequence, durable_head_event_id = self._durable_replay_head(record)
         return {
             "schema_version": _STATE_SCHEMA_VERSION,
             "session": {
@@ -396,7 +416,8 @@ class PersistenceMixin:
                 "status": record.status.value,
                 "created_at": record.created_at.isoformat(),
                 "last_activity_at": record.last_activity_at.isoformat(),
-                "event_seq": durable_event_seq,
+                "event_seq": record.event_seq,
+                "replay_head_sequence": durable_head_sequence,
                 "event_head_id": durable_head_event_id,
                 "model": _retained_model_id(metadata.get("model")),
                 "config_path": str(metadata.get("config_path") or ""),
@@ -522,13 +543,23 @@ class PersistenceMixin:
         session = payload["session"]
         session_id = str(session["session_id"])
         persisted_event_seq = int(session.get("event_seq") or 0)
+        persisted_replay_head_sequence = int(
+            session.get("replay_head_sequence", persisted_event_seq) or 0
+        )
         persisted_head_event_id = session.get("event_head_id")
+        if (
+            persisted_replay_head_sequence < 0
+            or persisted_replay_head_sequence > persisted_event_seq
+        ):
+            raise ValueError("retained replay head sequence is invalid")
         if persisted_head_event_id is not None and (
             not isinstance(persisted_head_event_id, str) or not persisted_head_event_id
         ):
             raise ValueError("retained replay head identity is invalid")
-        if persisted_event_seq == 0 and persisted_head_event_id is not None:
+        if persisted_replay_head_sequence == 0 and persisted_head_event_id is not None:
             raise ValueError("empty retained replay has a head identity")
+        if persisted_replay_head_sequence > 0 and persisted_head_event_id is None:
+            raise ValueError("retained replay head has no identity")
         model = _retained_model_id(session.get("model"))
         metadata: Dict[str, Any] = {}
         if model is not None:
@@ -568,6 +599,7 @@ class PersistenceMixin:
             event_seq=persisted_event_seq,
             replay_history_partial=bool(persisted_event_seq),
             replay_head_event_id=persisted_head_event_id,
+            replay_head_sequence=persisted_replay_head_sequence,
             metadata=metadata,
             loaded_from_retained_state=True,
         )
@@ -627,13 +659,14 @@ class PersistenceMixin:
             record.event_log.extend(
                 sorted(rehydrated_events, key=lambda event: int(event.seq or 0))
             )
-        if record.event_seq > 0 and record.replay_head_event_id is None:
+        if record.replay_head_sequence > 0 and record.replay_head_event_id is None:
             if record.event_log:
                 legacy_head = record.event_log[-1]
-                record.event_seq = int(legacy_head.seq or 0)
+                record.replay_head_sequence = int(legacy_head.seq or 0)
                 record.replay_head_event_id = legacy_head.event_id
             else:
                 record.event_seq = 0
+                record.replay_head_sequence = 0
         committed_turn_ids = {
             str(item.get("turn_id"))
             for item in record.terminal_event_envelopes

--- a/breadboard_engine/api/cli_bridge/registry/persistence.py
+++ b/breadboard_engine/api/cli_bridge/registry/persistence.py
@@ -420,6 +420,12 @@ class PersistenceMixin:
                 "replay_head_sequence": durable_head_sequence,
                 "event_head_id": durable_head_event_id,
                 "model": _retained_model_id(metadata.get("model")),
+                "mode": (
+                    str(metadata["mode"]).strip()
+                    if isinstance(metadata.get("mode"), str)
+                    and str(metadata["mode"]).strip()
+                    else None
+                ),
                 "config_path": str(metadata.get("config_path") or ""),
                 "workspace": str(metadata.get("workspace") or ""),
                 "model_role_lock": role_lock,
@@ -565,6 +571,11 @@ class PersistenceMixin:
         metadata: Dict[str, Any] = {}
         if model is not None:
             metadata["model"] = model
+        mode = session.get("mode")
+        if mode is not None:
+            if not isinstance(mode, str) or not mode.strip():
+                raise ValueError("retained session mode is invalid")
+            metadata["mode"] = mode.strip()
         if session.get("config_path"):
             metadata["config_path"] = str(session["config_path"])
         if session.get("workspace"):

--- a/breadboard_engine/api/cli_bridge/registry/records.py
+++ b/breadboard_engine/api/cli_bridge/registry/records.py
@@ -214,6 +214,7 @@ class SessionRecord:
     event_seq: int = 0
     replay_history_partial: bool = False
     replay_head_event_id: Optional[str] = None
+    replay_head_sequence: int = 0
     terminal_event_envelopes: list[Dict[str, Any]] = field(default_factory=list, repr=False)
     subscribers: Dict["asyncio.Queue[Optional[SessionEvent]]", SubscriberState] = field(
         default_factory=dict,
@@ -261,7 +262,11 @@ class SessionRecord:
             mode = self.metadata.get("mode")
         replay = replay_retention_facts(
             self.event_log,
-            head_sequence=self.event_seq,
+            head_sequence=(
+                self.replay_head_sequence or self.event_seq
+                if self.replay_history_partial
+                else self.event_seq
+            ),
             retained_history_partial=self.replay_history_partial,
             persisted_head_event_id=self.replay_head_event_id,
         )

--- a/breadboard_engine/api/cli_bridge/registry/records.py
+++ b/breadboard_engine/api/cli_bridge/registry/records.py
@@ -234,6 +234,7 @@ class SessionRecord:
     lifecycle_lock: "asyncio.Lock" = field(default_factory=asyncio.Lock, repr=False)
     deleting: bool = field(default=False, repr=False)
     admission_lock: "asyncio.Lock" = field(default_factory=asyncio.Lock, repr=False)
+    loaded_from_retained_state: bool = field(default=False, repr=False)
 
     def projected_status(self) -> SessionStatus:
         if self.product_session is None:

--- a/breadboard_engine/api/cli_bridge/routes/sessions_routes.py
+++ b/breadboard_engine/api/cli_bridge/routes/sessions_routes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import AsyncIterator
 
-from fastapi import Depends, FastAPI, File, Form, HTTPException, Query, Request, Response, UploadFile, status
+from fastapi import BackgroundTasks, Depends, FastAPI, File, Form, HTTPException, Query, Request, Response, UploadFile, status
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 
 from ..models import (
@@ -128,8 +128,17 @@ def register_session_routes(app: FastAPI, *, get_service, event_payloads) -> Non
             400: {"model": ErrorResponse},
         },
     )
-    async def post_input(session_id: str, payload: SessionInputRequest, svc: SessionService = Depends(get_service)):
-        return await svc.send_input(session_id, payload)
+    async def post_input(
+        session_id: str,
+        payload: SessionInputRequest,
+        background_tasks: BackgroundTasks,
+        svc: SessionService = Depends(get_service),
+    ):
+        return await svc.send_input(
+            session_id,
+            payload,
+            defer_execution=lambda operation: background_tasks.add_task(operation),
+        )
 
     @app.post(
         "/v1/sessions/{session_id}/turns/{turn_id}/cancel",

--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -794,6 +794,7 @@ class SessionService:
             "effective_lock_schema_version",
             "effective_lock_hash",
             "resources",
+            "workspace",
         ):
             request_metadata.pop(reserved_key, None)
         if default_profile is not None:
@@ -814,6 +815,10 @@ class SessionService:
         )
         runner = SessionRunner(session=record, registry=self.registry, request=request)
         runtime_config = runner.prepare_runtime_config()
+        if runner.request.workspace:
+            metadata["workspace"] = str(
+                Path(runner.request.workspace).expanduser().resolve()
+            )
         runtime_providers = (
             runtime_config.get("providers")
             if isinstance(runtime_config, dict)
@@ -1174,8 +1179,72 @@ class SessionService:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="session not found"
             )
+        if record.loaded_from_retained_state:
+            async with self._session_lock(session_id):
+                if record.loaded_from_retained_state:
+                    await self._resume_retained_session(record)
         return record
 
+    async def _resume_retained_session(self, record: SessionRecord) -> None:
+        profile = resolve_default_profile()
+        default_identity = profile.public_identity()
+        metadata = dict(record.metadata or {})
+        recorded_config_path = str(metadata.get("config_path") or "").strip()
+        config_path = (
+            str(profile.source_path)
+            if not recorded_config_path
+            or recorded_config_path == default_identity["definition_ref"]
+            else recorded_config_path
+        )
+        recorded_workspace = metadata.get("workspace")
+        workspace = (
+            str(recorded_workspace).strip()
+            if isinstance(recorded_workspace, str) and recorded_workspace.strip()
+            else None
+        )
+        permission_mode = str(
+            metadata.get("permission_mode") or "configured"
+        ).strip().lower()
+        if permission_mode not in {"prompt", "ask", "interactive", "configured"}:
+            permission_mode = "configured"
+        metadata["permission_mode"] = permission_mode
+        record.metadata = metadata
+        runner = SessionRunner(
+            session=record,
+            registry=self.registry,
+            request=SessionCreateRequest(
+                config_path=config_path,
+                task="",
+                metadata=metadata,
+                workspace=workspace,
+                permission_mode=permission_mode,
+            ),
+        )
+        runner.prepare_runtime_config()
+        for turn in record.turns_by_id.values():
+            if turn.terminal_outcome is not None:
+                continue
+            if turn.cancellation_requested:
+                await runner._finish_turn(
+                    turn,
+                    "cancelled",
+                    reason=turn.cancellation_reason,
+                    advance_queue=False,
+                )
+            else:
+                await runner._finish_turn(
+                    turn,
+                    "failed",
+                    error_code="runtime_failure",
+                    advance_queue=False,
+                )
+        record.active_turn_id = None
+        record.queued_turn_ids.clear()
+        record.turn_admission = record.turn_admission.__class__.IDLE
+        record.runner = runner
+        runner.schedule_start()
+        runner.authorize_start()
+        record.loaded_from_retained_state = False
     async def event_stream(
         self,
         session_id: str,

--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -80,10 +80,12 @@ from .models import (
 )
 from .atp_diagnostics import build_atp_harness_diagnostic
 from .registry import (
+    CancellationRecord,
     SessionRecord,
     SessionRegistry,
     SubscriberState,
     TurnRecord,
+    cancellation_body_digest,
     identity_digest,
     submission_body_digest,
 )
@@ -1099,17 +1101,71 @@ class SessionService:
         turn_id: str,
         payload: SessionTurnCancelRequest,
     ) -> SessionTurnCancelResponse:
-        # The canonical runner exposes stop at session scope; preserve the fixed
-        # cancel DTO while routing cancellation through that authority boundary.
-        await self.stop_session(session_id, reason=payload.reason)
-        opaque = uuid.uuid4().hex
+        record = await self.ensure_session(session_id)
+        runner: Optional[SessionRunner] = getattr(record, "runner", None)
+        if not runner:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="session not active")
+        key = payload.cancellation_request_key
+        key_digest = identity_digest(key)
+        body_digest = cancellation_body_digest(turn_id, payload.reason)
+        async with record.admission_lock:
+            existing = record.cancellations_by_key.get(key)
+            if existing is None:
+                existing = record.cancellations_by_key_digest.get(key_digest)
+            if existing is not None:
+                if existing.body_digest != body_digest:
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail={"code": "cancellation_idempotency_conflict", "turn_id": existing.turn_id},
+                    )
+                return SessionTurnCancelResponse(
+                    cancellation_request_id=existing.cancellation_request_id,
+                    cancellation_request_key=key,
+                    input_id=existing.input_id,
+                    turn_id=existing.turn_id,
+                    disposition="deduplicated",
+                    original_disposition=existing.original_disposition,
+                )
+            turn = record.turns_by_id.get(turn_id)
+            if turn is None:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="turn not found")
+            if turn.terminal_outcome is not None:
+                raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="turn is already terminal")
+            if record.active_turn_id == turn_id:
+                disposition = "cancellation_requested"
+            elif turn.state == "queued":
+                disposition = "queued_cancelled"
+                try:
+                    record.queued_turn_ids.remove(turn_id)
+                except ValueError:
+                    raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="turn is not cancellable") from None
+            else:
+                raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="turn is not cancellable")
+            turn.cancellation_requested = True
+            turn.cancellation_reason = payload.reason
+            cancellation = CancellationRecord(
+                cancellation_request_id=uuid.uuid4().hex,
+                cancellation_request_key=key,
+                turn_id=turn_id,
+                input_id=turn.input_id,
+                reason=payload.reason,
+                original_disposition=disposition,
+                body_digest=body_digest,
+            )
+            record.cancellations_by_key[key] = cancellation
+            record.cancellations_by_key_digest[key_digest] = cancellation
+            await self.registry.persist(record)
+        if disposition == "queued_cancelled":
+            await runner.finish_queued_turn_cancellation(turn, payload.reason)
+        elif not runner.request_turn_cancellation(turn_id):
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="turn is no longer active")
         return SessionTurnCancelResponse(
-            cancellation_request_id=opaque,
-            cancellation_request_key=payload.cancellation_request_key,
-            input_id=opaque,
+            cancellation_request_id=cancellation.cancellation_request_id,
+            cancellation_request_key=key,
+            input_id=turn.input_id,
             turn_id=turn_id,
-            disposition="cancellation_requested",
-            original_disposition="cancellation_requested",
+            disposition=disposition,
+            original_disposition=disposition,
         )
 
     async def ensure_session(self, session_id: str) -> SessionRecord:

--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -767,6 +767,14 @@ class SessionService:
             request = request.model_copy(
                 update={"config_path": str(default_profile.source_path)}
             )
+        else:
+            request = request.model_copy(
+                update={
+                    "config_path": str(
+                        Path(str(request.config_path)).expanduser().resolve()
+                    )
+                }
+            )
         default_profile_overridden = any(
             key != "workspace.root" for key in (request.overrides or {})
         )
@@ -1240,12 +1248,23 @@ class SessionService:
         record = await self.registry.get(session_id)
         if not record:
             raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="session not found"
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="session not found",
+            )
+        if not record.loaded_from_retained_state:
+            return record
+        async with self._session_lock(session_id):
+            return await self._ensure_session_locked(session_id)
+
+    async def _ensure_session_locked(self, session_id: str) -> SessionRecord:
+        record = await self.registry.get(session_id)
+        if not record:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="session not found",
             )
         if record.loaded_from_retained_state:
-            async with self._session_lock(session_id):
-                if record.loaded_from_retained_state:
-                    await self._resume_retained_session(record)
+            await self._resume_retained_session(record)
         return record
 
     async def _resume_retained_session(self, record: SessionRecord) -> None:
@@ -1699,7 +1718,7 @@ class SessionService:
     async def _stop_session_locked(
         self, session_id: str, *, reason: str | None = None
     ) -> None:
-        record = await self.ensure_session(session_id)
+        record = await self._ensure_session_locked(session_id)
         runner: Optional[SessionRunner] = getattr(record, "runner", None)
         try:
             if runner:
@@ -1747,6 +1766,7 @@ class SessionService:
         attachments = tuple(payload.attachments or ())
         body_digest = submission_body_digest(payload.content, attachments)
         key_digest = identity_digest(client_message_id)
+        scheduled_after_admission: list[Callable[[], Awaitable[None]]] = []
 
         async def admit() -> SessionInputResponse:
             async with record.admission_lock:
@@ -1828,10 +1848,30 @@ class SessionService:
                         status_code=http_status, detail=str(exc)
                     ) from exc
                 scheduled_operation = scheduled_operations[0]
-                if defer_execution is None:
-                    await scheduled_operation()
-                else:
-                    defer_execution(scheduled_operation)
+
+                async def execute_admitted_turn() -> None:
+                    try:
+                        await scheduled_operation()
+                    except Exception:
+                        advance_queue = (
+                            turn.state == "active"
+                            and record.active_turn_id == turn.turn_id
+                        )
+                        await runner._finish_turn(
+                            turn,
+                            "failed",
+                            error_code="runtime_failure",
+                            advance_queue=advance_queue,
+                        )
+                        logger.warning(
+                            "Input execution failed after durable admission",
+                            extra={
+                                "session_id": record.session_id,
+                                "turn_id": turn.turn_id,
+                            },
+                        )
+
+                scheduled_after_admission.append(execute_admitted_turn)
                 return SessionInputResponse(
                     client_message_id=client_message_id,
                     input_id=turn.input_id,
@@ -1840,7 +1880,16 @@ class SessionService:
                     original_disposition=disposition,
                 )
 
-        return await self.registry.admit_turn(admit)
+        response = await self.registry.admit_turn(admit)
+        if scheduled_after_admission:
+            if len(scheduled_after_admission) != 1:
+                raise RuntimeError("admitted input has an invalid execution schedule")
+            scheduled_operation = scheduled_after_admission[0]
+            if defer_execution is None:
+                await scheduled_operation()
+            else:
+                defer_execution(scheduled_operation)
+        return response
 
     async def execute_command(
         self, session_id: str, payload: SessionCommandRequest
@@ -1913,7 +1962,7 @@ class SessionService:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail="no files provided"
             )
-        record = await self.ensure_session(session_id)
+        record = await self._ensure_session_locked(session_id)
         runner: Optional[SessionRunner] = getattr(record, "runner", None)
         if not runner:
             raise HTTPException(

--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -1299,7 +1299,12 @@ class SessionService:
                 events = list(record.event_log)
                 if from_id:
                     start_index = self._resolve_start_index(events, from_id)
-                    if start_index is None:
+                    if start_index is None and self._is_retained_head_cursor(record, from_id):
+                        events = [
+                            event for event in events
+                            if event.seq is not None and event.seq > record.replay_head_sequence
+                        ]
+                    elif start_index is None:
                         if not validated:
                             raise HTTPException(
                                 status_code=status.HTTP_409_CONFLICT,
@@ -1387,20 +1392,21 @@ class SessionService:
                         event.seq = record.event_seq
                     else:
                         record.event_seq = max(record.event_seq, int(event.seq))
-                    if event.type in {
-                        EventType.TURN_COMPLETED,
-                        EventType.TURN_FAILED,
-                        EventType.TURN_CANCELLED,
-                    }:
-                        try:
+                    try:
+                        if event.type in {
+                            EventType.TURN_COMPLETED,
+                            EventType.TURN_FAILED,
+                            EventType.TURN_CANCELLED,
+                        }:
                             await self.registry.persist(record, terminal_event=event)
-                        except Exception:
-                            record.event_seq = previous_event_seq
-                            event.seq = previous_event_seq_value
-                            # A terminal event without durable retention is not safe
-                            # to expose as resolved evidence.
-                            setattr(record, "_dispatcher_complete", True)
-                            break
+                        else:
+                            await self.registry.persist(record, cursor_event=event)
+                    except Exception:
+                        record.event_seq = previous_event_seq
+                        event.seq = previous_event_seq_value
+                        # Never expose an event cursor that is not durably resumable.
+                        setattr(record, "_dispatcher_complete", True)
+                        break
                     record.event_log.append(event)
                     if record.subscribers:
                         for subscriber in list(record.subscribers):
@@ -1564,7 +1570,7 @@ class SessionService:
             self._ensure_event_sequence(record)
             events = list(record.event_log)
             start_index = self._resolve_start_index(events, from_id)
-            if start_index is None:
+            if start_index is None and not self._is_retained_head_cursor(record, from_id):
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail={
@@ -1586,6 +1592,13 @@ class SessionService:
             else:
                 seq = max(seq, int(event.seq))
         record.event_seq = seq
+    @staticmethod
+    def _is_retained_head_cursor(record: SessionRecord, from_id: str) -> bool:
+        return (
+            record.replay_head_sequence > 0
+            and record.replay_head_event_id is not None
+            and from_id == record.replay_head_event_id
+        )
 
     def _resolve_start_index(
         self, events: list[SessionEvent], from_id: str

--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -12,7 +12,7 @@ import weakref
 from pathlib import Path
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any, AsyncIterator, Mapping, Optional, Sequence
+from typing import Any, AsyncIterator, Awaitable, Callable, Mapping, Optional, Sequence
 from breadboard.product.harness.lock import EffectiveHarnessLock
 from breadboard.product.runtime import (
     AnchoredStorage,
@@ -1643,9 +1643,12 @@ class SessionService:
         async with self._session_lock(session_id):
             await self._stop_session_locked(session_id)
             await self.registry.delete(session_id)
-
     async def send_input(
-        self, session_id: str, payload: SessionInputRequest
+        self,
+        session_id: str,
+        payload: SessionInputRequest,
+        *,
+        defer_execution: Callable[[Callable[[], Awaitable[None]]], None] | None = None,
     ) -> SessionInputResponse:
         record = await self.ensure_session(session_id)
         runner: Optional[SessionRunner] = getattr(record, "runner", None)
@@ -1656,10 +1659,13 @@ class SessionService:
         client_message_id = payload.client_message_id or uuid.uuid4().hex
         attachments = tuple(payload.attachments or ())
         body_digest = submission_body_digest(payload.content, attachments)
+        key_digest = identity_digest(client_message_id)
 
         async def admit() -> SessionInputResponse:
             async with record.admission_lock:
-                existing = record.submissions_by_key.get(client_message_id)
+                existing = record.submissions_by_key.get(
+                    client_message_id
+                ) or record.submissions_by_key_digest.get(key_digest)
                 if existing is not None:
                     if existing.body_digest != body_digest:
                         raise HTTPException(
@@ -1689,27 +1695,29 @@ class SessionService:
                 )
                 record.turns_by_id[turn.turn_id] = turn
                 record.submissions_by_key[client_message_id] = turn
-                record.submissions_by_key_digest[identity_digest(client_message_id)] = (
-                    turn
-                )
+                record.submissions_by_key_digest[key_digest] = turn
                 if disposition == "started":
                     record.active_turn_id = turn.turn_id
                 else:
                     record.queued_turn_ids.append(turn.turn_id)
                 record.turn_admission = record.turn_admission.__class__.ACTIVE
+                scheduled_operations: list[Callable[[], Awaitable[None]]] = []
                 try:
                     accepted_content = await runner.enqueue_input(
                         payload.content,
                         attachments=list(attachments),
                         input_id=turn.input_id,
                         turn_id=turn.turn_id,
+                        defer_execution=scheduled_operations.append,
                     )
-                except (ValueError, RuntimeError) as exc:
+                    if len(scheduled_operations) != 1:
+                        raise RuntimeError("input execution was not scheduled exactly once")
+                    turn.content = accepted_content
+                    await self.registry.persist(record)
+                except Exception as exc:
                     record.turns_by_id.pop(turn.turn_id, None)
                     record.submissions_by_key.pop(client_message_id, None)
-                    record.submissions_by_key_digest.pop(
-                        identity_digest(client_message_id), None
-                    )
+                    record.submissions_by_key_digest.pop(key_digest, None)
                     if record.active_turn_id == turn.turn_id:
                         record.active_turn_id = None
                     else:
@@ -1722,6 +1730,8 @@ class SessionService:
                         if record.active_turn_id is not None
                         else record.turn_admission.__class__.IDLE
                     )
+                    if not isinstance(exc, (ValueError, RuntimeError)):
+                        raise
                     http_status = (
                         status.HTTP_400_BAD_REQUEST
                         if isinstance(exc, ValueError)
@@ -1730,7 +1740,11 @@ class SessionService:
                     raise HTTPException(
                         status_code=http_status, detail=str(exc)
                     ) from exc
-                turn.content = accepted_content
+                scheduled_operation = scheduled_operations[0]
+                if defer_execution is None:
+                    await scheduled_operation()
+                else:
+                    defer_execution(scheduled_operation)
                 return SessionInputResponse(
                     client_message_id=client_message_id,
                     input_id=turn.input_id,

--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -1109,10 +1109,19 @@ class SessionService:
         record = await self.ensure_session(session_id)
         runner: Optional[SessionRunner] = getattr(record, "runner", None)
         if not runner:
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="session not active")
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="session not active",
+            )
         key = payload.cancellation_request_key
         key_digest = identity_digest(key)
         body_digest = cancellation_body_digest(turn_id, payload.reason)
+        retry_queued_turn: TurnRecord | None = None
+        response: SessionTurnCancelResponse | None = None
+        existing: CancellationRecord | None = None
+        turn: TurnRecord | None = None
+        cancellation: CancellationRecord | None = None
+        disposition: str | None = None
         async with record.admission_lock:
             existing = record.cancellations_by_key.get(key)
             if existing is None:
@@ -1121,9 +1130,12 @@ class SessionService:
                 if existing.body_digest != body_digest:
                     raise HTTPException(
                         status_code=status.HTTP_409_CONFLICT,
-                        detail={"code": "cancellation_idempotency_conflict", "turn_id": existing.turn_id},
+                        detail={
+                            "code": "cancellation_idempotency_conflict",
+                            "turn_id": existing.turn_id,
+                        },
                     )
-                return SessionTurnCancelResponse(
+                response = SessionTurnCancelResponse(
                     cancellation_request_id=existing.cancellation_request_id,
                     cancellation_request_key=key,
                     input_id=existing.input_id,
@@ -1131,47 +1143,98 @@ class SessionService:
                     disposition="deduplicated",
                     original_disposition=existing.original_disposition,
                 )
-            turn = record.turns_by_id.get(turn_id)
-            if turn is None:
-                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="turn not found")
-            if turn.terminal_outcome is not None:
-                raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="turn is already terminal")
-            if record.active_turn_id == turn_id:
-                disposition = "cancellation_requested"
-            elif turn.state == "queued":
-                disposition = "queued_cancelled"
-                try:
-                    record.queued_turn_ids.remove(turn_id)
-                except ValueError:
-                    raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="turn is not cancellable") from None
+                retained_turn = record.turns_by_id.get(existing.turn_id)
+                if (
+                    existing.original_disposition == "queued_cancelled"
+                    and retained_turn is not None
+                    and retained_turn.terminal_outcome is None
+                ):
+                    retry_queued_turn = retained_turn
+                else:
+                    return response
             else:
-                raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="turn is not cancellable")
-            turn.cancellation_requested = True
-            turn.cancellation_reason = payload.reason
-            cancellation = CancellationRecord(
-                cancellation_request_id=uuid.uuid4().hex,
-                cancellation_request_key=key,
-                turn_id=turn_id,
-                input_id=turn.input_id,
-                reason=payload.reason,
-                original_disposition=disposition,
-                body_digest=body_digest,
+                turn = record.turns_by_id.get(turn_id)
+                if turn is None:
+                    raise HTTPException(
+                        status_code=status.HTTP_404_NOT_FOUND,
+                        detail="turn not found",
+                    )
+                if turn.terminal_outcome is not None:
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail="turn is already terminal",
+                    )
+                queued_index: int | None = None
+                if record.active_turn_id == turn_id:
+                    disposition = "cancellation_requested"
+                elif turn.state == "queued":
+                    disposition = "queued_cancelled"
+                    try:
+                        queued_index = record.queued_turn_ids.index(turn_id)
+                    except ValueError:
+                        raise HTTPException(
+                            status_code=status.HTTP_409_CONFLICT,
+                            detail="turn is not cancellable",
+                        ) from None
+                else:
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail="turn is not cancellable",
+                    )
+                previous_cancellation_requested = turn.cancellation_requested
+                previous_cancellation_reason = turn.cancellation_reason
+                turn.cancellation_requested = True
+                turn.cancellation_reason = payload.reason
+                cancellation = CancellationRecord(
+                    cancellation_request_id=uuid.uuid4().hex,
+                    cancellation_request_key=key,
+                    turn_id=turn_id,
+                    input_id=turn.input_id,
+                    reason=payload.reason,
+                    original_disposition=disposition,
+                    body_digest=body_digest,
+                )
+                record.cancellations_by_key[key] = cancellation
+                record.cancellations_by_key_digest[key_digest] = cancellation
+                if queued_index is not None:
+                    record.queued_turn_ids.remove(turn_id)
+                try:
+                    await self.registry.persist(record)
+                except Exception:
+                    turn.cancellation_requested = previous_cancellation_requested
+                    turn.cancellation_reason = previous_cancellation_reason
+                    record.cancellations_by_key.pop(key, None)
+                    record.cancellations_by_key_digest.pop(key_digest, None)
+                    if queued_index is not None:
+                        record.queued_turn_ids.insert(queued_index, turn_id)
+                    raise
+                response = SessionTurnCancelResponse(
+                    cancellation_request_id=cancellation.cancellation_request_id,
+                    cancellation_request_key=key,
+                    input_id=turn.input_id,
+                    turn_id=turn_id,
+                    disposition=disposition,
+                    original_disposition=disposition,
+                )
+        if retry_queued_turn is not None:
+            assert existing is not None
+            assert response is not None
+            await runner.finish_queued_turn_cancellation(
+                retry_queued_turn,
+                existing.reason,
             )
-            record.cancellations_by_key[key] = cancellation
-            record.cancellations_by_key_digest[key_digest] = cancellation
-            await self.registry.persist(record)
+            return response
+        assert turn is not None
+        assert disposition is not None
+        assert response is not None
         if disposition == "queued_cancelled":
             await runner.finish_queued_turn_cancellation(turn, payload.reason)
         elif not runner.request_turn_cancellation(turn_id):
-            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="turn is no longer active")
-        return SessionTurnCancelResponse(
-            cancellation_request_id=cancellation.cancellation_request_id,
-            cancellation_request_key=key,
-            input_id=turn.input_id,
-            turn_id=turn_id,
-            disposition=disposition,
-            original_disposition=disposition,
-        )
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="turn is no longer active",
+            )
+        return response
 
     async def ensure_session(self, session_id: str) -> SessionRecord:
         record = await self.registry.get(session_id)
@@ -1186,6 +1249,13 @@ class SessionService:
         return record
 
     async def _resume_retained_session(self, record: SessionRecord) -> None:
+        if record.status in {
+            SessionStatus.COMPLETED,
+            SessionStatus.FAILED,
+            SessionStatus.STOPPED,
+        }:
+            record.loaded_from_retained_state = False
+            return
         profile = resolve_default_profile()
         default_identity = profile.public_identity()
         metadata = dict(record.metadata or {})
@@ -1597,7 +1667,11 @@ class SessionService:
         return (
             record.replay_head_sequence > 0
             and record.replay_head_event_id is not None
-            and from_id == record.replay_head_event_id
+            and from_id
+            in {
+                record.replay_head_event_id,
+                str(record.replay_head_sequence),
+            }
         )
 
     def _resolve_start_index(

--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -2113,12 +2113,18 @@ class SessionService:
         )
 
     async def list_models(self, config_path: str) -> ModelCatalogResponse:
-        if not config_path or not str(config_path).strip():
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST, detail="config_path required"
-            )
+        requested_path = str(config_path).strip()
+        if not requested_path:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="config_path required")
+        default_profile = resolve_default_profile()
+        default_identity = default_profile.public_identity()
+        resolved_path = (
+            str(default_profile.source_path)
+            if requested_path == default_identity["definition_ref"]
+            else requested_path
+        )
         try:
-            config = load_agent_config(config_path)
+            config = load_agent_config(resolved_path)
         except Exception as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -2139,7 +2145,7 @@ class SessionService:
         policy = policy_pack_for_config_authority(
             config,
             session_id="model_catalog",
-            config_path=config_path,
+            config_path=resolved_path,
             logger=logger,
         )
         if policy.model_allowlist is not None or policy.model_denylist:
@@ -2151,7 +2157,7 @@ class SessionService:
         return ModelCatalogResponse(
             models=entries,
             default_model=str(default_model) if default_model else None,
-            config_path=str(config_path),
+            config_path=requested_path,
             discovery_policy="configured_only",
             issues=issues,
         )

--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -1275,16 +1275,24 @@ class SessionService:
         }:
             record.loaded_from_retained_state = False
             return
-        profile = resolve_default_profile()
-        default_identity = profile.public_identity()
         metadata = dict(record.metadata or {})
         recorded_config_path = str(metadata.get("config_path") or "").strip()
-        config_path = (
-            str(profile.source_path)
-            if not recorded_config_path
-            or recorded_config_path == default_identity["definition_ref"]
-            else recorded_config_path
+        retained_config_path = (
+            Path(recorded_config_path).expanduser()
+            if recorded_config_path
+            else None
         )
+        if retained_config_path is not None and retained_config_path.is_absolute():
+            config_path = str(retained_config_path)
+        else:
+            profile = resolve_default_profile()
+            default_identity = profile.public_identity()
+            config_path = (
+                str(profile.source_path)
+                if not recorded_config_path
+                or recorded_config_path == default_identity["definition_ref"]
+                else recorded_config_path
+            )
         recorded_workspace = metadata.get("workspace")
         workspace = (
             str(recorded_workspace).strip()
@@ -1388,6 +1396,12 @@ class SessionService:
                 events = list(record.event_log)
                 if from_id:
                     start_index = self._resolve_start_index(events, from_id)
+                    if start_index is not None and not self._retained_replay_suffix_is_contiguous(
+                        record,
+                        events,
+                        start_index,
+                    ):
+                        start_index = None
                     if start_index is None and self._is_retained_head_cursor(record, from_id):
                         events = [
                             event for event in events
@@ -1505,6 +1519,13 @@ class SessionService:
                                 # Drop on overflow; subscribers are best-effort observers.
                                 continue
             finally:
+                record.event_queue.task_done()
+        while True:
+            try:
+                record.event_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            else:
                 record.event_queue.task_done()
         async with record.dispatch_lock:
             setattr(record, "_dispatcher_complete", True)
@@ -1659,6 +1680,12 @@ class SessionService:
             self._ensure_event_sequence(record)
             events = list(record.event_log)
             start_index = self._resolve_start_index(events, from_id)
+            if start_index is not None and not self._retained_replay_suffix_is_contiguous(
+                record,
+                events,
+                start_index,
+            ):
+                start_index = None
             if start_index is None and not self._is_retained_head_cursor(record, from_id):
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
@@ -1692,6 +1719,27 @@ class SessionService:
                 str(record.replay_head_sequence),
             }
         )
+
+    @staticmethod
+    def _retained_replay_suffix_is_contiguous(
+        record: SessionRecord,
+        events: list[SessionEvent],
+        start_index: int,
+    ) -> bool:
+        if not record.replay_history_partial:
+            return True
+        if start_index <= 0:
+            return False
+        cursor_sequence = events[start_index - 1].seq
+        replay_head = record.replay_head_sequence
+        if cursor_sequence is None or cursor_sequence > replay_head:
+            return False
+        expected_sequence = cursor_sequence + 1
+        for event in events[start_index:]:
+            if event.seq != expected_sequence or expected_sequence > replay_head:
+                return False
+            expected_sequence += 1
+        return expected_sequence == replay_head + 1
 
     def _resolve_start_index(
         self, events: list[SessionEvent], from_id: str

--- a/breadboard_engine/api/cli_bridge/session_lifecycle.py
+++ b/breadboard_engine/api/cli_bridge/session_lifecycle.py
@@ -172,6 +172,10 @@ class SessionLifecycleOwner:
                 if isinstance(task_turn_id, str)
                 else None
             )
+            if task_turn is not None and task_turn.terminal_outcome is not None:
+                host._input_queue.task_done()
+                state.input_inflight = False
+                continue
             if (
                 task_turn is not None
                 and host.session.active_turn_id != task_turn.turn_id
@@ -300,7 +304,13 @@ class SessionLifecycleOwner:
                     )
                     durable_success = False
             if task_turn is not None:
-                if host._stop_event.is_set():
+                if task_turn.cancellation_requested:
+                    await execution.finish_turn(
+                        task_turn,
+                        "cancelled",
+                        reason=task_turn.cancellation_reason or "user_requested",
+                    )
+                elif host._stop_event.is_set():
                     await execution.finish_turn(
                         task_turn, "cancelled", reason=completion_reason
                     )
@@ -317,6 +327,9 @@ class SessionLifecycleOwner:
                         reason=completion_reason,
                         error_code=failure_code,
                     )
+            turn_was_cancelled = bool(
+                task_turn is not None and task_turn.cancellation_requested
+            )
             if one_shot:
                 if host._stop_event.is_set():
                     await self.terminalize_admitted_turns(
@@ -334,7 +347,7 @@ class SessionLifecycleOwner:
                         reason=completion_reason,
                         error_code=failure_code,
                     )
-            if durable_success:
+            if durable_success and not turn_was_cancelled:
                 for (
                     event_type,
                     event_payload,

--- a/breadboard_engine/api/cli_bridge/session_lifecycle.py
+++ b/breadboard_engine/api/cli_bridge/session_lifecycle.py
@@ -102,20 +102,6 @@ class SessionLifecycleOwner:
             else host.prepare_runtime_config()
         )
         try:
-            todo_cfg = GuardrailCoordinator(base_cfg).todo_config()
-        except Exception:
-            todo_cfg = {"enabled": False}
-        host._todo_enabled = bool(todo_cfg.get("enabled"))
-        await execution.maybe_publish_todo_snapshot(
-            host._workspace_path, call_id="todo:snapshot:init"
-        )
-        try:
-            if host._workspace_path and host._checkpoint_manager is None:
-                host._checkpoint_manager = CheckpointManager(host._workspace_path)
-                host._checkpoint_manager.create_checkpoint("Session start")
-        except Exception:
-            host._checkpoint_manager = None
-        try:
             catalog_payload = host.get_skill_catalog()
             await host.publish_event_async(EventType.SKILLS_CATALOG, catalog_payload)
             selection = (
@@ -129,6 +115,20 @@ class SessionLifecycleOwner:
                 )
         except Exception:
             pass
+        try:
+            todo_cfg = GuardrailCoordinator(base_cfg).todo_config()
+        except Exception:
+            todo_cfg = {"enabled": False}
+        host._todo_enabled = bool(todo_cfg.get("enabled"))
+        await execution.maybe_publish_todo_snapshot(
+            host._workspace_path, call_id="todo:snapshot:init"
+        )
+        try:
+            if host._workspace_path and host._checkpoint_manager is None:
+                host._checkpoint_manager = CheckpointManager(host._workspace_path)
+                host._checkpoint_manager.create_checkpoint("Session start")
+        except Exception:
+            host._checkpoint_manager = None
         if initial_task:
             host._accepted_task_texts.append(initial_task)
             initial_turn = host.session.turns_by_id.get(

--- a/breadboard_engine/api/cli_bridge/session_lifecycle.py
+++ b/breadboard_engine/api/cli_bridge/session_lifecycle.py
@@ -259,13 +259,24 @@ class SessionLifecycleOwner:
                 completion_reason,
                 default="runtime_failure",
             )
+            turn_was_cancelled = bool(
+                task_turn is not None and task_turn.cancellation_requested
+            )
             with host._product_session_lock:
                 product_session = getattr(host.session, "product_session", None)
                 if product_session is None:
-                    durable_success = execution_completed
+                    durable_success = execution_completed or (
+                        turn_was_cancelled and not one_shot
+                    )
                 else:
                     product_state = product_session.read_model.status
-                    if product_state == "running" and not host._stop_event.is_set():
+                    if turn_was_cancelled:
+                        if one_shot and product_state == "running":
+                            host.transition_product_session(
+                                "cancel",
+                                task_turn.cancellation_reason or "user_requested",
+                            )
+                    elif product_state == "running" and not host._stop_event.is_set():
                         if execution_completed:
                             if one_shot:
                                 host.transition_product_session("complete")
@@ -277,9 +288,9 @@ class SessionLifecycleOwner:
                             )
                     product_state = product_session.read_model.status
                     durable_success = (
-                        product_state == "completed"
-                        if one_shot
-                        else product_state not in {"failed", "canceled"}
+                        product_state not in {"failed", "canceled"}
+                        if not one_shot
+                        else product_state == "completed"
                     )
             if durable_success:
                 try:
@@ -327,14 +338,15 @@ class SessionLifecycleOwner:
                         reason=completion_reason,
                         error_code=failure_code,
                     )
-            turn_was_cancelled = bool(
-                task_turn is not None and task_turn.cancellation_requested
-            )
             if one_shot:
-                if host._stop_event.is_set():
+                if turn_was_cancelled:
                     await self.terminalize_admitted_turns(
                         outcome="cancelled",
-                        reason="stop_requested",
+                        reason=task_turn.cancellation_reason or "user_requested",
+                    )
+                elif host._stop_event.is_set():
+                    await self.terminalize_admitted_turns(
+                        outcome="cancelled", reason="stop_requested"
                     )
                 elif execution_completed:
                     await self.terminalize_admitted_turns(
@@ -347,6 +359,12 @@ class SessionLifecycleOwner:
                         reason=completion_reason,
                         error_code=failure_code,
                     )
+            if not one_shot and not durable_success:
+                await self.terminalize_admitted_turns(
+                    outcome="failed",
+                    reason=completion_reason,
+                    error_code=failure_code,
+                )
             if durable_success and not turn_was_cancelled:
                 for (
                     event_type,

--- a/breadboard_engine/api/cli_bridge/session_lifecycle.py
+++ b/breadboard_engine/api/cli_bridge/session_lifecycle.py
@@ -360,11 +360,17 @@ class SessionLifecycleOwner:
                         error_code=failure_code,
                     )
             if not one_shot and not durable_success:
-                await self.terminalize_admitted_turns(
-                    outcome="failed",
-                    reason=completion_reason,
-                    error_code=failure_code,
-                )
+                if host._stop_event.is_set():
+                    await self.terminalize_admitted_turns(
+                        outcome="cancelled",
+                        reason="stop_requested",
+                    )
+                else:
+                    await self.terminalize_admitted_turns(
+                        outcome="failed",
+                        reason=completion_reason,
+                        error_code=failure_code,
+                    )
             if durable_success and not turn_was_cancelled:
                 for (
                     event_type,

--- a/breadboard_engine/api/cli_bridge/session_lifecycle.py
+++ b/breadboard_engine/api/cli_bridge/session_lifecycle.py
@@ -55,7 +55,7 @@ class SessionLifecycleHost(Protocol):
 class _LifecycleRunState:
     session_started_at: float
     input_inflight: bool = False
-
+    terminal_status: Optional[SessionStatus] = None
 
 class SessionLifecycleOwner:
     """Owns the ordered phases that run one CLI bridge session."""
@@ -74,7 +74,7 @@ class SessionLifecycleOwner:
             await self._mark_running()
             await self._initialize()
             await self._process_inputs(state)
-            await self._finalize()
+            await self._finalize(state)
         except Exception as exc:  # noqa: BLE001
             await self._fail(state, exc)
         finally:
@@ -399,9 +399,15 @@ class SessionLifecycleOwner:
             host._input_queue.task_done()
             state.input_inflight = False
             if one_shot or not durable_success:
+                if host._stop_event.is_set() or turn_was_cancelled:
+                    state.terminal_status = SessionStatus.STOPPED
+                elif execution_completed:
+                    state.terminal_status = SessionStatus.COMPLETED
+                else:
+                    state.terminal_status = SessionStatus.FAILED
                 break
 
-    async def _finalize(self) -> None:
+    async def _finalize(self, state: _LifecycleRunState) -> None:
         host = self._host
         if host._stop_event.is_set():
             await self.terminalize_admitted_turns(
@@ -417,7 +423,7 @@ class SessionLifecycleOwner:
                 metadata.get("non_interactive_cli_session")
                 or metadata.get("cli_session_kind") == "oneshot"
             )
-            final_status = (
+            final_status = state.terminal_status or (
                 SessionStatus.STOPPED
                 if host._stop_event.is_set() and not legacy_one_shot
                 else SessionStatus.COMPLETED

--- a/breadboard_engine/api/cli_bridge/session_lifecycle.py
+++ b/breadboard_engine/api/cli_bridge/session_lifecycle.py
@@ -458,9 +458,15 @@ class SessionLifecycleOwner:
         logger.error(
             "Session %s failed with code=%s", host.session.session_id, error_code
         )
-        await self.terminalize_admitted_turns(
-            outcome="failed", reason=error_code, error_code=error_code
-        )
+        try:
+            await self.terminalize_admitted_turns(
+                outcome="failed", reason=error_code, error_code=error_code
+            )
+        except Exception:
+            logger.error(
+                "Session %s could not persist terminal turn events",
+                host.session.session_id,
+            )
         product_session = getattr(host.session, "product_session", None)
         if product_session is None:
             product_state = "failed"
@@ -473,15 +479,26 @@ class SessionLifecycleOwner:
                     "runtime failure",
                 )
                 product_state = product_session.read_model.status
-        await host.registry.update_status(
-            host.session.session_id,
-            {
-                "completed": SessionStatus.COMPLETED,
-                "failed": SessionStatus.FAILED,
-                "canceled": SessionStatus.STOPPED,
-            }.get(product_state, SessionStatus.FAILED),
-        )
-        await host._publish_session_failure(error_code)
+        final_status = {
+            "completed": SessionStatus.COMPLETED,
+            "failed": SessionStatus.FAILED,
+            "canceled": SessionStatus.STOPPED,
+        }.get(product_state, SessionStatus.FAILED)
+        try:
+            await host.registry.update_status(host.session.session_id, final_status)
+        except Exception:
+            host.session.status = final_status
+            logger.error(
+                "Session %s could not persist terminal session status",
+                host.session.session_id,
+            )
+        try:
+            await host._publish_session_failure(error_code)
+        except Exception:
+            logger.error(
+                "Session %s could not publish its terminal failure event",
+                host.session.session_id,
+            )
 
     async def terminalize_admitted_turns(
         self,

--- a/breadboard_engine/api/cli_bridge/session_runner.py
+++ b/breadboard_engine/api/cli_bridge/session_runner.py
@@ -1140,7 +1140,10 @@ class SessionRunner:
         async with self.session.dispatch_lock:
             if getattr(self.session, "_dispatcher_complete", False):
                 raise RuntimeError("session event dispatcher is unavailable")
-            await self.session.event_queue.put(event)
+            try:
+                self.session.event_queue.put_nowait(event)
+            except asyncio.QueueFull as error:
+                raise RuntimeError("session event queue is full") from error
             self._published_events += 1
 
     def _touch_last_activity(self) -> None:

--- a/breadboard_engine/api/cli_bridge/session_runner.py
+++ b/breadboard_engine/api/cli_bridge/session_runner.py
@@ -12,8 +12,7 @@ import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, Mapping, Optional, Sequence, List
-
+from typing import Any, Awaitable, Callable, Dict, Mapping, Optional, Sequence, List
 from breadboard_engine.compilation.v2_loader import load_agent_config
 from breadboard.product.runtime.artifacts import _validate_artifact_name
 from breadboard.product.runtime import session_store
@@ -389,6 +388,7 @@ class SessionRunner:
         *,
         input_id: Optional[str] = None,
         turn_id: Optional[str] = None,
+        defer_execution: Optional[Callable[[Callable[[], Awaitable[None]]], None]] = None,
     ) -> str:
         if self._closed:
             raise RuntimeError("session is closed")
@@ -459,7 +459,13 @@ class SessionRunner:
                 self.session.metadata["session_contract"] = (
                     product_session.read_model.as_dict()
                 )
-            self._input_queue.put_nowait(payload)
+            if defer_execution is None:
+                self._input_queue.put_nowait(payload)
+            else:
+                async def enqueue_after_response() -> None:
+                    self._input_queue.put_nowait(payload)
+
+                defer_execution(enqueue_after_response)
         return content
 
     def transition_product_session(self, transition: str, *args: Any) -> None:

--- a/breadboard_engine/api/cli_bridge/session_runner.py
+++ b/breadboard_engine/api/cli_bridge/session_runner.py
@@ -704,6 +704,9 @@ class SessionRunner:
             overrides.setdefault("permissions.shell.default", "ask")
             overrides.setdefault("permissions.webfetch.default", "ask")
             overrides.setdefault("permissions.read.default", "ask")
+        if requested_permission_mode in {"prompt", "ask", "interactive", "configured"}:
+            self.request.permission_mode = requested_permission_mode
+            self.session.metadata["permission_mode"] = requested_permission_mode
         workspace_guess_path = self._resolve_workspace_guess(base_cfg)
         if workspace_guess_path:
             self._workspace_path = workspace_guess_path
@@ -999,6 +1002,7 @@ class SessionRunner:
         return self._task_execution.execute_task(
             task_text, input_id=input_id, turn_id=turn_id
         )
+
 
     async def _finish_turn(
         self,

--- a/breadboard_engine/api/cli_bridge/session_runner.py
+++ b/breadboard_engine/api/cli_bridge/session_runner.py
@@ -1126,6 +1126,8 @@ class SessionRunner:
             future.result()
             return
         try:
+            if getattr(self.session, "_dispatcher_complete", False):
+                raise RuntimeError("session event dispatcher is unavailable")
             self.session.event_queue.put_nowait(event)
             self._published_events += 1
         except asyncio.QueueFull:  # pragma: no cover - defensive
@@ -1135,8 +1137,11 @@ class SessionRunner:
             )
 
     async def _enqueue_event_async(self, event: SessionEvent) -> None:
-        await self.session.event_queue.put(event)
-        self._published_events += 1
+        async with self.session.dispatch_lock:
+            if getattr(self.session, "_dispatcher_complete", False):
+                raise RuntimeError("session event dispatcher is unavailable")
+            await self.session.event_queue.put(event)
+            self._published_events += 1
 
     def _touch_last_activity(self) -> None:
         try:

--- a/breadboard_engine/api/cli_bridge/session_runner.py
+++ b/breadboard_engine/api/cli_bridge/session_runner.py
@@ -801,9 +801,8 @@ class SessionRunner:
                 if isinstance(workspace, dict)
                 else None
             )
-        candidate = (
-            candidate
-            or f"tmp/agent_ws_{os.path.basename(self.request.config_path).split('.')[0]}"
+        candidate = candidate or (
+            "tmp/agent_ws_" + identity_digest(self.session.session_id)[:16]
         )
         try:
             path = Path(str(candidate)).expanduser()

--- a/breadboard_engine/api/cli_bridge/session_runner.py
+++ b/breadboard_engine/api/cli_bridge/session_runner.py
@@ -265,6 +265,8 @@ class SessionRunner:
                 return
             if self._stop_event.is_set():
                 queue.put({"kind": "stop"})
+            elif self._active_turn_cancellation_requested():
+                queue.put({"kind": "stop"})
             elif not self._resume_event.is_set():
                 queue.put({"kind": "pause"})
 
@@ -305,6 +307,31 @@ class SessionRunner:
                 except Exception:
                     pass
             return stopping
+
+    def _active_turn_cancellation_requested(self) -> bool:
+        turn = self.session.turns_by_id.get(self.session.active_turn_id or "")
+        return bool(turn is not None and turn.cancellation_requested and turn.terminal_outcome is None)
+
+    def request_turn_cancellation(self, turn_id: str) -> bool:
+        with self._product_session_lock:
+            turn = self.session.turns_by_id.get(turn_id)
+            if (
+                turn is None
+                or self.session.active_turn_id != turn_id
+                or not turn.cancellation_requested
+                or turn.terminal_outcome is not None
+            ):
+                return False
+            self._signal_control("stop")
+            return True
+
+    async def finish_queued_turn_cancellation(self, turn: TurnRecord, reason: str) -> None:
+        await self._finish_turn(
+            turn,
+            "cancelled",
+            reason=reason,
+            advance_queue=False,
+        )
 
     async def stop(self, reason: str = "operator request") -> None:
         if self._closed:

--- a/breadboard_engine/api/cli_bridge/session_runner.py
+++ b/breadboard_engine/api/cli_bridge/session_runner.py
@@ -436,9 +436,10 @@ class SessionRunner:
             ]
             if unknown:
                 raise ValueError(f"unknown attachment IDs: {', '.join(unknown)}")
+            selected_artifacts = [artifacts[item] for item in attachment_ids]
             total_bytes = sum(
-                int(getattr(artifacts[item], "size_bytes", MAX_ATTACHMENT_BYTES + 1))
-                for item in attachment_ids
+                int(getattr(item, "size_bytes", MAX_ATTACHMENT_BYTES + 1))
+                for item in selected_artifacts
             )
             if total_bytes > MAX_ATTACHMENT_BYTES:
                 raise ValueError(
@@ -451,19 +452,20 @@ class SessionRunner:
                 "input_id": input_id,
                 "turn_id": turn_id,
             }
-            product_session = getattr(self.session, "product_session", None)
-            if product_session is not None:
-                product_session.input(
-                    content, [artifacts[item] for item in attachment_ids]
-                )
-                self.session.metadata["session_contract"] = (
-                    product_session.read_model.as_dict()
-                )
-            if defer_execution is None:
+            def enqueue() -> None:
+                product_session = getattr(self.session, "product_session", None)
+                if product_session is not None:
+                    product_session.input(content, selected_artifacts)
+                    self.session.metadata["session_contract"] = (
+                        product_session.read_model.as_dict()
+                    )
                 self._input_queue.put_nowait(payload)
+            if defer_execution is None:
+                enqueue()
             else:
                 async def enqueue_after_response() -> None:
-                    self._input_queue.put_nowait(payload)
+                    with self._product_session_lock:
+                        enqueue()
 
                 defer_execution(enqueue_after_response)
         return content

--- a/breadboard_engine/api/cli_bridge/task_execution.py
+++ b/breadboard_engine/api/cli_bridge/task_execution.py
@@ -559,7 +559,6 @@ class TaskExecutionOwner:
             "prompt",
             "ask",
             "interactive",
-            "configured",
         }
         logger.info(
             "session(%s) task=%s stream=%s local=%s remote_toggle=%s",

--- a/breadboard_engine/api/cli_bridge/task_execution.py
+++ b/breadboard_engine/api/cli_bridge/task_execution.py
@@ -555,7 +555,12 @@ class TaskExecutionOwner:
             .strip()
             .lower()
         )
-        interactive_permissions = permission_mode in {"prompt", "ask", "interactive"}
+        interactive_permissions = permission_mode in {
+            "prompt",
+            "ask",
+            "interactive",
+            "configured",
+        }
         logger.info(
             "session(%s) task=%s stream=%s local=%s remote_toggle=%s",
             runner.session.session_id,

--- a/breadboard_engine/provider/runtimes/testing.py
+++ b/breadboard_engine/provider/runtimes/testing.py
@@ -8,6 +8,15 @@ from typing import Any, Dict, List, Optional
 
 from ..contracts import ProviderMessage, ProviderResult, ProviderRuntime, ProviderRuntimeContext, ProviderToolCall
 
+def _exact_zero_usage() -> Dict[str, int]:
+    return {
+        "inputTokens": 0,
+        "outputTokens": 0,
+        "cacheReadTokens": 0,
+        "cacheWriteTokens": 0,
+        "totalTokens": 0,
+    }
+
 
 class MockRuntime(ProviderRuntime):
     """A simple mock provider runtime for offline validation.
@@ -51,7 +60,7 @@ class MockRuntime(ProviderRuntime):
             return ProviderResult(
                 messages=out_messages,
                 raw_response={"mock": True, "mode": model_hint},
-                usage=None,
+                usage=_exact_zero_usage(),
                 encrypted_reasoning=None,
                 reasoning_summaries=None,
                 model="mock",
@@ -64,20 +73,6 @@ class MockRuntime(ProviderRuntime):
             tool_calls = msg.get("tool_calls")
             if isinstance(tool_calls, list):
                 prior_calls += len(tool_calls)
-
-        def _seen_tool(name: str) -> bool:
-            for msg in messages:
-                if msg.get("role") != "assistant":
-                    continue
-                for call in msg.get("tool_calls") or []:
-                    fn = getattr(getattr(call, "function", None), "name", "") or call.get("function")
-                    if fn == name:
-                        return True
-            return False
-
-        has_todo = _seen_tool("todo.write_board")
-        has_write = _seen_tool("write")
-        has_shell = _seen_tool("run_shell")
 
         def _mk_tool_call(name: str, args: Dict[str, Any]) -> ProviderToolCall:
             try:
@@ -172,7 +167,7 @@ class MockRuntime(ProviderRuntime):
         else:
             out_messages.append(ProviderMessage(role="assistant", content="Proceed to build and test.", tool_calls=[], finish_reason="stop", index=0))
 
-        return ProviderResult(messages=out_messages, raw_response={"mock": True}, usage=None, encrypted_reasoning=None, reasoning_summaries=None, model="mock")
+        return ProviderResult(messages=out_messages, raw_response={"mock": True}, usage=_exact_zero_usage(), encrypted_reasoning=None, reasoning_summaries=None, model="mock")
 
 
 class SmokeRuntime(ProviderRuntime):
@@ -219,7 +214,7 @@ class SmokeRuntime(ProviderRuntime):
                 )
             ],
             raw_response={"smoke": True},
-            usage=None,
+            usage=_exact_zero_usage(),
             encrypted_reasoning=None,
             reasoning_summaries=None,
             model="smoke",
@@ -330,7 +325,7 @@ class CliMockRuntime(ProviderRuntime):
             "mock": True,
             "prior_tool_calls": prior_calls,
         }
-        return ProviderResult(messages=out_messages, raw_response=raw_response, metadata={"status_code": 200})
+        return ProviderResult(messages=out_messages, raw_response=raw_response, usage=_exact_zero_usage(), metadata={"status_code": 200})
 
 
 __all__ = ["MockRuntime", "SmokeRuntime", "CliMockRuntime"]

--- a/breadboard_engine/provider/runtimes/testing.py
+++ b/breadboard_engine/provider/runtimes/testing.py
@@ -250,8 +250,20 @@ class CliMockRuntime(ProviderRuntime):
         for msg in messages:
             if msg.get("role") != "assistant":
                 continue
-            tool_calls = msg.get("tool_calls")
-            if not isinstance(tool_calls, list):
+            tool_calls: List[Dict[str, Any]] = []
+            direct_calls = msg.get("tool_calls")
+            if isinstance(direct_calls, list):
+                tool_calls.extend(
+                    call for call in direct_calls if isinstance(call, dict)
+                )
+            content = msg.get("content")
+            if isinstance(content, list):
+                tool_calls.extend(
+                    block
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "tool_call"
+                )
+            if not tool_calls:
                 continue
             prior_calls += len(tool_calls)
             for call in tool_calls:

--- a/breadboard_engine/provider/runtimes/testing.py
+++ b/breadboard_engine/provider/runtimes/testing.py
@@ -272,7 +272,12 @@ class CliMockRuntime(ProviderRuntime):
 
         def _mk_tool_call(name: str, args: Dict[str, Any]) -> ProviderToolCall:
             payload = json.dumps(args)
-            call = ProviderToolCall(id=None, name=name, arguments=payload, type="function")
+            call = ProviderToolCall(
+                id=f"cli-mock-call-{prior_calls + 1}-{name.replace('.', '-')}",
+                name=name,
+                arguments=payload,
+                type="function",
+            )
             try:
                 from types import SimpleNamespace as _SNS
                 setattr(call, "function", _SNS(name=name, arguments=payload))

--- a/breadboard_engine/provider/runtimes/testing.py
+++ b/breadboard_engine/provider/runtimes/testing.py
@@ -303,7 +303,7 @@ class CliMockRuntime(ProviderRuntime):
             call = _mk_tool_call(
                 "write",
                 {
-                    "path": "bubble_sort.py",
+                    "filePath": "bubble_sort.py",
                     "content": "def bubble_sort(nums):\n    n = len(nums)\n    for i in range(n):\n        for j in range(0, n - i - 1):\n            if nums[j] > nums[j + 1]:\n                nums[j], nums[j + 1] = nums[j + 1], nums[j]\n    return nums\n\nif __name__ == '__main__':\n    data = [5, 3, 1, 4, 2]\n    print(bubble_sort(data))\n",
                 },
             )
@@ -311,7 +311,7 @@ class CliMockRuntime(ProviderRuntime):
                 ProviderMessage(role="assistant", content=None, tool_calls=[call], finish_reason="stop", index=0)
             )
         elif not has_shell:
-            call = _mk_tool_call("run_shell", {"command": "python bubble_sort.py", "timeout": 30})
+            call = _mk_tool_call("run_shell", {"command": "python3 bubble_sort.py", "timeout": 30})
             out_messages.append(
                 ProviderMessage(role="assistant", content=None, tool_calls=[call], finish_reason="stop", index=0)
             )

--- a/breadboard_engine/provider/runtimes/testing.py
+++ b/breadboard_engine/provider/runtimes/testing.py
@@ -333,7 +333,7 @@ class CliMockRuntime(ProviderRuntime):
             out_messages.append(
                 ProviderMessage(
                     role="assistant",
-                    content="TASK COMPLETE",
+                    content="Bubble sort validation complete.\n\nTASK COMPLETE",
                     tool_calls=[],
                     finish_reason="stop",
                     index=0,

--- a/breadboard_engine/provider/runtimes/testing.py
+++ b/breadboard_engine/provider/runtimes/testing.py
@@ -250,12 +250,10 @@ class CliMockRuntime(ProviderRuntime):
         for msg in messages:
             if msg.get("role") != "assistant":
                 continue
-            tool_calls: List[Dict[str, Any]] = []
+            tool_calls: List[Any] = []
             direct_calls = msg.get("tool_calls")
             if isinstance(direct_calls, list):
-                tool_calls.extend(
-                    call for call in direct_calls if isinstance(call, dict)
-                )
+                tool_calls.extend(direct_calls)
             content = msg.get("content")
             if isinstance(content, list):
                 tool_calls.extend(
@@ -273,7 +271,10 @@ class CliMockRuntime(ProviderRuntime):
                     if isinstance(fn_block, dict):
                         name = fn_block.get("name")
                     name = name or call.get("name")
-                if not name:
+                else:
+                    fn_block = getattr(call, "function", None)
+                    name = getattr(fn_block, "name", None) or getattr(call, "name", None)
+                if not isinstance(name, str) or not name.strip():
                     continue
                 normalized_name = name.strip().lower()
                 if normalized_name.startswith("todo."):

--- a/breadboard_engine/provider/runtimes/testing.py
+++ b/breadboard_engine/provider/runtimes/testing.py
@@ -263,11 +263,12 @@ class CliMockRuntime(ProviderRuntime):
                     name = name or call.get("name")
                 if not name:
                     continue
-                if name.startswith("todo."):
+                normalized_name = name.strip().lower()
+                if normalized_name.startswith("todo."):
                     has_todo = True
-                elif name.startswith("write") or name == "create_file_from_block":
+                elif normalized_name.startswith("write") or normalized_name == "create_file_from_block":
                     has_write = True
-                elif name.startswith("run_shell") or name == "bash.run":
+                elif normalized_name.startswith("run_shell") or normalized_name == "bash.run":
                     has_shell = True
 
         def _mk_tool_call(name: str, args: Dict[str, Any]) -> ProviderToolCall:

--- a/tests/api/public/fixtures/system_describe.json
+++ b/tests/api/public/fixtures/system_describe.json
@@ -6,7 +6,7 @@
   "data": {
     "default_profile": {
       "definition_ref": "agent_configs/templates/daily_driver.v1.yaml",
-      "effective_lock_hash": "sha256:165d34c5ed177005fa289544da0b451294c89bb51b0d289f2372c4bd081eff43",
+      "effective_lock_hash": "sha256:6ea299b2d3ee382a8d8397cd5ed32080e99f8ae8b6a48006fce1ecad6859c10f",
       "effective_lock_schema_version": "bb.effective_config_graph.v1",
       "profile_id": "daily_driver.v1",
       "resources": [
@@ -20,7 +20,7 @@
         }
       ],
       "schema_version": "bb.harness_definition.v1",
-      "source_sha256": "sha256:155e9db1dabee3975739a221324215993002438dc33dd73402959dc4649709f5"
+      "source_sha256": "sha256:4a53aa79a94224dff33182107d19436a9037c9661e31555e56ce16b3786d0ac9"
     },
     "internal_extensions": [],
     "operation_count": 26,
@@ -163,7 +163,7 @@
   "error": null,
   "exit_code": 0,
   "hashes": {
-    "profile": "sha256:165d34c5ed177005fa289544da0b451294c89bb51b0d289f2372c4bd081eff43"
+    "profile": "sha256:6ea299b2d3ee382a8d8397cd5ed32080e99f8ae8b6a48006fce1ecad6859c10f"
   },
   "next_actions": [
     "breadboard system health"

--- a/tests/product/harness/test_templates.py
+++ b/tests/product/harness/test_templates.py
@@ -110,6 +110,7 @@ def test_checked_in_daily_driver_is_public_bounded_and_provider_free() -> None:
     assert document["prompts"]["packs"]["base"]["system"] == (
         "prompts/daily_driver_system.md"
     )
+    assert document["features"] == {"todos": {"enabled": True, "strict": True}}
     assert document["permissions"] == {
         "options": {"mode": "prompt"},
         "shell": {"default": "ask"},

--- a/tests/providers/test_provider_runtime_mock.py
+++ b/tests/providers/test_provider_runtime_mock.py
@@ -3,6 +3,8 @@ import pytest
 
 from breadboard_engine.provider_routing import provider_router
 from breadboard_engine.provider_runtime import ProviderRuntimeContext, provider_registry
+from breadboard_engine.provider.normalizer import normalize_provider_result
+
 
 EXACT_ZERO_USAGE = {
     "inputTokens": 0,
@@ -53,3 +55,19 @@ def test_synthetic_runtimes_report_exact_zero_usage(model_id: str) -> None:
     )
 
     assert result.usage == EXACT_ZERO_USAGE
+
+
+def test_cli_mock_runtime_emits_contract_valid_tool_calls() -> None:
+    descriptor, model = provider_router.get_runtime_descriptor("cli_mock/reference")
+    runtime = provider_registry.create_runtime(descriptor)
+    result = runtime.invoke(
+        client=runtime.create_client(api_key=descriptor.provider_id),
+        model=model,
+        messages=[{"role": "user", "content": "Hello"}],
+        tools=None,
+        stream=False,
+        context=ProviderRuntimeContext(session_state=object(), agent_config={}),
+    )
+
+    normalize_provider_result(result)
+    assert result.messages[0].tool_calls[0].id == "cli-mock-call-1-todo-write_board"

--- a/tests/providers/test_provider_runtime_mock.py
+++ b/tests/providers/test_provider_runtime_mock.py
@@ -85,15 +85,7 @@ def test_cli_mock_runtime_emits_contract_valid_tool_sequence() -> None:
     assert write_call.parsed_arguments["filePath"] == "bubble_sort.py"
 
     shell_call = invoke(
-        [
-            {
-                "role": "assistant",
-                "content": [
-                    {"type": "tool_call", "name": "todo.write_board"},
-                    {"type": "tool_call", "name": "Write"},
-                ],
-            }
-        ]
+        [{"role": "assistant", "tool_calls": [todo_call, write_call]}]
     )
     assert shell_call.id == "cli-mock-call-3-run_shell"
     assert shell_call.parsed_arguments["command"] == "python3 bubble_sort.py"

--- a/tests/providers/test_provider_runtime_mock.py
+++ b/tests/providers/test_provider_runtime_mock.py
@@ -57,17 +57,43 @@ def test_synthetic_runtimes_report_exact_zero_usage(model_id: str) -> None:
     assert result.usage == EXACT_ZERO_USAGE
 
 
-def test_cli_mock_runtime_emits_contract_valid_tool_calls() -> None:
+def test_cli_mock_runtime_emits_contract_valid_tool_sequence() -> None:
     descriptor, model = provider_router.get_runtime_descriptor("cli_mock/reference")
     runtime = provider_registry.create_runtime(descriptor)
-    result = runtime.invoke(
-        client=runtime.create_client(api_key=descriptor.provider_id),
-        model=model,
-        messages=[{"role": "user", "content": "Hello"}],
-        tools=None,
-        stream=False,
-        context=ProviderRuntimeContext(session_state=object(), agent_config={}),
-    )
+    client = runtime.create_client(api_key=descriptor.provider_id)
+    context = ProviderRuntimeContext(session_state=object(), agent_config={})
 
-    normalize_provider_result(result)
-    assert result.messages[0].tool_calls[0].id == "cli-mock-call-1-todo-write_board"
+    def invoke(messages):
+        result = runtime.invoke(
+            client=client,
+            model=model,
+            messages=messages,
+            tools=None,
+            stream=False,
+            context=context,
+        )
+        normalize_provider_result(result)
+        return result.messages[0].tool_calls[0]
+
+    todo_call = invoke([{"role": "user", "content": "Hello"}])
+    assert todo_call.id == "cli-mock-call-1-todo-write_board"
+
+    write_call = invoke(
+        [{"role": "assistant", "tool_calls": [{"name": "todo.write_board"}]}]
+    )
+    assert write_call.id == "cli-mock-call-2-write"
+    assert write_call.parsed_arguments["filePath"] == "bubble_sort.py"
+
+    shell_call = invoke(
+        [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {"name": "todo.write_board"},
+                    {"name": "write"},
+                ],
+            }
+        ]
+    )
+    assert shell_call.id == "cli-mock-call-3-run_shell"
+    assert shell_call.parsed_arguments["command"] == "python3 bubble_sort.py"

--- a/tests/providers/test_provider_runtime_mock.py
+++ b/tests/providers/test_provider_runtime_mock.py
@@ -88,9 +88,9 @@ def test_cli_mock_runtime_emits_contract_valid_tool_sequence() -> None:
         [
             {
                 "role": "assistant",
-                "tool_calls": [
-                    {"name": "todo.write_board"},
-                    {"name": "Write"},
+                "content": [
+                    {"type": "tool_call", "name": "todo.write_board"},
+                    {"type": "tool_call", "name": "Write"},
                 ],
             }
         ]

--- a/tests/providers/test_provider_runtime_mock.py
+++ b/tests/providers/test_provider_runtime_mock.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
+import pytest
 
 from breadboard_engine.provider_routing import provider_router
 from breadboard_engine.provider_runtime import ProviderRuntimeContext, provider_registry
+
+EXACT_ZERO_USAGE = {
+    "inputTokens": 0,
+    "outputTokens": 0,
+    "cacheReadTokens": 0,
+    "cacheWriteTokens": 0,
+    "totalTokens": 0,
+}
 
 
 def test_mock_runtime_no_tools_emits_no_tool_calls() -> None:
@@ -22,3 +31,25 @@ def test_mock_runtime_no_tools_emits_no_tool_calls() -> None:
     assert len(result.messages) == 1
     assert result.messages[0].tool_calls == []
     assert result.raw_response.get("mode") == "no_tools"
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    ("mock/reference", "smoke/reference", "cli_mock/reference"),
+)
+def test_synthetic_runtimes_report_exact_zero_usage(model_id: str) -> None:
+    descriptor, model = provider_router.get_runtime_descriptor(model_id)
+    runtime = provider_registry.create_runtime(descriptor)
+    client = runtime.create_client(api_key=descriptor.provider_id)
+    context = ProviderRuntimeContext(session_state=object(), agent_config={})
+
+    result = runtime.invoke(
+        client=client,
+        model=model,
+        messages=[{"role": "user", "content": "Hello"}],
+        tools=None,
+        stream=False,
+        context=context,
+    )
+
+    assert result.usage == EXACT_ZERO_USAGE

--- a/tests/providers/test_provider_runtime_mock.py
+++ b/tests/providers/test_provider_runtime_mock.py
@@ -89,3 +89,19 @@ def test_cli_mock_runtime_emits_contract_valid_tool_sequence() -> None:
     )
     assert shell_call.id == "cli-mock-call-3-run_shell"
     assert shell_call.parsed_arguments["command"] == "python3 bubble_sort.py"
+
+    completed = runtime.invoke(
+        client=client,
+        model=model,
+        messages=[
+            {
+                "role": "assistant",
+                "tool_calls": [todo_call, write_call, shell_call],
+            }
+        ],
+        tools=None,
+        stream=False,
+        context=context,
+    )
+    assert completed.messages[0].content == "Bubble sort validation complete.\n\nTASK COMPLETE"
+    assert completed.messages[0].tool_calls == []

--- a/tests/providers/test_provider_runtime_mock.py
+++ b/tests/providers/test_provider_runtime_mock.py
@@ -90,7 +90,7 @@ def test_cli_mock_runtime_emits_contract_valid_tool_sequence() -> None:
                 "role": "assistant",
                 "tool_calls": [
                     {"name": "todo.write_board"},
-                    {"name": "write"},
+                    {"name": "Write"},
                 ],
             }
         ]

--- a/tests/test_agent_openai_tools_integration.py
+++ b/tests/test_agent_openai_tools_integration.py
@@ -90,6 +90,35 @@ def test_opencode_write_alias_preserves_file_path() -> None:
     assert result == {"ok": True}
     assert captured == {"path": "bubble_sort.py", "content": "content\n"}
 
+def test_claude_write_alias_rejects_private_workspace_storage() -> None:
+    conductor_class = OpenAIConductor.__ray_metadata__.modified_class
+    conductor = object.__new__(conductor_class)
+    conductor.config = {}
+    conductor._normalize_workspace_path = lambda value: value
+    conductor._private_workspace_path = lambda _value: True
+    conductor._ray_get = lambda value: value
+    conductor.sandbox = types.SimpleNamespace(
+        write_text=types.SimpleNamespace(
+            remote=lambda _path, _content: pytest.fail(
+                "private workspace write reached sandbox"
+            )
+        )
+    )
+
+    result = conductor._exec_raw(
+        {
+            "function": "Write",
+            "arguments": {
+                "filePath": ".breadboard/artifacts/secret",
+                "content": "overwrite\n",
+            },
+        }
+    )
+
+    assert result == {
+        "error": "private workspace storage is unavailable to model tools"
+    }
+
 
 class _DummyMarkdownLogger:
     def __init__(self):

--- a/tests/test_agent_openai_tools_integration.py
+++ b/tests/test_agent_openai_tools_integration.py
@@ -64,6 +64,33 @@ def test_provider_schema_names_roundtrip():
     assert "read_file" in names
 
 
+def test_opencode_write_alias_preserves_file_path() -> None:
+    conductor_class = OpenAIConductor.__ray_metadata__.modified_class
+    conductor = object.__new__(conductor_class)
+    captured: dict[str, str] = {}
+    conductor.config = {}
+    conductor._normalize_workspace_path = lambda value: value
+    conductor._private_workspace_path = lambda _value: False
+    conductor._ray_get = lambda value: value
+    conductor.sandbox = types.SimpleNamespace(
+        write_text=types.SimpleNamespace(
+            remote=lambda path, content: (
+                captured.update(path=path, content=content) or {"ok": True}
+            )
+        )
+    )
+
+    result = conductor._exec_raw(
+        {
+            "function": "write",
+            "arguments": {"filePath": "bubble_sort.py", "content": "content\n"},
+        }
+    )
+
+    assert result == {"ok": True}
+    assert captured == {"path": "bubble_sort.py", "content": "content\n"}
+
+
 class _DummyMarkdownLogger:
     def __init__(self):
         self.messages = []

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from pathlib import Path
 import pytest
 
 from fastapi.testclient import TestClient
@@ -633,6 +634,54 @@ loop:
         True,
     ]
     assert [issue["code"] for issue in payload["issues"]] == ["deferred_provider"]
+
+
+def test_daily_driver_catalog_exposes_explicit_synthetic_route(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    import breadboard_engine.provider_broker.broker as broker_module
+
+    broker = ProviderBroker(SQLiteCredentialStore(tmp_path / "credentials.sqlite3"))
+    monkeypatch.setattr(broker_module, "_default_broker", broker)
+    monkeypatch.setenv("RAY_SCE_LOCAL_MODE", "1")
+    config_path = (
+        Path(__file__).resolve().parents[1]
+        / "agent_configs"
+        / "templates"
+        / "daily_driver.v1.yaml"
+    )
+
+    response = TestClient(create_app()).get(
+        "/v1/models",
+        params={"config_path": str(config_path)},
+    )
+
+    assert response.status_code == 200, response.text
+    models = {row["id"]: row for row in response.json()["models"]}
+    synthetic = models["cli_mock/reference"]
+    assert {
+        key: synthetic[key]
+        for key in (
+            "provider",
+            "canonical_provider",
+            "adapter",
+            "support_tier",
+            "available",
+            "availability_reason",
+            "discovery",
+            "source",
+        )
+    } == {
+        "provider": "cli_mock",
+        "canonical_provider": "cli_mock",
+        "adapter": "cli_mock_chat",
+        "support_tier": "evidence",
+        "available": True,
+        "availability_reason": None,
+        "discovery": "configured_only",
+        "source": "configured",
+    }
 
 
 def test_credential_state_rejects_rebinding_and_cross_site_requests_without_token(

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from pathlib import Path
 import pytest
 
 from fastapi.testclient import TestClient
@@ -645,12 +644,8 @@ def test_daily_driver_catalog_exposes_explicit_synthetic_route(
     broker = ProviderBroker(SQLiteCredentialStore(tmp_path / "credentials.sqlite3"))
     monkeypatch.setattr(broker_module, "_default_broker", broker)
     monkeypatch.setenv("RAY_SCE_LOCAL_MODE", "1")
-    config_path = (
-        Path(__file__).resolve().parents[1]
-        / "agent_configs"
-        / "templates"
-        / "daily_driver.v1.yaml"
-    )
+    monkeypatch.chdir(tmp_path)
+    config_path = "agent_configs/templates/daily_driver.v1.yaml"
 
     response = TestClient(create_app()).get(
         "/v1/models",
@@ -658,6 +653,7 @@ def test_daily_driver_catalog_exposes_explicit_synthetic_route(
     )
 
     assert response.status_code == 200, response.text
+    assert response.json()["config_path"] == config_path
     models = {row["id"]: row for row in response.json()["models"]}
     synthetic = models["cli_mock/reference"]
     assert {

--- a/tests/test_breadboard_cli_packaging.py
+++ b/tests/test_breadboard_cli_packaging.py
@@ -361,7 +361,7 @@ print(json.dumps({{
         "generated_operation_count": 26,
         "profile_id": "daily_driver.v1",
         "profile_hash": (
-            "sha256:165d34c5ed177005fa289544da0b451294c89bb51b0d289f2372c4bd081eff43"
+            "sha256:6ea299b2d3ee382a8d8397cd5ed32080e99f8ae8b6a48006fce1ecad6859c10f"
         ),
         "e4_import_count": 0,
     }

--- a/tests/test_session_runner_pending_permissions.py
+++ b/tests/test_session_runner_pending_permissions.py
@@ -574,7 +574,7 @@ async def test_mutating_loader_cannot_split_frozen_start_artifacts(monkeypatch, 
     monkeypatch.setattr("breadboard_engine.api.cli_bridge.session_runner.load_agent_config", load); monkeypatch.setattr("breadboard_engine.api.cli_bridge.runtime_emission.load_agent_config", lambda _: pytest.fail("emitter reloaded mutable source")); monkeypatch.setattr("breadboard_engine.api.cli_bridge.service.primitive_emission_enabled", enable_primitives)
     monkeypatch.setattr("breadboard_engine.api.cli_bridge.service.uuid.uuid4", lambda: "frozen-session"); monkeypatch.setattr("breadboard_engine.api.cli_bridge.session_runner.SessionRunner.schedule_start", lambda _runner: None); monkeypatch.setattr("breadboard_engine.api.cli_bridge.session_runner.SessionRunner.authorize_start", lambda _runner: None); monkeypatch.setenv("BREADBOARD_RUNTIME_RECORD_ROOT", str(tmp_path / "records")); monkeypatch.setenv("BREADBOARD_SESSION_EVENT_ROOT", str(tmp_path / "events"))
     service = SessionService(); response = await service.create_session(SessionCreateRequest(config_path="mutating.json", task="test")); record = await service.ensure_session(response.session_id); root = tmp_path / "records" / response.session_id; names = ("effective_config_graph", "capability_registry", "effective_tool_surface", "effective_operation_policy"); payloads = {name: json.loads((root / f"{name}.json").read_text()) for name in names}
-    graph, policy = payloads["effective_config_graph"], payloads["effective_operation_policy"]; tool_ids = {item["capability_id"] for item in payloads["capability_registry"]["capabilities"] if item["capability_type"] == "tool"}; assert calls == ["mutating.json"] and graph["graph_hash"] == record.product_session.events[0].payload["effective_lock_hash"]
+    graph, policy = payloads["effective_config_graph"], payloads["effective_operation_policy"]; tool_ids = {item["capability_id"] for item in payloads["capability_registry"]["capabilities"] if item["capability_type"] == "tool"}; assert calls == [str(Path("mutating.json").resolve())] and graph["graph_hash"] == record.product_session.events[0].payload["effective_lock_hash"]
     assert tool_ids == {"tool.list"} == set(payloads["effective_tool_surface"]["tool_ids"]) and [(rule["decision"], rule["match"]["pattern"]) for rule in policy["tool_policy"]["rules"]] == [("allow", "list"), ("deny", "blocked_tool")]
     serialized = json.dumps(payloads) + "".join(path.read_text() for path in tmp_path.rglob("*") if path.is_file()); assert policy["approvals"]["mode"] == "always_required" and all(secret not in serialized for secret in ("provider_auth_runtime", "runtime-secret", "flat-secret", "nested-secret", '"read"'))
     captured = {}
@@ -612,7 +612,7 @@ async def test_mutating_loader_cannot_split_frozen_start_artifacts(monkeypatch, 
         "flat-secret",
         "nested-secret",
     )
-    assert calls == ["mutating.json"]
+    assert calls == [str(Path("mutating.json").resolve())]
     assert captured["config"] == expected
     assert not redaction.contains_provider_auth_runtime(captured["overrides"])
     assert "workspace.root" in captured["overrides"]

--- a/tests/test_session_runner_pending_permissions.py
+++ b/tests/test_session_runner_pending_permissions.py
@@ -85,6 +85,25 @@ def test_explicit_noninteractive_permission_mode_survives_prompt_config() -> Non
 
 
 async def _initialized() -> None: pass
+def test_configured_permission_mode_preserves_profile_rules() -> None:
+    runner = _runner("configured-permissions")
+    runner.request.permission_mode = "configured"
+    runner._base_config_cache = {
+        "permissions": {
+            "options": {"mode": "prompt"},
+            "shell": {"default": "ask"},
+        }
+    }
+
+    prepared = runner.prepare_runtime_config()
+
+    assert prepared["permissions"] == {
+        "options": {"mode": "prompt"},
+        "shell": {"default": "ask"},
+    }
+    assert runner.session.metadata["permission_mode"] == "configured"
+
+
 @pytest.mark.asyncio
 async def test_runner_admission_requires_exact_registry_correlation() -> None:
     runner = _runner("correlation")

--- a/tests/test_session_runner_pending_permissions.py
+++ b/tests/test_session_runner_pending_permissions.py
@@ -102,6 +102,21 @@ def test_configured_permission_mode_preserves_profile_rules() -> None:
         "shell": {"default": "ask"},
     }
     assert runner.session.metadata["permission_mode"] == "configured"
+    agent_config = json.loads(json.dumps(prepared))
+    runner._agent = type(
+        "ConfiguredAgent",
+        (),
+        {
+            "_local_mode": True,
+            "config": agent_config,
+            "run_task": lambda *_args, **_kwargs: {
+                "completion_summary": {"completed": True}
+            },
+        },
+    )()
+    _execute_task(runner)
+    assert runner._agent.config["permissions"] == prepared["permissions"]
+    assert runner._permission_queue is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -21,6 +21,8 @@ from breadboard_engine.api.cli_bridge.registry import (
     SessionRecord,
     SessionRegistry,
     TurnRecord,
+    identity_digest,
+    submission_body_digest,
 )
 from breadboard_engine.api.cli_bridge.service import SessionService
 from breadboard_engine.api.cli_bridge.runtime_event_projector import (
@@ -840,6 +842,108 @@ async def test_session_input_is_durable_before_deferred_execution(tmp_path: Path
 
 
 @pytest.mark.asyncio
+async def test_retained_submission_digest_deduplicates_after_restart(
+    tmp_path: Path,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id="sess-retained-dedupe",
+        status=SessionStatus.RUNNING,
+    )
+    client_message_id = "client-retained"
+    turn = TurnRecord(
+        input_id="input-retained",
+        turn_id="turn-retained",
+        client_message_id=client_message_id,
+        content="continue",
+        attachments=(),
+        original_disposition="started",
+        state="active",
+        body_digest=submission_body_digest("continue", ()),
+    )
+    record.turns_by_id[turn.turn_id] = turn
+    record.submissions_by_key[client_message_id] = turn
+    record.submissions_by_key_digest[identity_digest(client_message_id)] = turn
+    record.active_turn_id = turn.turn_id
+    record.turn_admission = record.turn_admission.__class__.ACTIVE
+    await registry.create(record)
+
+    restarted = SessionRegistry(state_root=tmp_path)
+    restored = await restarted.get(record.session_id)
+    assert restored is not None
+    assert restored.submissions_by_key == {}
+    restored.loaded_from_retained_state = False
+
+    class Runner:
+        async def enqueue_input(self, *_args: Any, **_kwargs: Any) -> str:
+            raise AssertionError("deduplicated input must not execute")
+
+    restored.runner = Runner()
+    receipt = await SessionService(registry=restarted).send_input(
+        restored.session_id,
+        SessionInputRequest(
+            content="continue",
+            client_message_id=client_message_id,
+        ),
+    )
+
+    assert receipt.disposition == "deduplicated"
+    assert receipt.turn_id == turn.turn_id
+    assert receipt.input_id == turn.input_id
+
+
+@pytest.mark.asyncio
+async def test_admission_persistence_failure_rolls_back_unscheduled_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id="sess-admission-persist-failure",
+        status=SessionStatus.RUNNING,
+    )
+
+    class Runner:
+        async def enqueue_input(
+            self,
+            content: str,
+            attachments: list[str],
+            *,
+            defer_execution: Any,
+            **_kwargs: Any,
+        ) -> str:
+            async def execute() -> None:
+                raise AssertionError("failed admission must not execute")
+
+            defer_execution(execute)
+            return content
+
+    record.runner = Runner()
+    await registry.create(record)
+
+    async def fail_persist(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("injected admission persistence failure")
+
+    monkeypatch.setattr(registry, "persist", fail_persist)
+    deferred: list[Any] = []
+    with pytest.raises(OSError, match="injected admission persistence failure"):
+        await SessionService(registry=registry).send_input(
+            record.session_id,
+            SessionInputRequest(
+                content="continue",
+                client_message_id="client-persist-failure",
+            ),
+            defer_execution=deferred.append,
+        )
+
+    assert deferred == []
+    assert record.turns_by_id == {}
+    assert record.submissions_by_key == {}
+    assert record.submissions_by_key_digest == {}
+    assert record.active_turn_id is None
+    assert record.turn_admission.value == "idle"
+
+@pytest.mark.asyncio
 async def test_cancel_turn_requests_only_the_active_turn_and_is_idempotent(
     tmp_path: Path,
 ) -> None:
@@ -1081,7 +1185,12 @@ async def test_retained_restart_terminalizes_interrupted_turn_and_resumes_runner
     replacement_profile.write_text("{}\n", encoding="utf-8")
     monkeypatch.setattr(
         "breadboard_engine.api.cli_bridge.service.resolve_default_profile",
-        lambda: SimpleNamespace(source_path=replacement_profile),
+        lambda: SimpleNamespace(
+            source_path=replacement_profile,
+            public_identity=lambda: {
+                "definition_ref": "agent_configs/templates/daily_driver.v1.yaml"
+            },
+        ),
     )
     monkeypatch.setattr(SessionRunner, "prepare_runtime_config", lambda self: {})
 
@@ -1112,6 +1221,58 @@ async def test_retained_restart_terminalizes_interrupted_turn_and_resumes_runner
         assert retained["session"]["permission_mode"] == "configured"
         assert retained["turns"][0]["terminal_resolution_committed"] is True
         assert len(retained["terminal_event_envelopes"]) == 1
+    finally:
+        if restored.runner is not None:
+            await restored.runner.stop()
+
+@pytest.mark.asyncio
+async def test_retained_restart_preserves_explicit_config_and_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    explicit_config = tmp_path / "explicit-session.yaml"
+    explicit_config.write_text("{}\n", encoding="utf-8")
+    explicit_workspace = tmp_path / "workspace"
+    explicit_workspace.mkdir()
+    registry = SessionRegistry(state_root=tmp_path / "state")
+    record = SessionRecord(
+        session_id="session-restart-explicit-context",
+        status=SessionStatus.RUNNING,
+        metadata={
+            "config_path": str(explicit_config),
+            "workspace": str(explicit_workspace),
+            "permission_mode": "configured",
+        },
+    )
+    await registry.create(record)
+
+    default_profile = tmp_path / "default-session.yaml"
+    default_profile.write_text("{}\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "breadboard_engine.api.cli_bridge.service.resolve_default_profile",
+        lambda: SimpleNamespace(
+            source_path=default_profile,
+            public_identity=lambda: {
+                "definition_ref": "agent_configs/templates/daily_driver.v1.yaml"
+            },
+        ),
+    )
+    prepared_requests: list[SessionCreateRequest] = []
+
+    def capture_runtime_request(runner: SessionRunner) -> dict[str, Any]:
+        prepared_requests.append(runner.request)
+        return {}
+
+    monkeypatch.setattr(SessionRunner, "prepare_runtime_config", capture_runtime_request)
+
+    restarted = SessionRegistry(state_root=tmp_path / "state")
+    restored = await SessionService(registry=restarted).ensure_session(record.session_id)
+    try:
+        assert prepared_requests
+        assert prepared_requests[0].config_path == str(explicit_config)
+        assert prepared_requests[0].workspace == str(explicit_workspace)
+        assert restored.metadata["config_path"] == str(explicit_config)
+        assert restored.metadata["workspace"] == str(explicit_workspace)
     finally:
         if restored.runner is not None:
             await restored.runner.stop()

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -707,6 +707,47 @@ def test_session_runner_recognizes_replay_after_injected_system_reminder(
 
 
 @pytest.mark.asyncio
+async def test_session_runner_can_defer_execution_until_after_admission_response() -> None:
+    registry = SessionRegistry()
+    record = SessionRecord(session_id="sess-deferred-execution", status=SessionStatus.RUNNING)
+    turn = TurnRecord(
+        input_id="input-deferred",
+        turn_id="turn-deferred",
+        client_message_id="client-deferred",
+        content="continue",
+        attachments=(),
+        original_disposition="started",
+        state="active",
+    )
+    record.turns_by_id[turn.turn_id] = turn
+    record.active_turn_id = turn.turn_id
+    deferred: list[Any] = []
+    runner = SessionRunner(
+        session=record,
+        registry=registry,
+        request=SessionCreateRequest(config_path="cfg.yaml", task="", stream=False),
+    )
+
+    accepted = await runner.enqueue_input(
+        "continue",
+        input_id=turn.input_id,
+        turn_id=turn.turn_id,
+        defer_execution=deferred.append,
+    )
+
+    assert accepted == "continue"
+    assert runner._input_queue.empty()
+    assert len(deferred) == 1
+    await deferred[0]()
+    assert await runner._input_queue.get() == {
+        "content": "continue",
+        "attachments": [],
+        "input_id": turn.input_id,
+        "turn_id": turn.turn_id,
+    }
+
+
+@pytest.mark.asyncio
 async def test_session_input_returns_canonical_idempotent_turn_receipt() -> None:
     registry = SessionRegistry()
     record = SessionRecord(
@@ -726,10 +767,17 @@ async def test_session_input_returns_canonical_idempotent_turn_receipt() -> None
             *,
             input_id: str | None = None,
             turn_id: str | None = None,
+            defer_execution: Any = None,
         ) -> str:
-            self.inputs.append(
-                (content, attachments, input_id, turn_id, record.active_turn_id)
-            )
+            async def execute() -> None:
+                self.inputs.append(
+                    (content, attachments, input_id, turn_id, record.active_turn_id)
+                )
+
+            if defer_execution is None:
+                await execute()
+            else:
+                defer_execution(execute)
             return content
 
     runner = Runner()
@@ -757,6 +805,38 @@ async def test_session_input_returns_canonical_idempotent_turn_receipt() -> None
         ("continue", [], first.input_id, first.turn_id, first.turn_id),
     ]
     assert record.active_turn_id == first.turn_id
+
+
+@pytest.mark.asyncio
+async def test_session_input_is_durable_before_deferred_execution(tmp_path: Path) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(session_id="sess-durable-admission", status=SessionStatus.RUNNING)
+    runner = SessionRunner(
+        session=record,
+        registry=registry,
+        request=SessionCreateRequest(config_path="cfg.yaml", task="", stream=False),
+    )
+    record.runner = runner
+    await registry.create(record)
+    service = SessionService(registry=registry)
+    deferred: list[Any] = []
+
+    receipt = await service.send_input(
+        record.session_id,
+        SessionInputRequest(content="continue", client_message_id="client-durable"),
+        defer_execution=deferred.append,
+    )
+
+    assert runner._input_queue.empty()
+    assert len(deferred) == 1
+    restored = await SessionRegistry(state_root=tmp_path).get(record.session_id)
+    assert restored is not None
+    assert restored.turns_by_id[receipt.turn_id].input_id == receipt.input_id
+    assert restored.turns_by_id[receipt.turn_id].state == "active"
+    await deferred[0]()
+    queued = await runner._input_queue.get()
+    assert queued["input_id"] == receipt.input_id
+    assert queued["turn_id"] == receipt.turn_id
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
+from fastapi import HTTPException
 
 from breadboard_engine.api.cli_bridge.events import EventType, SessionEvent
 from breadboard_engine.api.cli_bridge.models import (
@@ -1339,6 +1340,16 @@ async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_
     assert [event.seq for event in restored.event_log] == [terminal_envelope["seq"]]
     replay_queue: asyncio.Queue[SessionEvent | None] = asyncio.Queue()
     restarted_service = SessionService(registry=restarted)
+    gap_queue: asyncio.Queue[SessionEvent | None] = asyncio.Queue()
+    with pytest.raises(HTTPException) as gap_error:
+        await restarted_service._register_subscriber(
+            restored,
+            gap_queue,
+            replay=True,
+            from_id=terminal_envelope["id"],
+        )
+    assert gap_error.value.status_code == 409
+    assert gap_error.value.detail["code"] == "resume_window_exceeded"
     await restarted_service._register_subscriber(
         restored,
         replay_queue,
@@ -1363,6 +1374,47 @@ async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_
         restored,
         numeric_replay_queue,
     )
+
+@pytest.mark.asyncio
+async def test_dispatcher_failure_drains_queue_and_rejects_future_events(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id="session-dispatcher-persist-failure",
+        status=SessionStatus.RUNNING,
+    )
+    await registry.create(record)
+    service = SessionService(registry=registry)
+    await service._ensure_dispatcher(record)
+
+    async def fail_persist(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("injected dispatcher persistence failure")
+
+    monkeypatch.setattr(registry, "persist", fail_persist)
+    record.event_queue.put_nowait(
+        SessionEvent(EventType.TASK_EVENT, record.session_id, {"index": 1})
+    )
+    record.event_queue.put_nowait(
+        SessionEvent(EventType.TASK_EVENT, record.session_id, {"index": 2})
+    )
+    assert record.dispatcher_task is not None
+    await record.dispatcher_task
+    await asyncio.wait_for(record.event_queue.join(), timeout=1)
+
+    assert record.event_queue.empty()
+    assert getattr(record, "_dispatcher_complete", False) is True
+    runner = SessionRunner(
+        session=record,
+        registry=registry,
+        request=SessionCreateRequest(config_path="cfg.yaml", task=""),
+    )
+    with pytest.raises(RuntimeError, match="dispatcher is unavailable"):
+        await runner._enqueue_event_async(
+            SessionEvent(EventType.TASK_EVENT, record.session_id, {"index": 3})
+        )
+
 
 @pytest.mark.asyncio
 async def test_retained_restart_terminalizes_interrupted_turn_and_resumes_runner(
@@ -1453,25 +1505,21 @@ async def test_retained_restart_preserves_explicit_config_and_workspace(
             "config_path": str(explicit_config),
             "workspace": str(explicit_workspace),
             "permission_mode": "configured",
+            "mode": "review",
         },
     )
     await registry.create(record)
 
-    default_profile = tmp_path / "default-session.yaml"
-    default_profile.write_text("{}\n", encoding="utf-8")
     monkeypatch.setattr(
         "breadboard_engine.api.cli_bridge.service.resolve_default_profile",
-        lambda: SimpleNamespace(
-            source_path=default_profile,
-            public_identity=lambda: {
-                "definition_ref": "agent_configs/templates/daily_driver.v1.yaml"
-            },
-        ),
+        lambda: pytest.fail("explicit retained config resolved the default profile"),
     )
     prepared_requests: list[SessionCreateRequest] = []
+    prepared_modes: list[str | None] = []
 
     def capture_runtime_request(runner: SessionRunner) -> dict[str, Any]:
         prepared_requests.append(runner.request)
+        prepared_modes.append(runner._mode)
         return {}
 
     monkeypatch.setattr(SessionRunner, "prepare_runtime_config", capture_runtime_request)
@@ -1482,8 +1530,10 @@ async def test_retained_restart_preserves_explicit_config_and_workspace(
         assert prepared_requests
         assert prepared_requests[0].config_path == str(explicit_config)
         assert prepared_requests[0].workspace == str(explicit_workspace)
+        assert prepared_modes == ["review"]
         assert restored.metadata["config_path"] == str(explicit_config)
         assert restored.metadata["workspace"] == str(explicit_workspace)
+        assert restored.metadata["mode"] == "review"
     finally:
         if restored.runner is not None:
             await restored.runner.stop()

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -5,6 +5,7 @@ import json
 import queue
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional, Tuple
 
 import pytest
@@ -954,6 +955,67 @@ async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_
     stream_open = SessionService._stream_open_event(restored)
     assert stream_open.payload["headSequence"] == replay_head.seq
     assert stream_open.payload["headEventId"] == replay_head.event_id
+
+@pytest.mark.asyncio
+async def test_retained_restart_terminalizes_interrupted_turn_and_resumes_runner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id="session-restart-interrupted",
+        status=SessionStatus.RUNNING,
+        metadata={"permission_mode": "configured"},
+    )
+    interrupted = TurnRecord(
+        input_id="input-interrupted",
+        turn_id="turn-interrupted",
+        client_message_id="client-interrupted",
+        content="must-not-persist",
+        attachments=(),
+        original_disposition="started",
+        state="active",
+    )
+    record.turns_by_id[interrupted.turn_id] = interrupted
+    record.active_turn_id = interrupted.turn_id
+    await registry.create(record)
+    await registry.persist(record)
+
+    replacement_profile = tmp_path / "replacement-session.yaml"
+    replacement_profile.write_text("{}\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "breadboard_engine.api.cli_bridge.service.resolve_default_profile",
+        lambda: SimpleNamespace(source_path=replacement_profile),
+    )
+    monkeypatch.setattr(SessionRunner, "prepare_runtime_config", lambda self: {})
+
+    restarted = SessionRegistry(state_root=tmp_path)
+    service = SessionService(registry=restarted)
+    restored = await service.ensure_session(record.session_id)
+    try:
+        await asyncio.sleep(0)
+        assert restored.loaded_from_retained_state is False
+        assert restored.runner is not None
+        restored_turn = restored.turns_by_id[interrupted.turn_id]
+        assert restored_turn.terminal_outcome == "failed"
+        assert restored_turn.terminal_resolution_committed is True
+        assert restored.active_turn_id is None
+        assert restored.turn_admission.value == "idle"
+        assert len(restored.terminal_event_envelopes) == 1
+        terminal = restored.terminal_event_envelopes[0]
+        assert terminal["type"] == "turn_failed"
+        assert terminal["input_id"] == interrupted.input_id
+        assert terminal["turn_id"] == interrupted.turn_id
+        assert terminal["payload"] == {"error": {"code": "runtime_failure"}}
+        assert (await service.ensure_session(record.session_id)).runner is restored.runner
+        retained = json.loads(next(tmp_path.glob("*.json")).read_text(encoding="utf-8"))
+        assert retained["session"]["permission_mode"] == "configured"
+        assert retained["turns"][0]["terminal_resolution_committed"] is True
+        assert len(retained["terminal_event_envelopes"]) == 1
+    finally:
+        if restored.runner is not None:
+            await restored.runner.stop()
+
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -2689,6 +2689,85 @@ async def test_interactive_failure_terminalizes_remaining_admitted_turns(
 
 
 @pytest.mark.asyncio
+async def test_interactive_stop_cancels_remaining_admitted_turns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id="session-stop-cancels-admitted",
+        status=SessionStatus.STARTING,
+    )
+    runner, product_session = _lifecycle_runner_with_product_session(
+        registry,
+        record,
+        monkeypatch,
+        [],
+    )
+    entered = threading.Event()
+    release = threading.Event()
+
+    def execute_task(
+        _task: str,
+        *,
+        input_id: str | None = None,
+        turn_id: str | None = None,
+    ) -> dict[str, Any]:
+        entered.set()
+        assert release.wait(2)
+        return {
+            "completion_summary": {
+                "completed": False,
+                "reason": "stopped_by_user",
+            },
+            "reward_metrics": None,
+            "logging_dir": None,
+            "_terminal_events": [],
+            "_turn_completion_payload": {},
+        }
+
+    monkeypatch.setattr(runner._task_execution, "execute_task", execute_task)
+    await registry.create(record)
+    await runner.prepare_start()
+    active = record.turns_by_id[record.active_turn_id or ""]
+    queued = TurnRecord(
+        input_id="input-queued",
+        turn_id="turn-queued",
+        client_message_id="message-queued",
+        content="queued",
+        attachments=(),
+        original_disposition="queued",
+        state="queued",
+    )
+    record.turns_by_id[queued.turn_id] = queued
+    record.queued_turn_ids.append(queued.turn_id)
+    record.turn_admission = record.turn_admission.__class__.ACTIVE
+    await registry.persist(record)
+    runner.schedule_start()
+    runner.authorize_start()
+    assert await asyncio.to_thread(entered.wait, 2)
+
+    stop_task = asyncio.create_task(runner.stop())
+    for _ in range(200):
+        if runner._stop_event.is_set():
+            break
+        await asyncio.sleep(0.01)
+    else:
+        raise AssertionError("runner stop did not signal execution")
+    release.set()
+    await stop_task
+
+    assert active.terminal_outcome == "cancelled"
+    assert queued.terminal_outcome == "cancelled"
+    assert active.terminal_resolution_committed is True
+    assert queued.terminal_resolution_committed is True
+    assert record.active_turn_id is None
+    assert list(record.queued_turn_ids) == []
+    assert product_session.read_model.status == "canceled"
+    assert record.status is SessionStatus.STOPPED
+
+
+@pytest.mark.asyncio
 async def test_session_runner_crash_terminalizes_active_and_queued_turns_once(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -840,6 +840,48 @@ async def test_session_input_is_durable_before_deferred_execution(tmp_path: Path
     assert queued["input_id"] == receipt.input_id
     assert queued["turn_id"] == receipt.turn_id
 
+@pytest.mark.asyncio
+async def test_deferred_input_failure_terminalizes_durable_turn(
+    tmp_path: Path,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id="sess-deferred-input-terminal-race",
+        status=SessionStatus.RUNNING,
+    )
+
+    class TerminalProductSession:
+        def input(self, _content: str, _artifacts: list[Any]) -> None:
+            raise RuntimeError("product session is terminal")
+
+    record.product_session = TerminalProductSession()
+    runner = SessionRunner(
+        session=record,
+        registry=registry,
+        request=SessionCreateRequest(config_path="cfg.yaml", task="", stream=False),
+    )
+    record.runner = runner
+    await registry.create(record)
+    deferred: list[Any] = []
+
+    receipt = await SessionService(registry=registry).send_input(
+        record.session_id,
+        SessionInputRequest(
+            content="continue",
+            client_message_id="client-terminal-race",
+        ),
+        defer_execution=deferred.append,
+    )
+    assert len(deferred) == 1
+
+    await deferred[0]()
+
+    turn = record.turns_by_id[receipt.turn_id]
+    assert turn.terminal_outcome == "failed"
+    assert turn.terminal_resolution_committed is True
+    assert record.active_turn_id is None
+    assert runner._input_queue.empty()
+
 
 @pytest.mark.asyncio
 async def test_retained_submission_digest_deduplicates_after_restart(
@@ -1474,6 +1516,82 @@ async def test_retained_terminal_session_is_not_resurrected(
     assert restored.runner is None
     assert restored.loaded_from_retained_state is False
     assert (await service.ensure_session(record.session_id)) is restored
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["stop", "delete"])
+async def test_locked_operation_resumes_retained_session_without_deadlock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    config_path = tmp_path / "retained-config.yaml"
+    config_path.write_text("{}\n", encoding="utf-8")
+    state_root = tmp_path / "state"
+    registry = SessionRegistry(state_root=state_root)
+    record = SessionRecord(
+        session_id=f"session-retained-{operation}",
+        status=SessionStatus.RUNNING,
+        metadata={
+            "config_path": str(config_path),
+            "permission_mode": "configured",
+        },
+    )
+    await registry.create(record)
+    monkeypatch.setattr(
+        "breadboard_engine.api.cli_bridge.service.resolve_default_profile",
+        lambda: SimpleNamespace(
+            source_path=config_path,
+            public_identity=lambda: {
+                "definition_ref": "agent_configs/templates/daily_driver.v1.yaml"
+            },
+        ),
+    )
+    monkeypatch.setattr(SessionRunner, "prepare_runtime_config", lambda self: {})
+    service = SessionService(registry=SessionRegistry(state_root=state_root))
+
+    if operation == "stop":
+        await asyncio.wait_for(service.stop_session(record.session_id), timeout=2)
+        stopped = await service.registry.get(record.session_id)
+        assert stopped is not None
+        assert stopped.status is SessionStatus.STOPPED
+    else:
+        await asyncio.wait_for(service.delete_session(record.session_id), timeout=2)
+        assert await service.registry.get(record.session_id) is None
+
+
+@pytest.mark.asyncio
+async def test_session_creation_persists_absolute_explicit_config_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = tmp_path / "relative-config.yaml"
+    config_path.write_text("profile: {name: relative-test}\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(
+        "BREADBOARD_RUNTIME_RECORD_ROOT",
+        str(tmp_path / "runtime-records"),
+    )
+    monkeypatch.setenv(
+        "BREADBOARD_SESSION_EVENT_ROOT",
+        str(tmp_path / "session-events"),
+    )
+    monkeypatch.setattr(SessionRunner, "schedule_start", lambda self: None)
+    monkeypatch.setattr(SessionRunner, "authorize_start", lambda self: None)
+    service = SessionService(state_root=tmp_path / "state")
+
+    response = await service.create_session(
+        SessionCreateRequest(
+            config_path=config_path.name,
+            task="",
+            stream=False,
+        )
+    )
+    created = await service.ensure_session(response.session_id)
+
+    assert created.metadata["config_path"] == str(config_path)
+    assert created.runner is not None
+    assert created.runner.request.config_path == str(config_path)
+    await service.delete_session(response.session_id)
 
 
 
@@ -2410,6 +2528,164 @@ def test_session_runner_unknown_runtime_event_fails_closed_and_strips_sentinel()
     )
     assert session_scoped is not None
     assert session_scoped[2] is None
+
+
+def _lifecycle_runner_with_product_session(
+    registry: SessionRegistry,
+    record: SessionRecord,
+    monkeypatch: pytest.MonkeyPatch,
+    outcomes: list[bool],
+) -> tuple[SessionRunner, Any]:
+    from breadboard.product.harness.lock import EffectiveHarnessLock
+    from breadboard.product.runtime import Session as ProductSession
+
+    product_session = ProductSession.start(
+        EffectiveHarnessLock._from_record(
+            {"graph_hash": "sha256:" + "a" * 64}
+        ),
+        "active",
+        session_id=record.session_id,
+    )
+    record.product_session = product_session
+    runner = SessionRunner(
+        session=record,
+        registry=registry,
+        request=SessionCreateRequest(
+            config_path="cfg.yaml",
+            task="active",
+            stream=False,
+        ),
+    )
+    record.runner = runner
+    monkeypatch.setattr(runner, "prepare_runtime_config", lambda: {})
+
+    async def initialized() -> None:
+        return None
+
+    monkeypatch.setattr(runner, "_ensure_agent_initialized", initialized)
+
+    def execute_task(
+        _task: str,
+        *,
+        input_id: str | None = None,
+        turn_id: str | None = None,
+    ) -> dict[str, Any]:
+        completed = outcomes.pop(0)
+        return {
+            "completion_summary": {
+                "completed": completed,
+                "reason": "completed" if completed else "stopped_by_user",
+            },
+            "reward_metrics": None,
+            "logging_dir": None,
+            "_terminal_events": [],
+            "_turn_completion_payload": {},
+        }
+    monkeypatch.setattr(runner._task_execution, "execute_task", execute_task)
+    return runner, product_session
+
+
+async def _wait_for_terminal_turn(turn: TurnRecord) -> None:
+    for _ in range(200):
+        if turn.terminal_resolution_committed:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"turn {turn.turn_id} did not become terminal")
+
+
+@pytest.mark.asyncio
+async def test_active_turn_cancellation_keeps_interactive_session_running(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id="session-active-cancel-continues",
+        status=SessionStatus.STARTING,
+    )
+    runner, product_session = _lifecycle_runner_with_product_session(
+        registry,
+        record,
+        monkeypatch,
+        [False, True],
+    )
+    await registry.create(record)
+    await runner.prepare_start()
+    active = record.turns_by_id[record.active_turn_id or ""]
+    active.cancellation_requested = True
+    active.cancellation_reason = "user_requested"
+    record.turn_admission = record.turn_admission.__class__.ACTIVE
+    await registry.persist(record)
+    runner.schedule_start()
+    runner.authorize_start()
+
+    await _wait_for_terminal_turn(active)
+    assert active.terminal_outcome == "cancelled", record.terminal_event_envelopes
+    assert product_session.read_model.status == "running"
+    assert record.status is SessionStatus.RUNNING
+
+    receipt = await SessionService(registry=registry).send_input(
+        record.session_id,
+        SessionInputRequest(
+            content="continue",
+            client_message_id="message-continue",
+        ),
+    )
+    continued = record.turns_by_id[receipt.turn_id]
+    await _wait_for_terminal_turn(continued)
+
+    assert continued.terminal_outcome == "completed"
+    assert product_session.read_model.status == "running"
+    assert record.status is SessionStatus.RUNNING
+    await runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_interactive_failure_terminalizes_remaining_admitted_turns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id="session-failure-drains-admitted",
+        status=SessionStatus.STARTING,
+    )
+    runner, product_session = _lifecycle_runner_with_product_session(
+        registry,
+        record,
+        monkeypatch,
+        [False],
+    )
+    await registry.create(record)
+    await runner.prepare_start()
+    active = record.turns_by_id[record.active_turn_id or ""]
+    queued = TurnRecord(
+        input_id="input-queued",
+        turn_id="turn-queued",
+        client_message_id="message-queued",
+        content="queued",
+        attachments=(),
+        original_disposition="queued",
+        state="queued",
+    )
+    record.turns_by_id[queued.turn_id] = queued
+    record.queued_turn_ids.append(queued.turn_id)
+    record.turn_admission = record.turn_admission.__class__.ACTIVE
+    await registry.persist(record)
+    runner.schedule_start()
+    runner.authorize_start()
+
+    await _wait_for_terminal_turn(queued)
+
+    assert active.terminal_outcome == "failed"
+    assert queued.terminal_outcome == "failed"
+    assert active.terminal_resolution_committed is True
+    assert queued.terminal_resolution_committed is True
+    assert record.active_turn_id is None
+    assert list(record.queued_turn_ids) == []
+    assert product_session.read_model.status == "failed"
+    assert record.status is SessionStatus.FAILED
+    await runner.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -2764,6 +2764,42 @@ async def test_interactive_failure_terminalizes_remaining_admitted_turns(
 
 
 @pytest.mark.asyncio
+async def test_dispatcher_persistence_failure_still_fails_session_lifecycle(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id="session-dispatcher-failure-lifecycle",
+        status=SessionStatus.STARTING,
+    )
+    runner, product_session = _lifecycle_runner_with_product_session(
+        registry,
+        record,
+        monkeypatch,
+        [False],
+    )
+    await registry.create(record)
+    await runner.prepare_start()
+    service = SessionService(registry=registry)
+    await service._ensure_dispatcher(record)
+
+    async def fail_event_persist(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("injected event persistence failure")
+
+    monkeypatch.setattr(registry, "persist", fail_event_persist)
+    runner.schedule_start()
+    runner.authorize_start()
+    assert runner._task is not None
+    await asyncio.wait_for(runner._task, timeout=2)
+
+    assert getattr(record, "_dispatcher_complete", False) is True
+    assert product_session.read_model.status == "failed"
+    assert record.status is SessionStatus.FAILED
+    assert runner._closed is True
+
+
+@pytest.mark.asyncio
 async def test_productless_interactive_failure_marks_session_failed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -2689,6 +2689,38 @@ async def test_interactive_failure_terminalizes_remaining_admitted_turns(
 
 
 @pytest.mark.asyncio
+async def test_productless_interactive_failure_marks_session_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id="session-productless-failure",
+        status=SessionStatus.RUNNING,
+    )
+    runner, _ = _lifecycle_runner_with_product_session(
+        registry,
+        record,
+        monkeypatch,
+        [False],
+    )
+    record.product_session = None
+    await registry.create(record)
+    await runner.prepare_start()
+    active = record.turns_by_id[record.active_turn_id or ""]
+    record.turn_admission = record.turn_admission.__class__.ACTIVE
+    await registry.persist(record)
+    runner.schedule_start()
+    runner.authorize_start()
+    assert runner._task is not None
+    await runner._task
+
+    assert active.terminal_outcome == "failed"
+    assert active.terminal_resolution_committed is True
+    assert record.status is SessionStatus.FAILED
+
+
+@pytest.mark.asyncio
 async def test_interactive_stop_cancels_remaining_admitted_turns(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -14,6 +14,7 @@ from breadboard_engine.api.cli_bridge.models import (
     SessionCreateRequest,
     SessionInputRequest,
     SessionStatus,
+    SessionTurnCancelRequest,
 )
 from breadboard_engine.api.cli_bridge.registry import (
     SessionRecord,
@@ -758,8 +759,117 @@ async def test_session_input_returns_canonical_idempotent_turn_receipt() -> None
 
 
 @pytest.mark.asyncio
-async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(
+async def test_cancel_turn_requests_only_the_active_turn_and_is_idempotent(
     tmp_path: Path,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(session_id="sess-active-cancel", status=SessionStatus.RUNNING)
+    turn = TurnRecord(
+        input_id="input-active",
+        turn_id="turn-active",
+        client_message_id="client-active",
+        content="active",
+        attachments=(),
+        original_disposition="started",
+        state="active",
+    )
+    record.turns_by_id[turn.turn_id] = turn
+    record.active_turn_id = turn.turn_id
+
+    class Runner:
+        def __init__(self) -> None:
+            self.requests: list[str] = []
+
+        def request_turn_cancellation(self, turn_id: str) -> bool:
+            self.requests.append(turn_id)
+            return True
+
+        async def finish_queued_turn_cancellation(
+            self, queued_turn: TurnRecord, reason: str,
+        ) -> None:
+            raise AssertionError((queued_turn, reason))
+
+    runner = Runner()
+    record.runner = runner
+    await registry.create(record)
+    service = SessionService(registry=registry)
+    request = SessionTurnCancelRequest(
+        cancellation_request_key="cancel-active",
+        reason="user_requested",
+    )
+
+    first = await service.cancel_turn(record.session_id, turn.turn_id, request)
+    duplicate = await service.cancel_turn(record.session_id, turn.turn_id, request)
+
+    assert first.disposition == "cancellation_requested"
+    assert first.original_disposition == "cancellation_requested"
+    assert duplicate.disposition == "deduplicated"
+    assert duplicate.cancellation_request_id == first.cancellation_request_id
+    assert runner.requests == [turn.turn_id]
+    assert turn.cancellation_requested is True
+    assert turn.cancellation_reason == "user_requested"
+    assert turn.terminal_outcome is None
+    assert record.status is SessionStatus.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_cancel_turn_terminalizes_queued_turn_without_stopping_session(
+    tmp_path: Path,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(session_id="sess-queued-cancel", status=SessionStatus.RUNNING)
+    active = TurnRecord(
+        input_id="input-active",
+        turn_id="turn-active",
+        client_message_id="client-active",
+        content="active",
+        attachments=(),
+        original_disposition="started",
+        state="active",
+    )
+    queued = TurnRecord(
+        input_id="input-queued",
+        turn_id="turn-queued",
+        client_message_id="client-queued",
+        content="queued",
+        attachments=(),
+        original_disposition="queued",
+        state="queued",
+    )
+    record.turns_by_id = {active.turn_id: active, queued.turn_id: queued}
+    record.active_turn_id = active.turn_id
+    record.queued_turn_ids.append(queued.turn_id)
+    runner = SessionRunner(
+        session=record,
+        registry=registry,
+        request=SessionCreateRequest(config_path="cfg.yaml", task="", stream=False),
+    )
+    record.runner = runner
+    await registry.create(record)
+    service = SessionService(registry=registry)
+
+    response = await service.cancel_turn(
+        record.session_id,
+        queued.turn_id,
+        SessionTurnCancelRequest(
+            cancellation_request_key="cancel-queued",
+            reason="superseded",
+        ),
+    )
+
+    assert response.disposition == "queued_cancelled"
+    assert queued.terminal_outcome == "cancelled"
+    assert queued.terminal_resolution_committed is True
+    assert record.active_turn_id == active.turn_id
+    assert list(record.queued_turn_ids) == []
+    assert record.status is SessionStatus.RUNNING
+    assert [envelope["turn_id"] for envelope in record.terminal_event_envelopes] == [
+        queued.turn_id
+    ]
+
+
+@pytest.mark.asyncio
+async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_path: Path,
 ) -> None:
     registry = SessionRegistry(state_root=tmp_path)
     record = SessionRecord(

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -999,8 +999,8 @@ async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_
     assert record.dispatcher_task is not None
     assert not record.dispatcher_task.done()
 
-    # Completion bookkeeping can advance the observed cursor after the retained
-    # terminal envelope. Persist only its head identity, never its payload.
+    # Compact retention stores terminal envelopes only, so later completion
+    # bookkeeping must not be advertised as a replayable head.
     completion_tail = SessionEvent(
         EventType.COMPLETION,
         record.session_id,
@@ -1020,8 +1020,8 @@ async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_
     assert "completion-payload-must-not-persist" not in retained_bytes
     assert "path-must-not-persist" not in retained_bytes
     retained = json.loads(retained_bytes)
-    assert retained["session"]["event_seq"] == replay_head.seq
-    assert retained["session"]["event_head_id"] == replay_head.event_id
+    assert retained["session"]["event_seq"] == terminal_envelope["seq"]
+    assert retained["session"]["event_head_id"] == terminal_envelope["id"]
 
     await record.event_queue.put(None)
     await record.dispatcher_task
@@ -1029,12 +1029,12 @@ async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_
     restored = await restarted.get(record.session_id)
     assert restored is not None
     summary = restored.to_summary()
-    assert summary.head_sequence == replay_head.seq
-    assert summary.head_event_id == replay_head.event_id
+    assert summary.head_sequence == terminal_envelope["seq"]
+    assert summary.head_event_id == terminal_envelope["id"]
     assert summary.terminal_event_envelopes == [terminal_envelope]
     stream_open = SessionService._stream_open_event(restored)
-    assert stream_open.payload["headSequence"] == replay_head.seq
-    assert stream_open.payload["headEventId"] == replay_head.event_id
+    assert stream_open.payload["headSequence"] == terminal_envelope["seq"]
+    assert stream_open.payload["headEventId"] == terminal_envelope["id"]
 
 @pytest.mark.asyncio
 async def test_retained_restart_terminalizes_interrupted_turn_and_resumes_runner(

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -1052,6 +1052,159 @@ async def test_cancel_turn_terminalizes_queued_turn_without_stopping_session(
         queued.turn_id
     ]
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("queued", [False, True])
+async def test_cancellation_persistence_failure_rolls_back_request(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    queued: bool,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id=f"sess-cancel-persist-failure-{queued}",
+        status=SessionStatus.RUNNING,
+    )
+    active = TurnRecord(
+        input_id="input-active",
+        turn_id="turn-active",
+        client_message_id="client-active",
+        content="active",
+        attachments=(),
+        original_disposition="started",
+        state="active",
+    )
+    target = (
+        TurnRecord(
+            input_id="input-queued",
+            turn_id="turn-queued",
+            client_message_id="client-queued",
+            content="queued",
+            attachments=(),
+            original_disposition="queued",
+            state="queued",
+        )
+        if queued
+        else active
+    )
+    record.turns_by_id[active.turn_id] = active
+    record.active_turn_id = active.turn_id
+    if queued:
+        record.turns_by_id[target.turn_id] = target
+        record.queued_turn_ids.append(target.turn_id)
+
+    class Runner:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def request_turn_cancellation(self, turn_id: str) -> bool:
+            self.calls.append(turn_id)
+            return True
+
+        async def finish_queued_turn_cancellation(
+            self,
+            turn: TurnRecord,
+            _reason: str,
+        ) -> None:
+            self.calls.append(turn.turn_id)
+
+    runner = Runner()
+    record.runner = runner
+    await registry.create(record)
+    queued_ids_before = list(record.queued_turn_ids)
+
+    async def fail_persist(*_args: Any, **_kwargs: Any) -> None:
+        raise OSError("injected cancellation persistence failure")
+
+    monkeypatch.setattr(registry, "persist", fail_persist)
+    with pytest.raises(OSError, match="injected cancellation persistence failure"):
+        await SessionService(registry=registry).cancel_turn(
+            record.session_id,
+            target.turn_id,
+            SessionTurnCancelRequest(
+                cancellation_request_key=f"cancel-persist-failure-{queued}",
+                reason="user_requested",
+            ),
+        )
+
+    assert target.cancellation_requested is False
+    assert target.cancellation_reason is None
+    assert record.cancellations_by_key == {}
+    assert record.cancellations_by_key_digest == {}
+    assert list(record.queued_turn_ids) == queued_ids_before
+    assert runner.calls == []
+
+@pytest.mark.asyncio
+async def test_queued_cancellation_retry_finishes_after_terminal_persist_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id="sess-queued-cancel-terminal-retry",
+        status=SessionStatus.RUNNING,
+    )
+    active = TurnRecord(
+        input_id="input-active",
+        turn_id="turn-active",
+        client_message_id="client-active",
+        content="active",
+        attachments=(),
+        original_disposition="started",
+        state="active",
+    )
+    queued = TurnRecord(
+        input_id="input-queued",
+        turn_id="turn-queued",
+        client_message_id="client-queued",
+        content="queued",
+        attachments=(),
+        original_disposition="queued",
+        state="queued",
+    )
+    record.turns_by_id = {active.turn_id: active, queued.turn_id: queued}
+    record.active_turn_id = active.turn_id
+    record.queued_turn_ids.append(queued.turn_id)
+    runner = SessionRunner(
+        session=record,
+        registry=registry,
+        request=SessionCreateRequest(config_path="cfg.yaml", task="", stream=False),
+    )
+    record.runner = runner
+    await registry.create(record)
+    original_persist = registry.persist
+    terminal_failure_injected = False
+
+    async def fail_first_terminal_persist(
+        persisted_record: SessionRecord,
+        **kwargs: Any,
+    ) -> None:
+        nonlocal terminal_failure_injected
+        if kwargs.get("terminal_event") is not None and not terminal_failure_injected:
+            terminal_failure_injected = True
+            raise OSError("injected terminal persistence failure")
+        await original_persist(persisted_record, **kwargs)
+
+    monkeypatch.setattr(registry, "persist", fail_first_terminal_persist)
+    request = SessionTurnCancelRequest(
+        cancellation_request_key="cancel-queued-terminal-retry",
+        reason="user_requested",
+    )
+    service = SessionService(registry=registry)
+
+    with pytest.raises(OSError, match="injected terminal persistence failure"):
+        await service.cancel_turn(record.session_id, queued.turn_id, request)
+
+    assert queued.terminal_outcome is None
+    assert list(record.queued_turn_ids) == []
+    assert record.cancellations_by_key
+
+    duplicate = await service.cancel_turn(record.session_id, queued.turn_id, request)
+
+    assert duplicate.disposition == "deduplicated"
+    assert duplicate.original_disposition == "queued_cancelled"
+    assert queued.terminal_outcome == "cancelled"
+    assert queued.terminal_resolution_committed is True
+
 
 @pytest.mark.asyncio
 async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_path: Path,
@@ -1152,6 +1305,22 @@ async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_
     )
     assert replay_queue.empty()
     await restarted_service._unregister_subscriber(restored, replay_queue)
+    assert restarted_service._is_retained_head_cursor(
+        restored,
+        str(replay_head.seq),
+    )
+    numeric_replay_queue: asyncio.Queue[SessionEvent | None] = asyncio.Queue()
+    await restarted_service._register_subscriber(
+        restored,
+        numeric_replay_queue,
+        replay=True,
+        from_id=str(replay_head.seq),
+    )
+    assert numeric_replay_queue.empty()
+    await restarted_service._unregister_subscriber(
+        restored,
+        numeric_replay_queue,
+    )
 
 @pytest.mark.asyncio
 async def test_retained_restart_terminalizes_interrupted_turn_and_resumes_runner(
@@ -1276,6 +1445,35 @@ async def test_retained_restart_preserves_explicit_config_and_workspace(
     finally:
         if restored.runner is not None:
             await restored.runner.stop()
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "terminal_status",
+    [
+        SessionStatus.COMPLETED,
+        SessionStatus.FAILED,
+        SessionStatus.STOPPED,
+    ],
+)
+async def test_retained_terminal_session_is_not_resurrected(
+    tmp_path: Path,
+    terminal_status: SessionStatus,
+) -> None:
+    registry = SessionRegistry(state_root=tmp_path)
+    record = SessionRecord(
+        session_id=f"session-retained-{terminal_status.value}",
+        status=terminal_status,
+    )
+    await registry.create(record)
+
+    restarted = SessionRegistry(state_root=tmp_path)
+    service = SessionService(registry=restarted)
+    restored = await service.ensure_session(record.session_id)
+
+    assert restored.status is terminal_status
+    assert restored.runner is None
+    assert restored.loaded_from_retained_state is False
+    assert (await service.ensure_session(record.session_id)) is restored
 
 
 

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -1417,6 +1417,31 @@ async def test_dispatcher_failure_drains_queue_and_rejects_future_events(
 
 
 @pytest.mark.asyncio
+async def test_async_event_enqueue_fails_fast_when_bounded_queue_is_full() -> None:
+    record = SessionRecord(
+        session_id="session-bounded-event-queue",
+        status=SessionStatus.RUNNING,
+    )
+    record.event_queue = asyncio.Queue(maxsize=1)
+    record.event_queue.put_nowait(
+        SessionEvent(EventType.TASK_EVENT, record.session_id, {"index": 1})
+    )
+    runner = SessionRunner(
+        session=record,
+        registry=SessionRegistry(),
+        request=SessionCreateRequest(config_path="cfg.yaml", task=""),
+    )
+
+    with pytest.raises(RuntimeError, match="event queue is full"):
+        await asyncio.wait_for(
+            runner._enqueue_event_async(
+                SessionEvent(EventType.TASK_EVENT, record.session_id, {"index": 2})
+            ),
+            timeout=1,
+        )
+
+
+@pytest.mark.asyncio
 async def test_retained_restart_terminalizes_interrupted_turn_and_resumes_runner(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -999,8 +999,8 @@ async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_
     assert record.dispatcher_task is not None
     assert not record.dispatcher_task.done()
 
-    # Compact retention stores terminal envelopes only, so later completion
-    # bookkeeping must not be advertised as a replayable head.
+    # Retention stores only sanitized terminal envelopes plus the exact durable
+    # cursor identity, never the payload behind a nonterminal replay head.
     completion_tail = SessionEvent(
         EventType.COMPLETION,
         record.session_id,
@@ -1015,13 +1015,14 @@ async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_
     )
     record.event_log.extend((completion_tail, replay_head))
     record.event_seq = 3
-    await registry.persist(record)
+    await registry.persist(record, cursor_event=replay_head)
     retained_bytes = next(tmp_path.glob("*.json")).read_text(encoding="utf-8")
     assert "completion-payload-must-not-persist" not in retained_bytes
     assert "path-must-not-persist" not in retained_bytes
     retained = json.loads(retained_bytes)
-    assert retained["session"]["event_seq"] == terminal_envelope["seq"]
-    assert retained["session"]["event_head_id"] == terminal_envelope["id"]
+    assert retained["session"]["event_seq"] == replay_head.seq
+    assert retained["session"]["replay_head_sequence"] == replay_head.seq
+    assert retained["session"]["event_head_id"] == replay_head.event_id
 
     await record.event_queue.put(None)
     await record.dispatcher_task
@@ -1029,12 +1030,24 @@ async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_
     restored = await restarted.get(record.session_id)
     assert restored is not None
     summary = restored.to_summary()
-    assert summary.head_sequence == terminal_envelope["seq"]
-    assert summary.head_event_id == terminal_envelope["id"]
+    assert summary.head_sequence == replay_head.seq
+    assert summary.head_event_id == replay_head.event_id
     assert summary.terminal_event_envelopes == [terminal_envelope]
     stream_open = SessionService._stream_open_event(restored)
-    assert stream_open.payload["headSequence"] == terminal_envelope["seq"]
-    assert stream_open.payload["headEventId"] == terminal_envelope["id"]
+    assert stream_open.payload["headSequence"] == replay_head.seq
+    assert stream_open.payload["headEventId"] == replay_head.event_id
+    assert restored.event_seq == replay_head.seq
+    assert [event.seq for event in restored.event_log] == [terminal_envelope["seq"]]
+    replay_queue: asyncio.Queue[SessionEvent | None] = asyncio.Queue()
+    restarted_service = SessionService(registry=restarted)
+    await restarted_service._register_subscriber(
+        restored,
+        replay_queue,
+        replay=True,
+        from_id=replay_head.event_id,
+    )
+    assert replay_queue.empty()
+    await restarted_service._unregister_subscriber(restored, replay_queue)
 
 @pytest.mark.asyncio
 async def test_retained_restart_terminalizes_interrupted_turn_and_resumes_runner(
@@ -1059,6 +1072,9 @@ async def test_retained_restart_terminalizes_interrupted_turn_and_resumes_runner
     record.turns_by_id[interrupted.turn_id] = interrupted
     record.active_turn_id = interrupted.turn_id
     await registry.create(record)
+    record.event_seq = 390
+    record.replay_head_sequence = 390
+    record.replay_head_event_id = "event-before-process-death"
     await registry.persist(record)
 
     replacement_profile = tmp_path / "replacement-session.yaml"
@@ -1083,6 +1099,10 @@ async def test_retained_restart_terminalizes_interrupted_turn_and_resumes_runner
         assert restored.turn_admission.value == "idle"
         assert len(restored.terminal_event_envelopes) == 1
         terminal = restored.terminal_event_envelopes[0]
+        assert terminal["seq"] == 391
+        summary = restored.to_summary()
+        assert summary.head_sequence == 391
+        assert summary.head_event_id == terminal["id"]
         assert terminal["type"] == "turn_failed"
         assert terminal["input_id"] == interrupted.input_id
         assert terminal["turn_id"] == interrupted.turn_id


### PR DESCRIPTION
Reconstructs the accepted G6 capability stack on the frozen engine main after PRs #73, #74, #75, and #77.

This supersedes raw PR #76. The reconstruction replays only the 15 capability commits unique to that proposal and drops 11 inherited ancestry commits already present on main, avoiding duplicate implementation and stale ownership boundaries.

Scope:
- synthetic provider/profile path used by the installed journey
- admitted-turn durability before execution and restart-safe idempotency
- active-turn cancellation with terminal consistency and continued interactive use
- retained-session recovery preserving explicit config, mode, workspace, and terminal outcome
- exact UUID and numeric retained replay cursors with gap-safe retained suffix validation
- deterministic per-session default workspace and bootstrap event ordering
- fail-closed dispatcher and lifecycle behavior under retained-state persistence loss
- private workspace protection for the Claude `Write` alias

Compatibility and migration:
- Compat reviewed: non-breaking
- Public session events retain their existing schema and preserve `skills_catalog` as the first bootstrap event.
- Retained state adds workspace, mode, digest indexes, and replay-head identity; existing retained records remain loadable.
- Explicit relative config paths are normalized to their creation-time absolute identity before persistence.
- Generated OpenAPI, exported CLI schemas, and TypeScript SDK output are unchanged.

Final candidate:
- head `2a71132637b9c674727e4ed916e12c5e34a788cf`
- tree `0770f98ba8e4b98bf2bd81d652fb5964f40eb87a`

Validation:
- 190 passed: session state, retained recovery/replay, configured policy, cancellation/failure/stop/dispatcher races, productless failure projection, permissions, system surface, auth, and OpenAI tool integration
- 90 passed: full public API, mock provider runtime, packaged templates, wheel and clean-install packaging
- 6 passed: exported CLI contracts and TypeScript SDK codegen
- generated OpenAPI and schemas unchanged

Lineage and omission:
- Source PR #76 head `3fa52469db07360f82102a3120284847ebbe7513`.
- 15 unique commits replayed with original authors/dates; 11 inherited commits omitted as superseded by merged main.
- Source PR #76 remains intact until this replacement is accepted.

Rollback: revert the PR merge as one unit; retained records written with additive fields remain readable by the pre-merge loader because unknown keys are ignored.

Independent review on the exact head/tree above:
- correctness PASS; all live review threads re-audited and resolved
- security PASS; no P0-P2 blockers

Non-goals and residual risk: no external-provider action, release, credential, RL readiness claim, or claim beyond the synthetic installed journey.