### PR TITLE
Add installed Pi and Oh My Pi E4 targets

### DIFF
--- a/breadboard_engine/e4_targets.py
+++ b/breadboard_engine/e4_targets.py
@@ -6,6 +6,7 @@ from importlib import metadata
 from importlib.resources.abc import Traversable
 import hashlib
 import json
+import os
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
@@ -68,9 +69,7 @@ def _resource_root() -> Traversable:
 
 
 def _location_key(location: object) -> str:
-    text = str(location)
-    path = Path(text)
-    return str(path.resolve()) if path.exists() else text
+    return os.path.abspath(str(location))
 
 
 def _load_e4_target_from_root(

--- a/breadboard_engine/e4_targets.py
+++ b/breadboard_engine/e4_targets.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+from importlib import resources
+from importlib.resources.abc import Traversable
+import json
+from pathlib import Path
+from typing import Any
+
+
+_RESOURCE_PACKAGE = "config.e4_targets"
+_INDEX_FILE = "index.json"
+_INDEX_SCHEMA = "bb.e4.target_index.v1"
+_TARGET_SCHEMA = "bb.e4.target.v1"
+
+
+class E4TargetError(ValueError):
+    """Raised when an E4 target package is missing, unsafe, or corrupt."""
+
+
+@dataclass(frozen=True)
+class E4TargetPackage:
+    target_id: str
+    descriptor: dict[str, Any]
+    _asset_root: Traversable
+    _asset_paths: frozenset[str]
+
+    def read_asset_bytes(self, relative_path: str) -> bytes:
+        if relative_path not in self._asset_paths:
+            raise E4TargetError(
+                f"target {self.target_id!r} does not declare asset {relative_path!r}"
+            )
+        return _read_bytes(_join_safe(self._asset_root, relative_path), relative_path)
+
+    def read_asset_text(self, relative_path: str) -> str:
+        try:
+            return self.read_asset_bytes(relative_path).decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise E4TargetError(
+                f"target {self.target_id!r} asset {relative_path!r} is not UTF-8"
+            ) from exc
+
+
+def list_e4_target_ids() -> tuple[str, ...]:
+    root = resources.files(_RESOURCE_PACKAGE)
+    index = _load_index(root)
+    return tuple(sorted(index["targets"]))
+
+
+def load_e4_target(target_id: str) -> E4TargetPackage:
+    return _load_e4_target_from_root(resources.files(_RESOURCE_PACKAGE), target_id)
+
+
+def _load_e4_target_from_root(
+    root: Traversable | Path, target_id: str
+) -> E4TargetPackage:
+    index = _load_index(root)
+    targets = index["targets"]
+    entry = targets.get(target_id)
+    if entry is None:
+        available = ", ".join(sorted(targets))
+        raise E4TargetError(f"unknown E4 target {target_id!r}; available: {available}")
+    if not isinstance(entry, dict):
+        raise E4TargetError(f"index entry for {target_id!r} must be an object")
+
+    descriptor_path = _required_string(
+        entry, "descriptor", f"index entry {target_id!r}"
+    )
+    descriptor_sha256 = _required_sha256(entry, "sha256", f"index entry {target_id!r}")
+    descriptor_parts = _validate_relative_path(descriptor_path)
+    descriptor_resource = _join_parts(root, descriptor_parts)
+    descriptor_bytes = _read_bytes(descriptor_resource, descriptor_path)
+    _verify_sha256(descriptor_bytes, descriptor_sha256, descriptor_path)
+    descriptor = _decode_json_object(descriptor_bytes, descriptor_path)
+
+    if descriptor.get("schema_version") != _TARGET_SCHEMA:
+        raise E4TargetError(
+            f"{descriptor_path} schema_version must be {_TARGET_SCHEMA!r}"
+        )
+    if descriptor.get("target_id") != target_id:
+        raise E4TargetError(
+            f"{descriptor_path} target_id does not match index key {target_id!r}"
+        )
+
+    descriptor_parent = _join_parts(root, descriptor_parts[:-1])
+    assets = descriptor.get("assets")
+    if not isinstance(assets, list) or not assets:
+        raise E4TargetError(f"{descriptor_path} assets must be a non-empty array")
+
+    declared_paths: set[str] = set()
+    for position, asset in enumerate(assets):
+        context = f"{descriptor_path} assets[{position}]"
+        if not isinstance(asset, dict):
+            raise E4TargetError(f"{context} must be an object")
+        asset_path = _required_string(asset, "path", context)
+        _validate_relative_path(asset_path)
+        if asset_path in declared_paths:
+            raise E4TargetError(
+                f"{descriptor_path} declares duplicate asset {asset_path!r}"
+            )
+        declared_paths.add(asset_path)
+        expected_digest = _required_sha256(asset, "sha256", context)
+        asset_bytes = _read_bytes(
+            _join_safe(descriptor_parent, asset_path),
+            f"{descriptor_path}:{asset_path}",
+        )
+        _verify_sha256(asset_bytes, expected_digest, f"{descriptor_path}:{asset_path}")
+        expected_bytes = asset.get("bytes")
+        if not isinstance(expected_bytes, int) or expected_bytes < 0:
+            raise E4TargetError(f"{context}.bytes must be a non-negative integer")
+        if len(asset_bytes) != expected_bytes:
+            raise E4TargetError(
+                f"{descriptor_path}:{asset_path} size mismatch: "
+                f"expected {expected_bytes}, got {len(asset_bytes)}"
+            )
+
+    execution = descriptor.get("execution")
+    if not isinstance(execution, dict) or not execution:
+        raise E4TargetError(f"{descriptor_path} execution must be a non-empty object")
+    for key, value in execution.items():
+        if not key.endswith("_asset"):
+            continue
+        if not isinstance(value, str) or value not in declared_paths:
+            raise E4TargetError(
+                f"{descriptor_path} execution.{key} must name a declared asset"
+            )
+
+    return E4TargetPackage(
+        target_id=target_id,
+        descriptor=descriptor,
+        _asset_root=descriptor_parent,
+        _asset_paths=frozenset(declared_paths),
+    )
+
+
+def _load_index(root: Traversable | Path) -> dict[str, Any]:
+    index = _decode_json_object(
+        _read_bytes(root.joinpath(_INDEX_FILE), _INDEX_FILE), _INDEX_FILE
+    )
+    if index.get("schema_version") != _INDEX_SCHEMA:
+        raise E4TargetError(f"{_INDEX_FILE} schema_version must be {_INDEX_SCHEMA!r}")
+    targets = index.get("targets")
+    if not isinstance(targets, dict) or not targets:
+        raise E4TargetError(f"{_INDEX_FILE} targets must be a non-empty object")
+    if any(not isinstance(target_id, str) or not target_id for target_id in targets):
+        raise E4TargetError(f"{_INDEX_FILE} target IDs must be non-empty strings")
+    return index
+
+
+def _join_safe(root: Traversable | Path, relative_path: str) -> Traversable | Path:
+    return _join_parts(root, _validate_relative_path(relative_path))
+
+
+def _join_parts(root: Traversable | Path, parts: tuple[str, ...]) -> Traversable | Path:
+    resource = root
+    for part in parts:
+        resource = resource.joinpath(part)
+    return resource
+
+
+def _validate_relative_path(relative_path: str) -> tuple[str, ...]:
+    if not isinstance(relative_path, str) or not relative_path:
+        raise E4TargetError("target resource path must be a non-empty string")
+    if relative_path.startswith("/") or "\\" in relative_path:
+        raise E4TargetError(f"unsafe target resource path {relative_path!r}")
+    parts = tuple(relative_path.split("/"))
+    if any(part in {"", ".", ".."} for part in parts):
+        raise E4TargetError(f"unsafe target resource path {relative_path!r}")
+    return parts
+
+
+def _read_bytes(resource: Traversable | Path, label: str) -> bytes:
+    try:
+        if not resource.is_file():
+            raise E4TargetError(f"target resource {label!r} is missing or not a file")
+        return resource.read_bytes()
+    except E4TargetError:
+        raise
+    except OSError as exc:
+        raise E4TargetError(f"could not read target resource {label!r}: {exc}") from exc
+
+
+def _decode_json_object(content: bytes, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(content)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise E4TargetError(f"target resource {label!r} is not valid JSON") from exc
+    if not isinstance(value, dict):
+        raise E4TargetError(f"target resource {label!r} must contain a JSON object")
+    return value
+
+
+def _required_string(value: dict[str, Any], key: str, context: str) -> str:
+    field = value.get(key)
+    if not isinstance(field, str) or not field:
+        raise E4TargetError(f"{context}.{key} must be a non-empty string")
+    return field
+
+
+def _required_sha256(value: dict[str, Any], key: str, context: str) -> str:
+    digest = _required_string(value, key, context)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise E4TargetError(f"{context}.{key} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _verify_sha256(content: bytes, expected: str, label: str) -> None:
+    actual = hashlib.sha256(content).hexdigest()
+    if actual != expected:
+        raise E4TargetError(
+            f"target resource {label!r} SHA-256 mismatch: expected {expected}, got {actual}"
+        )

--- a/breadboard_engine/e4_targets.py
+++ b/breadboard_engine/e4_targets.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from importlib import metadata
+from importlib.resources.abc import Traversable
 import hashlib
 import json
 from pathlib import Path
@@ -9,7 +11,9 @@ from types import MappingProxyType
 from typing import Any
 
 
-_RESOURCE_DIRECTORY = Path("config/e4_targets")
+_DISTRIBUTION_NAME = "breadboard-harness-cli"
+_LOADER_PATH = "breadboard_engine/e4_targets.py"
+_RESOURCE_DIRECTORY = "config/e4_targets"
 _INDEX_FILE = "index.json"
 _INDEX_SCHEMA = "bb.e4.target_index.v1"
 _TARGET_SCHEMA = "bb.e4.target.v1"
@@ -23,7 +27,7 @@ class E4TargetError(ValueError):
 class E4TargetPackage:
     target_id: str
     descriptor: Mapping[str, Any]
-    _asset_root: Path
+    _asset_root: Traversable
     _asset_paths: frozenset[str]
 
     def read_asset_bytes(self, relative_path: str) -> bytes:
@@ -51,11 +55,27 @@ def load_e4_target(target_id: str) -> E4TargetPackage:
     return _load_e4_target_from_root(_resource_root(), target_id)
 
 
-def _resource_root() -> Path:
-    return Path(__file__).resolve().parents[1] / _RESOURCE_DIRECTORY
+def _resource_root() -> Traversable:
+    loader_location = _location_key(__file__)
+    for distribution in metadata.distributions(name=_DISTRIBUTION_NAME):
+        candidate = distribution.locate_file(_LOADER_PATH)
+        if _location_key(candidate) == loader_location:
+            return distribution.locate_file(_RESOURCE_DIRECTORY)
+    raise E4TargetError(
+        f"could not locate {_RESOURCE_DIRECTORY!r} in the distribution "
+        f"that owns {loader_location!r}"
+    )
 
 
-def _load_e4_target_from_root(root: Path, target_id: str) -> E4TargetPackage:
+def _location_key(location: object) -> str:
+    text = str(location)
+    path = Path(text)
+    return str(path.resolve()) if path.exists() else text
+
+
+def _load_e4_target_from_root(
+    root: Traversable | Path, target_id: str
+) -> E4TargetPackage:
     index = _load_index(root)
     targets = index["targets"]
     entry = targets.get(target_id)
@@ -135,7 +155,7 @@ def _load_e4_target_from_root(root: Path, target_id: str) -> E4TargetPackage:
     )
 
 
-def _load_index(root: Path) -> dict[str, Any]:
+def _load_index(root: Traversable | Path) -> dict[str, Any]:
     index = _decode_json_object(
         _read_bytes(root.joinpath(_INDEX_FILE), _INDEX_FILE), _INDEX_FILE
     )
@@ -159,12 +179,15 @@ def _freeze_json(value: Any) -> Any:
     return value
 
 
-def _join_safe(root: Path, relative_path: str) -> Path:
+def _join_safe(root: Traversable | Path, relative_path: str) -> Traversable | Path:
     return _join_parts(root, _validate_relative_path(relative_path))
 
 
-def _join_parts(root: Path, parts: tuple[str, ...]) -> Path:
-    return root.joinpath(*parts)
+def _join_parts(root: Traversable | Path, parts: tuple[str, ...]) -> Traversable | Path:
+    resource = root
+    for part in parts:
+        resource = resource.joinpath(part)
+    return resource
 
 
 def _validate_relative_path(relative_path: str) -> tuple[str, ...]:
@@ -178,7 +201,7 @@ def _validate_relative_path(relative_path: str) -> tuple[str, ...]:
     return parts
 
 
-def _read_bytes(resource: Path, label: str) -> bytes:
+def _read_bytes(resource: Traversable | Path, label: str) -> bytes:
     try:
         if not resource.is_file():
             raise E4TargetError(f"target resource {label!r} is missing or not a file")

--- a/breadboard_engine/e4_targets.py
+++ b/breadboard_engine/e4_targets.py
@@ -10,6 +10,8 @@ import os
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 
 _DISTRIBUTION_NAME = "breadboard-harness-cli"
@@ -62,10 +64,45 @@ def _resource_root() -> Traversable:
         candidate = distribution.locate_file(_LOADER_PATH)
         if _location_key(candidate) == loader_location:
             return distribution.locate_file(_RESOURCE_DIRECTORY)
+        editable_root = _editable_source_root(distribution)
+        if editable_root is not None and (
+            _location_key(editable_root / _LOADER_PATH) == loader_location
+        ):
+            return editable_root / _RESOURCE_DIRECTORY
     raise E4TargetError(
         f"could not locate {_RESOURCE_DIRECTORY!r} in the distribution "
         f"that owns {loader_location!r}"
     )
+
+
+def _editable_source_root(distribution: metadata.Distribution) -> Path | None:
+    raw = distribution.read_text("direct_url.json")
+    if raw is None:
+        return None
+    try:
+        direct_url = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(direct_url, dict):
+        return None
+    directory_info = direct_url.get("dir_info")
+    url = direct_url.get("url")
+    if (
+        not isinstance(directory_info, dict)
+        or directory_info.get("editable") is not True
+        or not isinstance(url, str)
+    ):
+        return None
+    parsed = urlparse(url)
+    if (
+        parsed.scheme != "file"
+        or parsed.netloc not in {"", "localhost"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    source_root = Path(url2pathname(parsed.path))
+    return source_root if source_root.is_absolute() else None
 
 
 def _location_key(location: object) -> str:

--- a/breadboard_engine/e4_targets.py
+++ b/breadboard_engine/e4_targets.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 import hashlib
-from importlib import resources
-from importlib.resources.abc import Traversable
 import json
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 
-_RESOURCE_PACKAGE = "config.e4_targets"
+_RESOURCE_DIRECTORY = Path("config/e4_targets")
 _INDEX_FILE = "index.json"
 _INDEX_SCHEMA = "bb.e4.target_index.v1"
 _TARGET_SCHEMA = "bb.e4.target.v1"
@@ -22,8 +22,8 @@ class E4TargetError(ValueError):
 @dataclass(frozen=True)
 class E4TargetPackage:
     target_id: str
-    descriptor: dict[str, Any]
-    _asset_root: Traversable
+    descriptor: Mapping[str, Any]
+    _asset_root: Path
     _asset_paths: frozenset[str]
 
     def read_asset_bytes(self, relative_path: str) -> bytes:
@@ -43,18 +43,19 @@ class E4TargetPackage:
 
 
 def list_e4_target_ids() -> tuple[str, ...]:
-    root = resources.files(_RESOURCE_PACKAGE)
-    index = _load_index(root)
+    index = _load_index(_resource_root())
     return tuple(sorted(index["targets"]))
 
 
 def load_e4_target(target_id: str) -> E4TargetPackage:
-    return _load_e4_target_from_root(resources.files(_RESOURCE_PACKAGE), target_id)
+    return _load_e4_target_from_root(_resource_root(), target_id)
 
 
-def _load_e4_target_from_root(
-    root: Traversable | Path, target_id: str
-) -> E4TargetPackage:
+def _resource_root() -> Path:
+    return Path(__file__).resolve().parents[1] / _RESOURCE_DIRECTORY
+
+
+def _load_e4_target_from_root(root: Path, target_id: str) -> E4TargetPackage:
     index = _load_index(root)
     targets = index["targets"]
     entry = targets.get(target_id)
@@ -107,7 +108,7 @@ def _load_e4_target_from_root(
         )
         _verify_sha256(asset_bytes, expected_digest, f"{descriptor_path}:{asset_path}")
         expected_bytes = asset.get("bytes")
-        if not isinstance(expected_bytes, int) or expected_bytes < 0:
+        if type(expected_bytes) is not int or expected_bytes < 0:
             raise E4TargetError(f"{context}.bytes must be a non-negative integer")
         if len(asset_bytes) != expected_bytes:
             raise E4TargetError(
@@ -128,13 +129,13 @@ def _load_e4_target_from_root(
 
     return E4TargetPackage(
         target_id=target_id,
-        descriptor=descriptor,
+        descriptor=_freeze_json(descriptor),
         _asset_root=descriptor_parent,
         _asset_paths=frozenset(declared_paths),
     )
 
 
-def _load_index(root: Traversable | Path) -> dict[str, Any]:
+def _load_index(root: Path) -> dict[str, Any]:
     index = _decode_json_object(
         _read_bytes(root.joinpath(_INDEX_FILE), _INDEX_FILE), _INDEX_FILE
     )
@@ -148,15 +149,22 @@ def _load_index(root: Traversable | Path) -> dict[str, Any]:
     return index
 
 
-def _join_safe(root: Traversable | Path, relative_path: str) -> Traversable | Path:
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return MappingProxyType(
+            {key: _freeze_json(child) for key, child in value.items()}
+        )
+    if isinstance(value, list):
+        return tuple(_freeze_json(child) for child in value)
+    return value
+
+
+def _join_safe(root: Path, relative_path: str) -> Path:
     return _join_parts(root, _validate_relative_path(relative_path))
 
 
-def _join_parts(root: Traversable | Path, parts: tuple[str, ...]) -> Traversable | Path:
-    resource = root
-    for part in parts:
-        resource = resource.joinpath(part)
-    return resource
+def _join_parts(root: Path, parts: tuple[str, ...]) -> Path:
+    return root.joinpath(*parts)
 
 
 def _validate_relative_path(relative_path: str) -> tuple[str, ...]:
@@ -170,7 +178,7 @@ def _validate_relative_path(relative_path: str) -> tuple[str, ...]:
     return parts
 
 
-def _read_bytes(resource: Traversable | Path, label: str) -> bytes:
+def _read_bytes(resource: Path, label: str) -> bytes:
     try:
         if not resource.is_file():
             raise E4TargetError(f"target resource {label!r} is missing or not a file")

--- a/breadboard_engine/e4_targets.py
+++ b/breadboard_engine/e4_targets.py
@@ -30,15 +30,15 @@ class E4TargetError(ValueError):
 class E4TargetPackage:
     target_id: str
     descriptor: Mapping[str, Any]
-    _asset_root: Traversable
-    _asset_paths: frozenset[str]
+    _assets: Mapping[str, bytes]
 
     def read_asset_bytes(self, relative_path: str) -> bytes:
-        if relative_path not in self._asset_paths:
+        try:
+            return self._assets[relative_path]
+        except KeyError:
             raise E4TargetError(
                 f"target {self.target_id!r} does not declare asset {relative_path!r}"
-            )
-        return _read_bytes(_join_safe(self._asset_root, relative_path), relative_path)
+            ) from None
 
     def read_asset_text(self, relative_path: str) -> str:
         try:
@@ -152,6 +152,7 @@ def _load_e4_target_from_root(
         raise E4TargetError(f"{descriptor_path} assets must be a non-empty array")
 
     declared_paths: set[str] = set()
+    verified_assets: dict[str, bytes] = {}
     for position, asset in enumerate(assets):
         context = f"{descriptor_path} assets[{position}]"
         if not isinstance(asset, dict):
@@ -177,6 +178,7 @@ def _load_e4_target_from_root(
                 f"{descriptor_path}:{asset_path} size mismatch: "
                 f"expected {expected_bytes}, got {len(asset_bytes)}"
             )
+        verified_assets[asset_path] = asset_bytes
 
     execution = descriptor.get("execution")
     if not isinstance(execution, dict) or not execution:
@@ -192,8 +194,7 @@ def _load_e4_target_from_root(
     return E4TargetPackage(
         target_id=target_id,
         descriptor=_freeze_json(descriptor),
-        _asset_root=descriptor_parent,
-        _asset_paths=frozenset(declared_paths),
+        _assets=MappingProxyType(verified_assets),
     )
 
 
@@ -235,7 +236,11 @@ def _join_parts(root: Traversable | Path, parts: tuple[str, ...]) -> Traversable
 def _validate_relative_path(relative_path: str) -> tuple[str, ...]:
     if not isinstance(relative_path, str) or not relative_path:
         raise E4TargetError("target resource path must be a non-empty string")
-    if relative_path.startswith("/") or "\\" in relative_path:
+    if (
+        relative_path.startswith("/")
+        or "\\" in relative_path
+        or ":" in relative_path
+    ):
         raise E4TargetError(f"unsafe target resource path {relative_path!r}")
     parts = tuple(relative_path.split("/"))
     if any(part in {"", ".", ".."} for part in parts):

--- a/breadboard_engine/e4_targets.py
+++ b/breadboard_engine/e4_targets.py
@@ -76,7 +76,10 @@ def _resource_root() -> Traversable:
 
 
 def _editable_source_root(distribution: metadata.Distribution) -> Path | None:
-    raw = distribution.read_text("direct_url.json")
+    try:
+        raw = distribution.read_text("direct_url.json")
+    except (OSError, UnicodeError):
+        return None
     if raw is None:
         return None
     try:
@@ -93,7 +96,10 @@ def _editable_source_root(distribution: metadata.Distribution) -> Path | None:
         or not isinstance(url, str)
     ):
         return None
-    parsed = urlparse(url)
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
     if (
         parsed.scheme != "file"
         or parsed.netloc not in {"", "localhost"}

--- a/config/e4_targets/index.json
+++ b/config/e4_targets/index.json
@@ -3,11 +3,11 @@
   "targets": {
     "oh-my-pi@16.2.13": {
       "descriptor": "oh_my_pi/16.2.13/target.json",
-      "sha256": "e6ae4b5f3a504acde0c447b843b091ff9d0f7f8b6fc209f089427ed6132390f2"
+      "sha256": "537fb2659e6f8f619e0fd832d48d57c5f8c0da4b2356022b0ebecd6ccbb7a105"
     },
     "pi@0.57.1": {
       "descriptor": "pi/0.57.1/target.json",
-      "sha256": "8343980a59e5d30443cfb829bd988d4d9a7d556df2b0f194fb1bfbada6589c84"
+      "sha256": "0131e41b0ffbbd0800fd332b769de2603caf4716382989a50c9e47a8f8d2441c"
     }
   }
 }

--- a/config/e4_targets/index.json
+++ b/config/e4_targets/index.json
@@ -7,7 +7,7 @@
     },
     "pi@0.57.1": {
       "descriptor": "pi/0.57.1/target.json",
-      "sha256": "5a9e25160b0bd4256a07eb967f935f332b9c7875a6f4fc5b88d9f06e8f452863"
+      "sha256": "8343980a59e5d30443cfb829bd988d4d9a7d556df2b0f194fb1bfbada6589c84"
     }
   }
 }

--- a/config/e4_targets/index.json
+++ b/config/e4_targets/index.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "bb.e4.target_index.v1",
+  "targets": {
+    "oh-my-pi@16.2.13": {
+      "descriptor": "oh_my_pi/16.2.13/target.json",
+      "sha256": "e6ae4b5f3a504acde0c447b843b091ff9d0f7f8b6fc209f089427ed6132390f2"
+    },
+    "pi@0.57.1": {
+      "descriptor": "pi/0.57.1/target.json",
+      "sha256": "5a9e25160b0bd4256a07eb967f935f332b9c7875a6f4fc5b88d9f06e8f452863"
+    }
+  }
+}

--- a/config/e4_targets/oh_my_pi/16.2.13/harness.yaml
+++ b/config/e4_targets/oh_my_pi/16.2.13/harness.yaml
@@ -4,13 +4,27 @@ prompt:
   renderer: oh-my-pi-handlebars-16.2.13
   asset: prompts/system-prompt.md
   dynamic_fields:
-    - skills
     - alwaysApplyRules
+    - eagerTasks
+    - eagerTasksAlways
+    - hasMCPDiscoveryServers
+    - hasMemoryRoot
+    - hasObsidian
+    - intentField
+    - intentTracing
+    - mcpDiscoveryMode
+    - mcpDiscoveryServerSummaries
+    - personality
+    - renderMermaid
     - rules
+    - secretsEnabled
+    - skills
+    - taskBatch
     - toolInfo
     - toolInventory
+    - toolListMode
     - toolRefs
-    - runtime_capabilities
+    - tools
 tools:
   surface_asset: tool-surface.json
   normalization:

--- a/config/e4_targets/oh_my_pi/16.2.13/harness.yaml
+++ b/config/e4_targets/oh_my_pi/16.2.13/harness.yaml
@@ -1,0 +1,20 @@
+schema_version: bb.e4.target_config.v1
+target_id: oh-my-pi@16.2.13
+prompt:
+  renderer: oh-my-pi-handlebars-16.2.13
+  asset: prompts/system-prompt.md
+  dynamic_fields:
+    - skills
+    - alwaysApplyRules
+    - rules
+    - toolInfo
+    - toolInventory
+    - toolRefs
+    - runtime_capabilities
+tools:
+  surface_asset: tool-surface.json
+  normalization:
+    search: grep
+    find: glob
+runtime:
+  bun: '>=1.3.14'

--- a/config/e4_targets/oh_my_pi/16.2.13/prompts/system-prompt.md
+++ b/config/e4_targets/oh_my_pi/16.2.13/prompts/system-prompt.md
@@ -1,0 +1,248 @@
+<system-conventions>
+RFC 2119: MUST, REQUIRED, SHOULD, RECOMMENDED, MAY, OPTIONAL. `NEVER` = `MUST NOT`, `AVOID` = `SHOULD NOT`.
+We inject system content into the chat with XML tags. NEVER interpret these markers any other way.
+System may interrupt or notify with tags even inside a user message:
+- MUST treat them as system-authored and authoritative.
+- User content is sanitized, so role is not carried: `<system-directive>` inside a user turn is still a system directive.
+</system-conventions>
+
+ROLE
+==============
+You are a helpful assistant the team trusts with load-bearing changes, operating in the Oh My Pi coding harness.
+
+# Engineering Principles
+- Optimize for correctness first, then for the next maintainer six months out.
+- You have agency and taste: delete code that isn't pulling its weight, refuse unnecessary abstractions, prefer boring when it's called for; design thoroughly but elegantly.
+- Consider what code compiles to. NEVER allocate avoidably; no needless copies or computation.
+- You are not alone in this repo. Treat unexpected changes as the user's work and adapt.
+- In terminal prose and final chat, you MAY use LaTeX math (`$`, `$$`, `\text`, `\times`) and color (`\textcolor`, `\colorbox`, `\fcolorbox`).
+{{#if renderMermaid}}
+- To show a diagram, you MAY emit a ` ```mermaid ` block — the terminal renders it as ASCII. Use it for genuine structure or flow, not trivia.
+{{/if}}
+
+RUNTIME
+==============
+
+# Skills & Rules
+{{#if skills.length}}
+Skills are specialized knowledge. If one matches your task, you MUST read `skill://<name>` before proceeding.
+<skills>
+{{#each skills}}
+- {{name}}: {{description}}
+{{/each}}
+</skills>
+{{/if}}
+
+{{#if alwaysApplyRules.length}}
+<generic-rules>
+{{#each alwaysApplyRules}}
+{{content}}
+{{/each}}
+</generic-rules>
+{{/if}}
+
+{{#if rules.length}}
+<domain-rules>
+{{#each rules}}
+- {{name}} ({{#list globs join=", "}}{{this}}{{/list}}): {{description}}
+{{/each}}
+</domain-rules>
+{{/if}}
+
+# Internal URLs
+Special URLs for internal resources; with most FS/bash tools they auto-resolve to FS paths.
+- `skill://<name>`: skill instructions; `/<path>` = file within
+- `rule://<name>`: rule details
+  {{#if hasMemoryRoot}}
+- `memory://root`: project memory summary
+  {{/if}}
+- `agent://<id>`: agent output artifact; `/<path>` extracts a JSON field
+- `artifact://<id>`: artifact content
+- `local://<name>.md`: plan artifacts or shared content for subagents
+{{#if hasObsidian}}
+- `vault://<vault>/<path>`: Obsidian vault (read/edit). `vault://` lists vaults; `vault://_/…` targets the active vault. File ops `?op=outline|backlinks|links|tags|properties|tasks|base|…`; vault ops `?op=search&q=…|daily|tasks|orphans|unresolved|bases|…`.
+{{/if}}
+- `mcp://<uri>`: MCP resource
+- `issue://<N>` (or `issue://<owner>/<repo>/<N>`): GitHub issue, disk-cached. Bare lists recent issues; `?state=open|closed|all&limit=&author=&label=`.
+- `pr://<N>` (or `pr://<owner>/<repo>/<N>`): GitHub PR, same cache; `?comments=0` drops comments. Bare lists recent PRs; `?state=open|closed|merged|all&limit=&author=&label=`.
+- `omp://`: harness docs; AVOID unless the user asks about the harness itself.
+
+{{#if toolInfo.length}}
+{{#if toolListMode}}
+# Tool Inventory
+{{#each toolInfo}}
+- {{#if label}}{{label}}: `{{name}}`{{else}}`{{name}}`{{/if}}
+{{/each}}
+{{else}}
+{{toolInventory}}
+{{/if}}
+{{#if mcpDiscoveryMode}}
+<discovery-notice>
+{{#if hasMCPDiscoveryServers}}Discoverable MCP servers this session: {{#list mcpDiscoveryServerSummaries join=", "}}{{this}}{{/list}}.{{/if}}
+If the task may involve external systems (SaaS APIs, chat, tickets, databases, deployments, or other non-local integrations), you SHOULD call `{{toolRefs.search_tool_bm25}}` before concluding no such tool exists.
+</discovery-notice>
+{{/if}}
+{{/if}}
+
+TOOL POLICY
+==============
+
+# General
+Use tools whenever they improve correctness, completeness, or grounding.
+- You MUST complete the task using available tools.
+- SHOULD resolve prerequisites before acting.
+- NEVER stop at the first plausible answer if another call would cut uncertainty.
+- Empty, partial, or suspiciously narrow lookup? Retry with a different strategy.
+- SHOULD parallelize independent calls.
+{{#has tools "task"}}- User says `parallel` or `parallelize` → MUST use `{{toolRefs.task}}` subagents; parallel tool calls alone do not satisfy.{{/has}}
+
+# Tool I/O
+- Prefer relative paths for `path`-like fields.
+{{#if intentTracing}}- Most tools take `{{intentField}}`: a concise intent, present participle, 2–6 words, no period, capitalized.{{/if}}
+{{#if secretsEnabled}}- Redacted `#XXXX#` tokens in output are opaque strings.{{/if}}
+{{#has tools "inspect_image"}}- Image tasks: prefer `{{toolRefs.inspect_image}}` over `{{toolRefs.read}}` to spare session context.{{/has}}
+
+# Specialized Tools
+You MUST use the specialized tool over its shell equivalent:
+{{#has tools "read"}}- File or directory reads → `{{toolRefs.read}}` (a directory path lists entries).{{/has}}
+{{#has tools "edit"}}- Surgical edits → `{{toolRefs.edit}}`.{{/has}}
+{{#has tools "write"}}- Create or overwrite → `{{toolRefs.write}}`.{{/has}}
+{{#has tools "lsp"}}- Code intelligence → `{{toolRefs.lsp}}`.{{/has}}
+{{#has tools "grep"}}- Regex search → `{{toolRefs.grep}}`, not `grep`, `rg`, or `awk`.{{/has}}
+{{#has tools "glob"}}- Globbing → `{{toolRefs.glob}}`, not `ls **/*.ext` or `fd`.{{/has}}
+{{#has tools "eval"}}- Default for any compute: `{{toolRefs.eval}}` cells. Bash is the EXCEPTION — only single binary calls or short fact-computing pipelines (`wc -l`, `sort | uniq -c`, `diff`, checksums). The moment a command grows a loop, conditional, heredoc, `-e`/`-c` script, `$(…)` nesting, or >2 pipe stages, it's a program → `{{toolRefs.eval}}`. NEVER write multiline or inline-script bash.{{/has}}
+{{#has tools "bash"}}- `{{toolRefs.bash}}`: real binaries and short fact pipelines only. Commands shadowing the specialized tools above are blocked.{{/has}}
+{{#has tools "bash"}}- Litmus: one external-CLI call or short pipeline returning a count, frequency, set difference, or checksum → bash.{{#has tools "eval"}} Needs control flow, state, or fights shell quoting → `{{toolRefs.eval}}`.{{/has}} Merely moves, pages, or trims bytes a tool can fetch → use the tool.{{/has}}
+
+{{#has tools "report_tool_issue"}}
+<critical>
+`{{toolRefs.report_tool_issue}}` powers automated QA. If ANY tool returns output inconsistent with its described behavior given your parameters, call it with the tool name and a concise description. Don't hesitate—false positives are fine.
+</critical>
+{{/has}}
+
+# Exploration
+You NEVER open a file hoping. Hope is not a strategy.
+- You MUST load only what's necessary; AVOID reading files or sections you don't need.
+{{#has tools "grep"}}- Use `{{toolRefs.grep}}` to locate targets.{{/has}}
+{{#has tools "glob"}}- Use `{{toolRefs.glob}}` to map structure.{{/has}}
+{{#has tools "read"}}- Use `{{toolRefs.read}}` with offset/limit instead of whole-file reads.{{/has}}
+{{#has tools "task"}}- Use `{{toolRefs.task}}` to map unknown code instead of reading file after file yourself.{{/has}}
+
+{{#has tools "lsp"}}
+# LSP
+You NEVER use search or manual edits for code intelligence when a language server is available:
+- definition / type_definition / implementation / references / hover
+- code_actions for refactors, imports, and fixes—list first, then apply with `apply: true` plus `query`
+{{/has}}
+
+{{#ifAny (includes tools "ast_grep") (includes tools "ast_edit")}}
+# AST
+You SHOULD use syntax-aware tools before text hacks:
+{{#has tools "ast_grep"}}- `{{toolRefs.ast_grep}}` for structural discovery.{{/has}}
+{{#has tools "ast_edit"}}- `{{toolRefs.ast_edit}}` for codemods.{{/has}}
+- Use `grep` only for plain-text lookup when structure is irrelevant.
+{{/ifAny}}
+
+# Delegation
+{{#if eagerTasks}}
+{{#has tools "task"}}
+{{#if eagerTasksAlways}}
+Delegation is the default here, not the exception. Once the design is settled, you MUST fan the work out to `{{toolRefs.task}}` subagents rather than doing it yourself. Work alone ONLY when one of these is unambiguously true:
+- A single-file edit under approximately 30 lines
+- A direct answer or explanation requiring no code changes
+- The user explicitly asked you to run a command yourself.
+
+Everything else—multi-file changes, refactors, new features, tests, investigations—MUST be decomposed and delegated.{{#if taskBatch}} Batch independent slices into one parallel `{{toolRefs.task}}` call; never serialize what can run concurrently.{{/if}}{{else}}Delegation is preferred here. Once the design is settled, you SHOULD fan substantial work out to `{{toolRefs.task}}` subagents instead of doing everything yourself. Multi-file changes, refactors, new features, tests, and investigations are strong candidates. Use your judgment for small, single-file, or interactive work.{{#if taskBatch}} When you delegate independent slices, batch them into one parallel `{{toolRefs.task}}` call rather than serializing them.{{/if}}
+{{/if}}
+{{/has}}
+{{/if}}
+
+EXECUTION WORKFLOW
+==============
+
+# 1. Scope
+{{#ifAny skills.length rules.length}}- Read relevant {{#if skills.length}}skills{{#if rules.length}} and rules{{/if}}{{else}}rules{{/if}} first.{{/ifAny}}
+- For multi-file work, plan before touching files; research existing code and conventions first.
+
+# 2. Research Before Editing
+- Read sections, not snippets. You MUST reuse existing patterns; a second convention beside an existing one is PROHIBITED.
+  {{#has tools "lsp"}}- You MUST run `{{toolRefs.lsp}} references` before modifying exported symbols. Missed callsites are bugs.{{/has}}
+- Re-read before acting if a tool fails or a file changed since you read it.
+
+# 3. Decompose
+- Update todos as you go; skip them for trivial requests. Marking a todo done is a transition: start the next in the same turn.
+- NEVER abandon phases under scope pressure—delegate, don't shrink.
+  {{#has tools "task"}}- Default to parallel for complex changes. Delegate via `{{toolRefs.task}}` for non-importing file edits, multi-subsystem investigation, and decomposable work.{{/has}}
+- Plan only what makes the request work. Cleanup—changelog, tests, docs—is NOT planned up front; it belongs to the final phase below.
+
+# 4. Implement
+- Fix problems at the source. Remove obsolete code—no leftover comments, aliases, or re-exports.
+- Prefer updating existing files over creating new ones.
+- Review changes from the user's perspective.
+{{#has tools "grep"}}- Grep instead of guessing.{{/has}}
+{{#has tools "ask"}}- Ask before destructive commands or deleting code you didn't write.{{else}}- Don't run destructive git commands or delete code you didn't write.{{/has}}
+
+# 5. Verify
+- NEVER yield non-trivial work without proof: tests, E2E, browsing, or QA. Run only tests you added or modified unless asked otherwise.
+- Test behavior, using tester agent where available. Assert logical behavior, not current state.
+- Aim at conditional branches, edge values, invariants across fields, and error handling versus silent broken results.
+
+# 6. Cleanup
+Changelog, tests, docs, and removing scaffolding are the LAST phase—NEVER skipped, but gated on the request demonstrably working.
+
+- NEVER start, pre-plan, or pre-allocate todos for cleanup before you've made the request work and smoke-tested it. Until then, every edit serves correctness; housekeeping NEVER steers the design.
+- Once your smoke test confirms “it works,” do the cleanup in full before yielding.
+
+DELIVERY CONTRACT
+==============
+
+<contract>
+Inviolable.
+- NEVER yield unless the deliverable is complete. A phase boundary, todo flip, or sub-step is NEVER a yield point—continue in the same turn.
+- NEVER fabricate outputs. Claims about code, tools, tests, docs, or sources MUST be grounded.
+- NEVER substitute an easier or more familiar problem:
+  - Don't infer extra scope—retries, validation, telemetry, abstraction “while you're at it”—because it changes the contract.
+  - Don't solve the symptom—suppress a warning or exception, special-case an input—unless asked. Do the real ask.
+- NEVER ask for what tools, repo context, or files can provide.
+- NEVER punt half-solved work back.
+- Default to clean cutover: migrate every caller; leave no shims, aliases, or deprecated paths.
+</contract>
+
+<completeness>
+- “Done” means the deliverable behaves as specified end to end—not that a scaffold compiles or a narrowed test passes.
+- A named plan, phase list, checklist, or spec MUST satisfy every acceptance criterion. A plausible subset is failure, not partial success.
+- NEVER silently shrink scope. Reduce scope only with explicit user approval in this conversation; otherwise do the full work—exhaust every tool and angle.
+- NEVER ship stubs, placeholders, mocks, no-ops, fake fallbacks, or `TODO: implement` as delivered work. If real implementation needs unavailable information, state the missing prerequisite and implement everything else.
+- NEVER relabel unfinished work—“scaffold,” “MVP,” “v1,” “foundation,” “follow-up”—to imply completion. Not done? Say so.
+</completeness>
+
+<evidence-and-output>
+- Output format MUST match the ask.
+- Every claim about code, tools, tests, docs, or sources MUST be grounded.
+- Mark any claim not directly observed or established as `[INFERENCE]`.
+- Verification claims MUST match what was exercised, preferably smoke tested.
+- No required tool lookup may be skipped when it would cut uncertainty.
+- Be brief in prose, not in evidence, verification, or blocking details.
+</evidence-and-output>
+
+<yielding>
+Before yielding, verify:
+- All requested deliverables are complete; no partial implementation is presented as complete.
+- All affected artifacts—callsites, tests, docs—are updated or intentionally left unchanged.
+- The output and evidence requirements above are satisfied.
+
+Before declaring blocked:
+- Be sure the information is unreachable through tools, context, or anything in reach. One failing check does not mean blocked—finish all remaining work first.
+- Still stuck? State exactly what's missing and what you tried.
+</yielding>
+
+{{#if personality}}
+<personality>
+{{personality}}
+</personality>
+{{/if}}
+
+<critical>
+- NEVER narrate or consider session limits, token or tool budgets, effort estimates, or how much you can finish. Not your concern—start as if unbounded; execute or delegate.
+- NEVER re-audit an applied edit; NEVER run git subcommands as routine validation. Tool results are THE verification.
+</critical>

--- a/config/e4_targets/oh_my_pi/16.2.13/target.json
+++ b/config/e4_targets/oh_my_pi/16.2.13/target.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "bb.e4.target.v1",
+  "target_id": "oh-my-pi@16.2.13",
+  "family": "oh-my-pi",
+  "version": "16.2.13",
+  "execution": {
+    "config_asset": "harness.yaml",
+    "system_prompt_asset": "prompts/system-prompt.md",
+    "tool_surface_asset": "tool-surface.json"
+  },
+  "upstream": {
+    "repository": "https://github.com/can1357/oh-my-pi.git",
+    "source": {
+      "commit": "5356713eae60e67ee64d9b02e3b5e377d248ee7f",
+      "directory": "packages/coding-agent",
+      "archive_sha256": "03fd855b01bb7457f85e929ff747d8560d7cf7ed420fd0676bf32b917fb264a3",
+      "archive_bytes": 42065260
+    },
+    "package": {
+      "name": "@oh-my-pi/pi-coding-agent",
+      "version": "16.2.13",
+      "tarball": "https://registry.npmjs.org/@oh-my-pi/pi-coding-agent/-/pi-coding-agent-16.2.13.tgz",
+      "integrity": "sha512-ZKi9xul+Ef6wmq4VoETCmEFrAOOqx0Wq24MxHM6vL7al2NW/q7RCJc3StlLmHs8zN06C2tI/XQTMJbm5UDX0fA==",
+      "shasum_sha1": "6c837a0d741ceaa6daa243474b67e11425739fb2",
+      "tarball_sha256": "293056afc7d0d59c9aa8726efdbefc8d3a05a3dfca4261b4af5431d79a6593ff",
+      "tarball_bytes": 8833029
+    }
+  },
+  "freeze_manifest_entries": [
+    "oh_my_pi_p6_0_l1_config_context_tool_surface_v1",
+    "oh_my_pi_p6_0_l2_tool_execution_v1",
+    "oh_my_pi_p6_0_l3_command_network_hook_v1",
+    "oh_my_pi_p6_6_task_job_subagent_v1"
+  ],
+  "assets": [
+    {
+      "path": "harness.yaml",
+      "sha256": "50cf75d2eb6451c3d7136badbad0851a87c22654a8726244a610fb659c5d1e1b",
+      "bytes": 410
+    },
+    {
+      "path": "prompts/system-prompt.md",
+      "sha256": "0d96613a7492b5c30a5c83eedde8c5747c6a9d35d7d0c9b8dd0a5c44f7a77123",
+      "bytes": 14487
+    },
+    {
+      "path": "tool-surface.json",
+      "sha256": "d890d2856ac43dd05a3ce7ac72fefa6bf78ca21b8ff3ac3d29797ca91fdfb6ff",
+      "bytes": 673
+    }
+  ]
+}

--- a/config/e4_targets/oh_my_pi/16.2.13/target.json
+++ b/config/e4_targets/oh_my_pi/16.2.13/target.json
@@ -35,8 +35,8 @@
   "assets": [
     {
       "path": "harness.yaml",
-      "sha256": "50cf75d2eb6451c3d7136badbad0851a87c22654a8726244a610fb659c5d1e1b",
-      "bytes": 410
+      "sha256": "72f2ca775ae0ff805664831aec339384b7f5d66c3035b648a2e0fae0c60b3c09",
+      "bytes": 691
     },
     {
       "path": "prompts/system-prompt.md",

--- a/config/e4_targets/oh_my_pi/16.2.13/tool-surface.json
+++ b/config/e4_targets/oh_my_pi/16.2.13/tool-surface.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": "bb.e4.tool_surface.v1",
+  "target_id": "oh-my-pi@16.2.13",
+  "ordered_tools": [
+    "read",
+    "bash",
+    "edit",
+    "ast_grep",
+    "ast_edit",
+    "ask",
+    "debug",
+    "eval",
+    "ssh",
+    "github",
+    "glob",
+    "grep",
+    "lsp",
+    "inspect_image",
+    "browser",
+    "checkpoint",
+    "rewind",
+    "task",
+    "job",
+    "irc",
+    "todo",
+    "web_search",
+    "search_tool_bm25",
+    "write",
+    "memory_edit",
+    "retain",
+    "recall",
+    "reflect",
+    "learn",
+    "manage_skill"
+  ],
+  "legacy_aliases": {
+    "search": "grep",
+    "find": "glob"
+  },
+  "source_path": "packages/coding-agent/src/tools/builtin-names.ts"
+}

--- a/config/e4_targets/pi/0.57.1/harness.yaml
+++ b/config/e4_targets/pi/0.57.1/harness.yaml
@@ -1,0 +1,32 @@
+schema_version: bb.e4.target_config.v1
+target_id: pi@0.57.1
+prompt:
+  renderer: pi-0.57.1
+  asset: prompts/system-prompt.md
+  dynamic_fields:
+    - readme_path
+    - docs_path
+    - examples_path
+    - current_date_time
+    - cwd
+tools:
+  ordered:
+    - read
+    - bash
+    - edit
+    - write
+    - grep
+    - find
+    - ls
+  surface_asset: tool-surface.json
+session:
+  persistence: disabled
+  extensions: disabled
+  skills: disabled
+  prompt_templates: disabled
+thinking: off
+retry:
+  enabled: false
+  max_retries: 0
+transport:
+  mode: json

--- a/config/e4_targets/pi/0.57.1/prompts/system-prompt.md
+++ b/config/e4_targets/pi/0.57.1/prompts/system-prompt.md
@@ -1,0 +1,31 @@
+You are an expert coding assistant operating inside pi, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.
+
+Available tools:
+- read: Read file contents
+- bash: Execute bash commands (ls, grep, find, etc.)
+- edit: Make surgical edits to files (find exact text and replace)
+- write: Create or overwrite files
+- grep: Search file contents for patterns (respects .gitignore)
+- find: Find files by glob pattern (respects .gitignore)
+- ls: List directory contents
+
+In addition to the tools above, you may have access to other custom tools depending on the project.
+
+Guidelines:
+- Prefer grep/find/ls tools over bash for file exploration (faster, respects .gitignore)
+- Use read to examine files before editing. You must use this tool instead of cat or sed.
+- Use edit for precise changes (old text must match exactly)
+- Use write only for new files or complete rewrites
+- When summarizing your actions, output plain text directly - do NOT use cat or bash to display what you did
+- Be concise in your responses
+- Show file paths clearly when working with files
+
+Pi documentation (read only when the user asks about pi itself, its SDK, extensions, themes, skills, or TUI):
+- Main documentation: {{readme_path}}
+- Additional docs: {{docs_path}}
+- Examples: {{examples_path}} (extensions, custom tools, SDK)
+- When asked about: extensions (docs/extensions.md, examples/extensions/), themes (docs/themes.md), skills (docs/skills.md), prompt templates (docs/prompt-templates.md), TUI components (docs/tui.md), keybindings (docs/keybindings.md), SDK integrations (docs/sdk.md), custom providers (docs/custom-provider.md), adding models (docs/models.md), pi packages (docs/packages.md)
+- When working on pi topics, read the docs and examples, and follow .md cross-references before implementing
+- Always read pi .md files completely and follow links to related docs (e.g., tui.md for TUI API details)
+Current date and time: {{current_date_time}}
+Current working directory: {{cwd}}

--- a/config/e4_targets/pi/0.57.1/target.json
+++ b/config/e4_targets/pi/0.57.1/target.json
@@ -30,7 +30,7 @@
   "upstream": {
     "repository": "https://github.com/badlogic/pi-mono.git",
     "source": {
-      "commit": "a9cedccdde77e9d765303463d8a6cd11c58f7a7f",
+      "identity_kind": "archive_snapshot_without_git_dir",
       "directory": "packages/coding-agent",
       "archive_sha256": "bd64909b10a34c30890606f8787ee2ac47b9e7989e3db581978dd8214d62e87b",
       "archive_bytes": 4755355
@@ -38,6 +38,7 @@
     "package": {
       "name": "@mariozechner/pi-coding-agent",
       "version": "0.57.1",
+      "git_head": "a9cedccdde77e9d765303463d8a6cd11c58f7a7f",
       "tarball": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.57.1.tgz",
       "integrity": "sha512-u5MQEduj68rwVIsRsqrWkJYiJCyPph/a6bMoJAQKo1sb+Pc17Y/ojwa+wGssnUMjEB38AQKofWTVe8NFEpSWNw==",
       "shasum_sha1": "58433481f4a469e28f3faac7ea3d2b10cb1bfefb",

--- a/config/e4_targets/pi/0.57.1/target.json
+++ b/config/e4_targets/pi/0.57.1/target.json
@@ -63,8 +63,8 @@
     },
     {
       "path": "tool-surface.json",
-      "sha256": "5c0a772eb9cd76a05e3ef2019ff5b7cff97b2f88d08a98c41bd3f82046dd17f8",
-      "bytes": 825
+      "sha256": "ab1571ae9ecc28342476589c4d82ba81f1f1a28f6c3450beb10803bed7924810",
+      "bytes": 6184
     }
   ]
 }

--- a/config/e4_targets/pi/0.57.1/target.json
+++ b/config/e4_targets/pi/0.57.1/target.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "bb.e4.target.v1",
+  "target_id": "pi@0.57.1",
+  "family": "pi",
+  "version": "0.57.1",
+  "execution": {
+    "config_asset": "harness.yaml",
+    "system_prompt_asset": "prompts/system-prompt.md",
+    "tool_surface_asset": "tool-surface.json"
+  },
+  "overlay": {
+    "overlay_id": "r3-json-no-session.v1",
+    "argv": [
+      "--mode",
+      "json",
+      "--no-session",
+      "--thinking",
+      "off",
+      "--tools",
+      "read,bash,edit,write,grep,find,ls",
+      "--no-extensions",
+      "--no-skills",
+      "--no-prompt-templates"
+    ],
+    "settings": {
+      "retry.enabled": false,
+      "retry.maxRetries": 0
+    }
+  },
+  "upstream": {
+    "repository": "https://github.com/badlogic/pi-mono.git",
+    "source": {
+      "commit": "a9cedccdde77e9d765303463d8a6cd11c58f7a7f",
+      "directory": "packages/coding-agent",
+      "archive_sha256": "bd64909b10a34c30890606f8787ee2ac47b9e7989e3db581978dd8214d62e87b",
+      "archive_bytes": 4755355
+    },
+    "package": {
+      "name": "@mariozechner/pi-coding-agent",
+      "version": "0.57.1",
+      "tarball": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.57.1.tgz",
+      "integrity": "sha512-u5MQEduj68rwVIsRsqrWkJYiJCyPph/a6bMoJAQKo1sb+Pc17Y/ojwa+wGssnUMjEB38AQKofWTVe8NFEpSWNw==",
+      "shasum_sha1": "58433481f4a469e28f3faac7ea3d2b10cb1bfefb",
+      "tarball_sha256": "8648e71d5553388ed710f1ef4165d9f090e1783e446629410c545875ac564b6f",
+      "tarball_bytes": 3761279
+    }
+  },
+  "freeze_manifest_entries": [
+    "pi_p5_l1_cli_config_context_tool_surface_v1",
+    "pi_p5_l2_extension_session_residual_v1"
+  ],
+  "assets": [
+    {
+      "path": "harness.yaml",
+      "sha256": "390475822fe07f1674af87771874d25248c5e53f1767eb0bf535916c96e0cf31",
+      "bytes": 542
+    },
+    {
+      "path": "prompts/system-prompt.md",
+      "sha256": "223ae5bd2b036f97abc63b55ecbecf698b1b284176e62a012cbc982042263005",
+      "bytes": 2030
+    },
+    {
+      "path": "tool-surface.json",
+      "sha256": "5c0a772eb9cd76a05e3ef2019ff5b7cff97b2f88d08a98c41bd3f82046dd17f8",
+      "bytes": 825
+    }
+  ]
+}

--- a/config/e4_targets/pi/0.57.1/tool-surface.json
+++ b/config/e4_targets/pi/0.57.1/tool-surface.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "bb.e4.tool_surface.v1",
+  "target_id": "pi@0.57.1",
+  "ordered_tools": [
+    "read",
+    "bash",
+    "edit",
+    "write",
+    "grep",
+    "find",
+    "ls"
+  ],
+  "descriptions": {
+    "read": "Read file contents",
+    "bash": "Execute bash commands (ls, grep, find, etc.)",
+    "edit": "Make surgical edits to files (find exact text and replace)",
+    "write": "Create or overwrite files",
+    "grep": "Search file contents for patterns (respects .gitignore)",
+    "find": "Find files by glob pattern (respects .gitignore)",
+    "ls": "List directory contents"
+  },
+  "breadboard_implementation_ids": {
+    "read": "read_file",
+    "bash": "run_shell",
+    "edit": "apply_search_replace",
+    "write": "create_file",
+    "grep": "opencode_grep",
+    "find": "opencode_glob",
+    "ls": "list_dir"
+  }
+}

--- a/config/e4_targets/pi/0.57.1/tool-surface.json
+++ b/config/e4_targets/pi/0.57.1/tool-surface.json
@@ -10,22 +10,177 @@
     "find",
     "ls"
   ],
-  "descriptions": {
-    "read": "Read file contents",
-    "bash": "Execute bash commands (ls, grep, find, etc.)",
-    "edit": "Make surgical edits to files (find exact text and replace)",
-    "write": "Create or overwrite files",
-    "grep": "Search file contents for patterns (respects .gitignore)",
-    "find": "Find files by glob pattern (respects .gitignore)",
-    "ls": "List directory contents"
+  "tools": {
+    "read": {
+      "description": "Read the contents of a file. Supports text files and images (jpg, png, gif, webp). Images are sent as attachments. For text files, output is truncated to 2000 lines or 50KB (whichever is hit first). Use offset/limit for large files. When you need the full file, continue with offset until complete.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Path to the file to read (relative or absolute)"
+          },
+          "offset": {
+            "type": "number",
+            "description": "Line number to start reading from (1-indexed)"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of lines to read"
+          }
+        },
+        "required": [
+          "path"
+        ]
+      }
+    },
+    "bash": {
+      "description": "Execute a bash command in the current working directory. Returns stdout and stderr. Output is truncated to last 2000 lines or 50KB (whichever is hit first). If truncated, full output is saved to a temp file. Optionally provide a timeout in seconds.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "type": "string",
+            "description": "Bash command to execute"
+          },
+          "timeout": {
+            "type": "number",
+            "description": "Timeout in seconds (optional, no default timeout)"
+          }
+        },
+        "required": [
+          "command"
+        ]
+      }
+    },
+    "edit": {
+      "description": "Edit a file by replacing exact text. The oldText must match exactly (including whitespace). Use this for precise, surgical edits.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Path to the file to edit (relative or absolute)"
+          },
+          "oldText": {
+            "type": "string",
+            "description": "Exact text to find and replace (must match exactly)"
+          },
+          "newText": {
+            "type": "string",
+            "description": "New text to replace the old text with"
+          }
+        },
+        "required": [
+          "path",
+          "oldText",
+          "newText"
+        ]
+      }
+    },
+    "write": {
+      "description": "Write content to a file. Creates the file if it doesn't exist, overwrites if it does. Automatically creates parent directories.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Path to the file to write (relative or absolute)"
+          },
+          "content": {
+            "type": "string",
+            "description": "Content to write to the file"
+          }
+        },
+        "required": [
+          "path",
+          "content"
+        ]
+      }
+    },
+    "grep": {
+      "description": "Search file contents for a pattern. Returns matching lines with file paths and line numbers. Respects .gitignore. Output is truncated to 100 matches or 50KB (whichever is hit first). Long lines are truncated to 500 chars.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "description": "Search pattern (regex or literal string)"
+          },
+          "path": {
+            "type": "string",
+            "description": "Directory or file to search (default: current directory)"
+          },
+          "glob": {
+            "type": "string",
+            "description": "Filter files by glob pattern, e.g. '*.ts' or '**/*.spec.ts'"
+          },
+          "ignoreCase": {
+            "type": "boolean",
+            "description": "Case-insensitive search (default: false)"
+          },
+          "literal": {
+            "type": "boolean",
+            "description": "Treat pattern as literal string instead of regex (default: false)"
+          },
+          "context": {
+            "type": "number",
+            "description": "Number of lines to show before and after each match (default: 0)"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of matches to return (default: 100)"
+          }
+        },
+        "required": [
+          "pattern"
+        ]
+      }
+    },
+    "find": {
+      "description": "Search for files by glob pattern. Returns matching file paths relative to the search directory. Respects .gitignore. Output is truncated to 1000 results or 50KB (whichever is hit first).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "description": "Glob pattern to match files, e.g. '*.ts', '**/*.json', or 'src/**/*.spec.ts'"
+          },
+          "path": {
+            "type": "string",
+            "description": "Directory to search in (default: current directory)"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of results (default: 1000)"
+          }
+        },
+        "required": [
+          "pattern"
+        ]
+      }
+    },
+    "ls": {
+      "description": "List directory contents. Returns entries sorted alphabetically, with '/' suffix for directories. Includes dotfiles. Output is truncated to 500 entries or 50KB (whichever is hit first).",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "Directory to list (default: current directory)"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of entries to return (default: 500)"
+          }
+        },
+        "required": []
+      }
+    }
   },
-  "breadboard_implementation_ids": {
-    "read": "read_file",
-    "bash": "run_shell",
-    "edit": "apply_search_replace",
-    "write": "create_file",
-    "grep": "opencode_grep",
-    "find": "opencode_glob",
-    "ls": "list_dir"
+  "dispatch": {
+    "kind": "target_adapter",
+    "adapter_id": "pi-0.57.1",
+    "binding_requirement": "RL-E4-2"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ namespaces = true
 "breadboard_engine" = ["engine-build-provenance.v1.json"]
 "breadboard_sdk.generated" = ["*.json"]
 "config.e4_lanes" = ["*.yaml", "*.json"]
+"config.e4_targets" = ["**/*.json", "**/*.yaml", "**/*.md"]
 "config.product" = ["*.json"]
 "conformance.comparators" = ["registry.json"]
 "conformance.provider_differential" = ["matrix.v1.json", "scenario.v1.json", "oracle/*.json", "schemas/*.json"]

--- a/tests/test_breadboard_cli_packaging.py
+++ b/tests/test_breadboard_cli_packaging.py
@@ -161,10 +161,20 @@ def test_built_wheel_owns_runtime_resources_and_excludes_repository_debris(
         "breadboard/product/cli/main.py",
         "breadboard/product/operations/generated_bindings.py",
         "breadboard_engine/compilation/bundle.py",
+        "breadboard_engine/e4_targets.py",
         "breadboard_sdk/__init__.py",
         "breadboard_sdk/generated/__init__.py",
         "breadboard_sdk/generated/public_bindings.py",
         "breadboard_sdk/generated/public_surface_manifest.v1.json",
+        "config/e4_targets/index.json",
+        "config/e4_targets/oh_my_pi/16.2.13/harness.yaml",
+        "config/e4_targets/oh_my_pi/16.2.13/prompts/system-prompt.md",
+        "config/e4_targets/oh_my_pi/16.2.13/target.json",
+        "config/e4_targets/oh_my_pi/16.2.13/tool-surface.json",
+        "config/e4_targets/pi/0.57.1/harness.yaml",
+        "config/e4_targets/pi/0.57.1/prompts/system-prompt.md",
+        "config/e4_targets/pi/0.57.1/target.json",
+        "config/e4_targets/pi/0.57.1/tool-surface.json",
         "config/product/tui-release.json",
         "conformance/comparators/registry.json",
         "contracts/kernel/manifests/bb.engine_conformance_manifest.v1.schema.json",
@@ -282,6 +292,7 @@ from breadboard.product.harness.templates import (
 )
 from breadboard.product.operation_catalog import product_operation_catalog
 from breadboard_engine.compilation.primitive_records import get_spec
+from breadboard_engine.e4_targets import list_e4_target_ids, load_e4_target
 
 source_root = Path({str(ROOT)!r}).resolve()
 distribution = importlib.metadata.distribution("breadboard-harness-cli")
@@ -333,6 +344,15 @@ assert len(generated["operations"]) == 26
 assert len(SDK_OPERATION_BINDINGS) == len(PRODUCT_OPERATION_BINDINGS) == 26
 assert sdk_public_bindings.PUBLIC_OPERATION_BINDINGS is SDK_OPERATION_BINDINGS
 assert files("breadboard_sdk.generated").joinpath("public_bindings.py").is_file()
+target_ids = list_e4_target_ids()
+assert target_ids == ("oh-my-pi@16.2.13", "pi@0.57.1")
+pi_target = load_e4_target("pi@0.57.1")
+omp_target = load_e4_target("oh-my-pi@16.2.13")
+assert pi_target.descriptor["upstream"]["package"]["integrity"].startswith("sha512-")
+assert omp_target.descriptor["upstream"]["source"]["commit"] == (
+    "5356713eae60e67ee64d9b02e3b5e377d248ee7f"
+)
+assert "target_id: pi@0.57.1" in pi_target.read_asset_text("harness.yaml")
 assert distribution.version == "0.0.0"
 print(json.dumps({{
     "distribution": distribution.metadata["Name"],
@@ -343,6 +363,7 @@ print(json.dumps({{
     "profile_id": default_profile["profile_id"],
     "profile_hash": default_profile["effective_lock_hash"],
     "e4_import_count": len(e4_imports),
+    "e4_target_ids": target_ids,
 }}))
 """
     probe_result = subprocess.run(
@@ -364,6 +385,7 @@ print(json.dumps({{
             "sha256:6ea299b2d3ee382a8d8397cd5ed32080e99f8ae8b6a48006fce1ecad6859c10f"
         ),
         "e4_import_count": 0,
+        "e4_target_ids": ["oh-my-pi@16.2.13", "pi@0.57.1"],
     }
 
     help_result = subprocess.run(

--- a/tests/test_breadboard_cli_packaging.py
+++ b/tests/test_breadboard_cli_packaging.py
@@ -233,6 +233,33 @@ def test_built_wheel_owns_runtime_resources_and_excludes_repository_debris(
         if name.startswith("docs/")
     )
 
+    zip_probe = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-c",
+            (
+                "import json, sys; "
+                f"sys.path.insert(0, {str(wheel)!r}); "
+                "from breadboard_engine.e4_targets import "
+                "list_e4_target_ids, load_e4_target; "
+                "targets = list_e4_target_ids(); "
+                "assert load_e4_target('pi@0.57.1').read_asset_text("
+                "'harness.yaml').startswith('schema_version:'); "
+                "print(json.dumps(targets))"
+            ),
+        ],
+        cwd=tmp_path,
+        env=_clean_environment(),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert json.loads(zip_probe.stdout) == [
+        "oh-my-pi@16.2.13",
+        "pi@0.57.1",
+    ]
+
 
 def test_built_wheel_clean_install_runs_public_surface_without_credentials(
     tmp_path: Path,

--- a/tests/test_breadboard_cli_packaging.py
+++ b/tests/test_breadboard_cli_packaging.py
@@ -292,7 +292,11 @@ from breadboard.product.harness.templates import (
 )
 from breadboard.product.operation_catalog import product_operation_catalog
 from breadboard_engine.compilation.primitive_records import get_spec
-from breadboard_engine.e4_targets import list_e4_target_ids, load_e4_target
+from breadboard_engine.e4_targets import (
+    _resource_root,
+    list_e4_target_ids,
+    load_e4_target,
+)
 
 source_root = Path({str(ROOT)!r}).resolve()
 distribution = importlib.metadata.distribution("breadboard-harness-cli")
@@ -303,6 +307,8 @@ origins = [
 ]
 assert all(path.is_relative_to(site_root) for path in origins)
 assert all(not path.is_relative_to(source_root) for path in origins)
+target_resource_root = _resource_root().resolve()
+assert target_resource_root == site_root / "config" / "e4_targets"
 catalog = product_operation_catalog()
 assert catalog["contract_id"] == "bb.public_operation_catalog.v2"
 assert len(catalog["operations"]) == 26

--- a/tests/test_e4_targets.py
+++ b/tests/test_e4_targets.py
@@ -95,6 +95,40 @@ def test_pinned_targets_load_with_exact_release_source_and_runtime_assets() -> N
     assert "target_id: pi@0.57.1" in pi_config
     assert "max_retries: 0" in pi_config
 
+    pi_surface = json.loads(pi.read_asset_text("tool-surface.json"))
+    assert pi_surface["ordered_tools"] == [
+        "read",
+        "bash",
+        "edit",
+        "write",
+        "grep",
+        "find",
+        "ls",
+    ]
+    assert "breadboard_implementation_ids" not in pi_surface
+    assert pi_surface["dispatch"] == {
+        "kind": "target_adapter",
+        "adapter_id": "pi-0.57.1",
+        "binding_requirement": "RL-E4-2",
+    }
+    assert pi_surface["tools"]["edit"]["parameters"]["required"] == [
+        "path",
+        "oldText",
+        "newText",
+    ]
+    assert pi_surface["tools"]["write"]["parameters"]["required"] == [
+        "path",
+        "content",
+    ]
+    assert tuple(pi_surface["tools"]["grep"]["parameters"]["properties"]) == (
+        "pattern",
+        "path",
+        "glob",
+        "ignoreCase",
+        "literal",
+        "context",
+        "limit",
+    )
     omp = load_e4_target("oh-my-pi@16.2.13")
     assert omp.descriptor["upstream"]["source"] == {
         "commit": "5356713eae60e67ee64d9b02e3b5e377d248ee7f",
@@ -105,6 +139,30 @@ def test_pinned_targets_load_with_exact_release_source_and_runtime_assets() -> N
         "archive_bytes": 42065260,
     }
     assert omp.descriptor["upstream"]["package"]["version"] == "16.2.13"
+    omp_config = yaml.safe_load(omp.read_asset_text("harness.yaml"))
+    assert omp_config["prompt"]["dynamic_fields"] == [
+        "alwaysApplyRules",
+        "eagerTasks",
+        "eagerTasksAlways",
+        "hasMCPDiscoveryServers",
+        "hasMemoryRoot",
+        "hasObsidian",
+        "intentField",
+        "intentTracing",
+        "mcpDiscoveryMode",
+        "mcpDiscoveryServerSummaries",
+        "personality",
+        "renderMermaid",
+        "rules",
+        "secretsEnabled",
+        "skills",
+        "taskBatch",
+        "toolInfo",
+        "toolInventory",
+        "toolListMode",
+        "toolRefs",
+        "tools",
+    ]
     omp_surface = json.loads(omp.read_asset_text("tool-surface.json"))
     assert omp_surface["ordered_tools"][:5] == [
         "read",

--- a/tests/test_e4_targets.py
+++ b/tests/test_e4_targets.py
@@ -49,11 +49,19 @@ def test_editable_source_root_accepts_only_absolute_local_file_urls(
     )
     assert _editable_source_root(valid) == source_root
 
+    def unreadable_metadata(_: str) -> str:
+        raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid byte")
+
+    assert (
+        _editable_source_root(SimpleNamespace(read_text=unreadable_metadata)) is None
+    )
+
     for url in (
         "https://example.invalid/source",
         "file:relative/source",
         "file:///tmp/source?unexpected=query",
         "file://remote.invalid/source",
+        "file://[",
     ):
         invalid = SimpleNamespace(
             read_text=lambda _, url=url: json.dumps(

--- a/tests/test_e4_targets.py
+++ b/tests/test_e4_targets.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 import shutil
@@ -10,6 +11,7 @@ import yaml
 from breadboard_engine.e4_targets import (
     E4TargetError,
     _load_e4_target_from_root,
+    _resource_root,
     list_e4_target_ids,
     load_e4_target,
 )
@@ -19,6 +21,10 @@ ROOT = Path(__file__).resolve().parents[1]
 TARGET_ROOT = ROOT / "config" / "e4_targets"
 
 
+def test_target_resources_bind_to_loader_distribution_root() -> None:
+    assert _resource_root() == TARGET_ROOT
+
+
 def test_pinned_targets_load_with_exact_release_source_and_runtime_assets() -> None:
     assert list_e4_target_ids() == ("oh-my-pi@16.2.13", "pi@0.57.1")
 
@@ -26,7 +32,7 @@ def test_pinned_targets_load_with_exact_release_source_and_runtime_assets() -> N
     assert pi.descriptor["upstream"] == {
         "repository": "https://github.com/badlogic/pi-mono.git",
         "source": {
-            "commit": "a9cedccdde77e9d765303463d8a6cd11c58f7a7f",
+            "identity_kind": "archive_snapshot_without_git_dir",
             "directory": "packages/coding-agent",
             "archive_sha256": (
                 "bd64909b10a34c30890606f8787ee2ac47b9e7989e3db581978dd8214d62e87b"
@@ -36,6 +42,7 @@ def test_pinned_targets_load_with_exact_release_source_and_runtime_assets() -> N
         "package": {
             "name": "@mariozechner/pi-coding-agent",
             "version": "0.57.1",
+            "git_head": "a9cedccdde77e9d765303463d8a6cd11c58f7a7f",
             "tarball": (
                 "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/"
                 "pi-coding-agent-0.57.1.tgz"
@@ -53,7 +60,7 @@ def test_pinned_targets_load_with_exact_release_source_and_runtime_assets() -> N
     }
     assert pi.descriptor["overlay"] == {
         "overlay_id": "r3-json-no-session.v1",
-        "argv": [
+        "argv": (
             "--mode",
             "json",
             "--no-session",
@@ -64,7 +71,7 @@ def test_pinned_targets_load_with_exact_release_source_and_runtime_assets() -> N
             "--no-extensions",
             "--no-skills",
             "--no-prompt-templates",
-        ],
+        ),
         "settings": {"retry.enabled": False, "retry.maxRetries": 0},
     }
     pi_config = pi.read_asset_text(pi.descriptor["execution"]["config_asset"])
@@ -129,6 +136,15 @@ def test_target_loader_rejects_unknown_and_undeclared_assets() -> None:
         target.read_asset_text("../target.json")
 
 
+def test_loaded_target_descriptor_is_deeply_immutable() -> None:
+    target = load_e4_target("pi@0.57.1")
+
+    with pytest.raises(TypeError):
+        target.descriptor["overlay"]["argv"][0] = "--mutated"
+    with pytest.raises(TypeError):
+        target.descriptor["overlay"]["settings"]["retry.enabled"] = True
+
+
 def test_target_loader_rejects_corrupt_runtime_asset(tmp_path: Path) -> None:
     copied_root = tmp_path / "e4_targets"
     shutil.copytree(TARGET_ROOT, copied_root)
@@ -136,6 +152,25 @@ def test_target_loader_rejects_corrupt_runtime_asset(tmp_path: Path) -> None:
     harness.write_text(harness.read_text(encoding="utf-8") + "corrupt: true\n")
 
     with pytest.raises(E4TargetError, match="SHA-256 mismatch"):
+        _load_e4_target_from_root(copied_root, "pi@0.57.1")
+
+
+def test_target_loader_rejects_boolean_asset_size(tmp_path: Path) -> None:
+    copied_root = tmp_path / "e4_targets"
+    shutil.copytree(TARGET_ROOT, copied_root)
+    descriptor_path = copied_root / "pi" / "0.57.1" / "target.json"
+    descriptor = json.loads(descriptor_path.read_text(encoding="utf-8"))
+    descriptor["assets"][0]["bytes"] = True
+    descriptor_path.write_text(json.dumps(descriptor), encoding="utf-8")
+
+    index_path = copied_root / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["targets"]["pi@0.57.1"]["sha256"] = hashlib.sha256(
+        descriptor_path.read_bytes()
+    ).hexdigest()
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+
+    with pytest.raises(E4TargetError, match="bytes must be a non-negative integer"):
         _load_e4_target_from_root(copied_root, "pi@0.57.1")
 
 

--- a/tests/test_e4_targets.py
+++ b/tests/test_e4_targets.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 from pathlib import Path
 import shutil
+from types import SimpleNamespace
 
 import pytest
 import yaml
@@ -11,6 +12,7 @@ import yaml
 from breadboard_engine.e4_targets import (
     E4TargetError,
     _load_e4_target_from_root,
+    _editable_source_root,
     _location_key,
     _resource_root,
     list_e4_target_ids,
@@ -24,6 +26,41 @@ TARGET_ROOT = ROOT / "config" / "e4_targets"
 
 def test_target_resources_bind_to_loader_distribution_root() -> None:
     assert _resource_root() == TARGET_ROOT
+
+
+def test_target_resources_load_outside_editable_checkout_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    assert _resource_root() == TARGET_ROOT
+    assert list_e4_target_ids() == ("oh-my-pi@16.2.13", "pi@0.57.1")
+
+
+def test_editable_source_root_accepts_only_absolute_local_file_urls(
+    tmp_path: Path,
+) -> None:
+    source_root = tmp_path / "source root"
+    valid = SimpleNamespace(
+        read_text=lambda _: json.dumps(
+            {"url": source_root.as_uri(), "dir_info": {"editable": True}}
+        )
+    )
+    assert _editable_source_root(valid) == source_root
+
+    for url in (
+        "https://example.invalid/source",
+        "file:relative/source",
+        "file:///tmp/source?unexpected=query",
+        "file://remote.invalid/source",
+    ):
+        invalid = SimpleNamespace(
+            read_text=lambda _, url=url: json.dumps(
+                {"url": url, "dir_info": {"editable": True}}
+            )
+        )
+        assert _editable_source_root(invalid) is None
 
 
 def test_distribution_owner_match_does_not_resolve_symlink_aliases(

--- a/tests/test_e4_targets.py
+++ b/tests/test_e4_targets.py
@@ -275,6 +275,18 @@ def test_target_loader_rejects_corrupt_runtime_asset(tmp_path: Path) -> None:
         _load_e4_target_from_root(copied_root, "pi@0.57.1")
 
 
+def test_loaded_target_serves_only_verified_asset_bytes(tmp_path: Path) -> None:
+    copied_root = tmp_path / "e4_targets"
+    shutil.copytree(TARGET_ROOT, copied_root)
+    target = _load_e4_target_from_root(copied_root, "pi@0.57.1")
+    expected = target.read_asset_bytes("harness.yaml")
+    harness = copied_root / "pi" / "0.57.1" / "harness.yaml"
+
+    harness.write_text("changed after verification\n", encoding="utf-8")
+
+    assert target.read_asset_bytes("harness.yaml") == expected
+
+
 def test_target_loader_rejects_boolean_asset_size(tmp_path: Path) -> None:
     copied_root = tmp_path / "e4_targets"
     shutil.copytree(TARGET_ROOT, copied_root)
@@ -294,12 +306,19 @@ def test_target_loader_rejects_boolean_asset_size(tmp_path: Path) -> None:
         _load_e4_target_from_root(copied_root, "pi@0.57.1")
 
 
-def test_target_loader_rejects_unsafe_descriptor_path(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "unsafe_path",
+    ("../target.json", "D:/outside/target.json"),
+)
+def test_target_loader_rejects_unsafe_descriptor_path(
+    tmp_path: Path,
+    unsafe_path: str,
+) -> None:
     copied_root = tmp_path / "e4_targets"
     shutil.copytree(TARGET_ROOT, copied_root)
     index_path = copied_root / "index.json"
     index = json.loads(index_path.read_text(encoding="utf-8"))
-    index["targets"]["pi@0.57.1"]["descriptor"] = "../target.json"
+    index["targets"]["pi@0.57.1"]["descriptor"] = unsafe_path
     index_path.write_text(json.dumps(index), encoding="utf-8")
 
     with pytest.raises(E4TargetError, match="unsafe target resource path"):

--- a/tests/test_e4_targets.py
+++ b/tests/test_e4_targets.py
@@ -11,6 +11,7 @@ import yaml
 from breadboard_engine.e4_targets import (
     E4TargetError,
     _load_e4_target_from_root,
+    _location_key,
     _resource_root,
     list_e4_target_ids,
     load_e4_target,
@@ -23,6 +24,22 @@ TARGET_ROOT = ROOT / "config" / "e4_targets"
 
 def test_target_resources_bind_to_loader_distribution_root() -> None:
     assert _resource_root() == TARGET_ROOT
+
+
+def test_distribution_owner_match_does_not_resolve_symlink_aliases(
+    tmp_path: Path,
+) -> None:
+    loader = tmp_path / "installed" / "breadboard_engine" / "e4_targets.py"
+    loader.parent.mkdir(parents=True)
+    loader.write_text("", encoding="utf-8")
+    alias = tmp_path / "hostile" / "breadboard_engine" / "e4_targets.py"
+    alias.parent.mkdir(parents=True)
+    try:
+        alias.symlink_to(loader)
+    except OSError:
+        pytest.skip("symlink creation is not available")
+
+    assert _location_key(alias) != _location_key(loader)
 
 
 def test_pinned_targets_load_with_exact_release_source_and_runtime_assets() -> None:

--- a/tests/test_e4_targets.py
+++ b/tests/test_e4_targets.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+
+import pytest
+import yaml
+
+from breadboard_engine.e4_targets import (
+    E4TargetError,
+    _load_e4_target_from_root,
+    list_e4_target_ids,
+    load_e4_target,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TARGET_ROOT = ROOT / "config" / "e4_targets"
+
+
+def test_pinned_targets_load_with_exact_release_source_and_runtime_assets() -> None:
+    assert list_e4_target_ids() == ("oh-my-pi@16.2.13", "pi@0.57.1")
+
+    pi = load_e4_target("pi@0.57.1")
+    assert pi.descriptor["upstream"] == {
+        "repository": "https://github.com/badlogic/pi-mono.git",
+        "source": {
+            "commit": "a9cedccdde77e9d765303463d8a6cd11c58f7a7f",
+            "directory": "packages/coding-agent",
+            "archive_sha256": (
+                "bd64909b10a34c30890606f8787ee2ac47b9e7989e3db581978dd8214d62e87b"
+            ),
+            "archive_bytes": 4755355,
+        },
+        "package": {
+            "name": "@mariozechner/pi-coding-agent",
+            "version": "0.57.1",
+            "tarball": (
+                "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/"
+                "pi-coding-agent-0.57.1.tgz"
+            ),
+            "integrity": (
+                "sha512-u5MQEduj68rwVIsRsqrWkJYiJCyPph/a6bMoJAQKo1sb+Pc17Y/"
+                "ojwa+wGssnUMjEB38AQKofWTVe8NFEpSWNw=="
+            ),
+            "shasum_sha1": "58433481f4a469e28f3faac7ea3d2b10cb1bfefb",
+            "tarball_sha256": (
+                "8648e71d5553388ed710f1ef4165d9f090e1783e446629410c545875ac564b6f"
+            ),
+            "tarball_bytes": 3761279,
+        },
+    }
+    assert pi.descriptor["overlay"] == {
+        "overlay_id": "r3-json-no-session.v1",
+        "argv": [
+            "--mode",
+            "json",
+            "--no-session",
+            "--thinking",
+            "off",
+            "--tools",
+            "read,bash,edit,write,grep,find,ls",
+            "--no-extensions",
+            "--no-skills",
+            "--no-prompt-templates",
+        ],
+        "settings": {"retry.enabled": False, "retry.maxRetries": 0},
+    }
+    pi_config = pi.read_asset_text(pi.descriptor["execution"]["config_asset"])
+    assert "target_id: pi@0.57.1" in pi_config
+    assert "max_retries: 0" in pi_config
+
+    omp = load_e4_target("oh-my-pi@16.2.13")
+    assert omp.descriptor["upstream"]["source"] == {
+        "commit": "5356713eae60e67ee64d9b02e3b5e377d248ee7f",
+        "directory": "packages/coding-agent",
+        "archive_sha256": (
+            "03fd855b01bb7457f85e929ff747d8560d7cf7ed420fd0676bf32b917fb264a3"
+        ),
+        "archive_bytes": 42065260,
+    }
+    assert omp.descriptor["upstream"]["package"]["version"] == "16.2.13"
+    omp_surface = json.loads(omp.read_asset_text("tool-surface.json"))
+    assert omp_surface["ordered_tools"][:5] == [
+        "read",
+        "bash",
+        "edit",
+        "ast_grep",
+        "ast_edit",
+    ]
+    assert omp_surface["legacy_aliases"] == {"search": "grep", "find": "glob"}
+
+
+def test_target_freeze_references_match_calibrated_source_rows() -> None:
+    manifest = yaml.safe_load(
+        (ROOT / "config" / "e4_target_freeze_manifest.yaml").read_text(encoding="utf-8")
+    )
+    freeze_rows = manifest["e4_configs"]
+
+    pi = load_e4_target("pi@0.57.1")
+    for entry_id in pi.descriptor["freeze_manifest_entries"]:
+        harness = freeze_rows[entry_id]["harness"]
+        assert harness["upstream_release_label"] == (
+            "@mariozechner/pi-coding-agent@0.57.1"
+        )
+        assert harness["upstream_commit"] == (
+            "archive:sha256:"
+            "bd64909b10a34c30890606f8787ee2ac47b9e7989e3db581978dd8214d62e87b"
+        )
+
+    omp = load_e4_target("oh-my-pi@16.2.13")
+    for entry_id in omp.descriptor["freeze_manifest_entries"]:
+        harness = freeze_rows[entry_id]["harness"]
+        assert harness["upstream_release_label"] == (
+            "@oh-my-pi/pi-coding-agent@16.2.13"
+        )
+        assert harness["upstream_commit"] == (
+            "5356713eae60e67ee64d9b02e3b5e377d248ee7f"
+        )
+
+
+def test_target_loader_rejects_unknown_and_undeclared_assets() -> None:
+    with pytest.raises(E4TargetError, match="unknown E4 target"):
+        load_e4_target("pi@latest")
+
+    target = load_e4_target("pi@0.57.1")
+    with pytest.raises(E4TargetError, match="does not declare asset"):
+        target.read_asset_text("../target.json")
+
+
+def test_target_loader_rejects_corrupt_runtime_asset(tmp_path: Path) -> None:
+    copied_root = tmp_path / "e4_targets"
+    shutil.copytree(TARGET_ROOT, copied_root)
+    harness = copied_root / "pi" / "0.57.1" / "harness.yaml"
+    harness.write_text(harness.read_text(encoding="utf-8") + "corrupt: true\n")
+
+    with pytest.raises(E4TargetError, match="SHA-256 mismatch"):
+        _load_e4_target_from_root(copied_root, "pi@0.57.1")
+
+
+def test_target_loader_rejects_unsafe_descriptor_path(tmp_path: Path) -> None:
+    copied_root = tmp_path / "e4_targets"
+    shutil.copytree(TARGET_ROOT, copied_root)
+    index_path = copied_root / "index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    index["targets"]["pi@0.57.1"]["descriptor"] = "../target.json"
+    index_path.write_text(json.dumps(index), encoding="utf-8")
+
+    with pytest.raises(E4TargetError, match="unsafe target resource path"):
+        _load_e4_target_from_root(copied_root, "pi@0.57.1")


### PR DESCRIPTION
## Scope

Adds installed-package-safe, integrity-checked E4 targets for:

- `@mariozechner/pi-coding-agent@0.57.1`
- `@oh-my-pi/pi-coding-agent@16.2.13`

Each target pins npm release integrity, tarball SHA-256, upstream source identity, calibrated freeze-manifest rows, a target harness, prompt template, and ordered tool surface. The loader binds resources to the exact distribution that owns the running loader, supports strict PEP 610 editable installs, validates index, descriptor, asset paths, sizes, and SHA-256 digests, snapshots verified asset bytes, deep-freezes returned descriptors, and restricts reads to declared assets.

The Pi target carries the immutable R3 overlay exactly:

`--mode json --no-session --thinking off --tools read,bash,edit,write,grep,find,ls --no-extensions --no-skills --no-prompt-templates retry.enabled=false retry.maxRetries=0`

This PR establishes pinned targets only. It does not claim Pi/Oh My Pi behavioral parity, provider parity, sandbox readiness, SWE readiness, or training readiness. Target-adapter dispatch is explicitly assigned to RL-E4-2; this PR makes no direct registry binding claim.

## Evidence

- `pytest -q tests/test_e4_targets.py tests/test_e4_target_freeze_manifest.py` — 15 passed
- Outside-checkout editable-install smoke loads both targets from `/tmp`
- `pytest -q tests/test_breadboard_cli_packaging.py` — 3 passed from committed clean source
- `ruff check breadboard_engine/e4_targets.py tests/test_e4_targets.py` — passed
- Wheel tests load both targets from a clean pip installation and directly through zipimport.
- Verified assets are immutable snapshots; editable files changed after load cannot alter served bytes.
- Resource validation rejects Windows drive-qualified, URI-like, absolute, backslash, dot, and parent paths.

## Review fixes

Exact-head reviews and automated review found mutable nested descriptors, boolean byte counts, generic namespace lookup, an over-claimed Pi Git-source binding, filesystem-only resource traversal, symlink-alias ownership, incomplete OMP renderer inputs, incompatible/unregistered Pi direct dispatch IDs, missing PEP 610 editable ownership, malformed metadata error handling, asset verification-to-use races, and drive-qualified resource paths. Final head `a3748e2047e4e4a8bd651a4f7a48a826f7e025b1` fixes every finding with regression coverage. The Pi asset records exact upstream tool descriptions and native JSON schemas; RL-E4-2 owns compatible adapter dispatch.

## Provenance

- Pi npm integrity: `sha512-u5MQEduj68rwVIsRsqrWkJYiJCyPph/a6bMoJAQKo1sb+Pc17Y/ojwa+wGssnUMjEB38AQKofWTVe8NFEpSWNw==`
- Pi package tarball SHA-256: `8648e71d5553388ed710f1ef4165d9f090e1783e446629410c545875ac564b6f`
- Pi npm `gitHead`: `a9cedccdde77e9d765303463d8a6cd11c58f7a7f`
- Pi frozen source archive SHA-256: `bd64909b10a34c30890606f8787ee2ac47b9e7989e3db581978dd8214d62e87b`
- Oh My Pi npm integrity: `sha512-ZKi9xul+Ef6wmq4VoETCmEFrAOOqx0Wq24MxHM6vL7al2NW/q7RCJc3StlLmHs8zN06C2tI/XQTMJbm5UDX0fA==`
- Oh My Pi package tarball SHA-256: `293056afc7d0d59c9aa8726efdbefc8d3a05a3dfca4261b4af5431d79a6593ff`
- Oh My Pi source commit: `5356713eae60e67ee64d9b02e3b5e377d248ee7f`
- Oh My Pi frozen source archive SHA-256: `03fd855b01bb7457f85e929ff747d8560d7cf7ed420fd0676bf32b917fb264a3`