### PR TITLE
feat(rl): add episode-scoped provider profiles

### DIFF
--- a/breadboard_engine/agent.py
+++ b/breadboard_engine/agent.py
@@ -44,6 +44,7 @@ def _get_ray():  # type: ignore[no-untyped-def]
 from .agent_llm_openai import OpenAIConductor
 from .compilation.v2_loader import _config_resolution_base_dirs, load_agent_config
 from .provider.routing import provider_router
+from .provider.contracts import OpenAICompletionsProviderProfile
 from .provider import provider_adapter_manager
 from .compilation.tool_yaml_loader import load_yaml_tools
 from .compilation.system_prompt_compiler import get_compiler
@@ -404,6 +405,7 @@ class AgenticCoder:
         context: Optional[Dict[str, Any]] = None,
         kernel_emitter_run_dir: Optional[str] = None,
         kernel_emitter_mode: Optional[str] = None,
+        provider_profile: Optional[OpenAICompletionsProviderProfile] = None,
     ) -> Dict[str, Any]:
         """Run a single task and return results."""
         if replay_session and self.agent is not None:
@@ -485,6 +487,7 @@ class AgenticCoder:
                 kernel_emitter_run_dir=kernel_emitter_run_dir,
                 kernel_emitter_mode=kernel_emitter_mode,
                 context=context,
+                provider_profile=provider_profile,
             )
 
         ref = self.agent.run_agentic_loop.remote(
@@ -503,6 +506,7 @@ class AgenticCoder:
             kernel_emitter_run_dir=kernel_emitter_run_dir,
             kernel_emitter_mode=kernel_emitter_mode,
             context=context,
+            provider_profile=provider_profile,
         )
         ray_mod = _get_ray()
         if ray_mod is None:

--- a/breadboard_engine/agent_llm_openai.py
+++ b/breadboard_engine/agent_llm_openai.py
@@ -5566,15 +5566,6 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
                 kernel_emitter = JsonlKernelEmitter(_Path(kernel_emitter_run_dir), mode=mode)  # type: ignore[arg-type]
             except Exception:
                 kernel_emitter = None
-        session_state = SessionState(
-            self.workspace,
-            self.image,
-            self.config,
-            event_emitter=emitter,
-            kernel_emitter=kernel_emitter,
-            episode_provider_profile=provider_profile,
-        )
-        self._active_session_state = session_state
         if not isinstance(context, dict):
             raise ProviderContractError(
                 "run context requires admitted session/input/turn identifiers"
@@ -5612,6 +5603,15 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
             raise ProviderContractError(
                 "run context input_media accepts only media blocks"
             )
+        session_state = SessionState(
+            self.workspace,
+            self.image,
+            self.config,
+            event_emitter=emitter,
+            kernel_emitter=kernel_emitter,
+            episode_provider_profile=provider_profile,
+        )
+        self._active_session_state = session_state
         session_state.set_provider_metadata("session_id", provider_session_id)
         session_state.set_turn_context(
             input_id=provider_input_id,

--- a/breadboard_engine/agent_llm_openai.py
+++ b/breadboard_engine/agent_llm_openai.py
@@ -5736,8 +5736,6 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
                 self._reward_metrics_sqlite = None
                 self._todo_metrics_sqlite = None
 
-        if provider_profile is None:
-            self._ensure_capability_probes(session_state, markdown_logger)
         self.provider_metrics.reset()
         user_prompt, max_steps = self._prepare_replay_session(session_state, user_prompt, max_steps)
         
@@ -6326,6 +6324,8 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
         run_loop_error: Optional[Dict[str, Any]] = None
         self._active_session_state = session_state
         try:
+            if provider_profile is None:
+                self._ensure_capability_probes(session_state, markdown_logger)
             if is_longrun_enabled(getattr(self, "config", None)):
                 work_queue = build_work_queue(
                     getattr(self, "config", None),

--- a/breadboard_engine/agent_llm_openai.py
+++ b/breadboard_engine/agent_llm_openai.py
@@ -6465,6 +6465,27 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
             except Exception:
                 pass
         finally:
+            profile_client = getattr(session_state, "_episode_provider_client", None)
+            if profile_client is not None:
+                try:
+                    profile_client.close()
+                except Exception as exc:
+                    cleanup_error = public_error_projection(
+                        exc,
+                        default_code="profile_client_cleanup_failed",
+                    )
+                    try:
+                        session_state.set_provider_metadata(
+                            "profile_client_cleanup_error",
+                            {
+                                "type": cleanup_error["error_type"],
+                                "message": cleanup_error["error"],
+                            },
+                        )
+                    except Exception:
+                        pass
+                finally:
+                    session_state._episode_provider_client = None
             self._persist_final_workspace()
             try:
                 self._persist_multi_agent_log()

--- a/breadboard_engine/agent_llm_openai.py
+++ b/breadboard_engine/agent_llm_openai.py
@@ -5611,7 +5611,6 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
             kernel_emitter=kernel_emitter,
             episode_provider_profile=provider_profile,
         )
-        self._active_session_state = session_state
         session_state.set_provider_metadata("session_id", provider_session_id)
         session_state.set_turn_context(
             input_id=provider_input_id,
@@ -6324,6 +6323,7 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
         # Main agentic loop - significantly simplified
         run_result = None
         run_loop_error: Optional[Dict[str, Any]] = None
+        self._active_session_state = session_state
         try:
             if is_longrun_enabled(getattr(self, "config", None)):
                 work_queue = build_work_queue(

--- a/breadboard_engine/agent_llm_openai.py
+++ b/breadboard_engine/agent_llm_openai.py
@@ -5736,7 +5736,8 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
                 self._reward_metrics_sqlite = None
                 self._todo_metrics_sqlite = None
 
-        self._ensure_capability_probes(session_state, markdown_logger)
+        if provider_profile is None:
+            self._ensure_capability_probes(session_state, markdown_logger)
         self.provider_metrics.reset()
         user_prompt, max_steps = self._prepare_replay_session(session_state, user_prompt, max_steps)
         

--- a/breadboard_engine/agent_llm_openai.py
+++ b/breadboard_engine/agent_llm_openai.py
@@ -365,7 +365,6 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
         local_mode: bool = False,
         prompt_base_dirs: Optional[List[Path]] = None,
         protected_paths: Optional[Sequence[str]] = None,
-        provider_profile: Optional[OpenAICompletionsProviderProfile] = None,
     ) -> None:
         """Initialize conductor with workspace, image, and configuration."""
         captured_protected_paths = tuple(
@@ -391,11 +390,6 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
             zero_tool_abort_message=ZERO_TOOL_ABORT_MESSAGE,
             completion_guard_abort_threshold=COMPLETION_GUARD_ABORT_THRESHOLD,
         )
-        if provider_profile is not None and not isinstance(
-            provider_profile, OpenAICompletionsProviderProfile
-        ):
-            raise ProviderContractError("provider_profile is invalid")
-        self._provider_profile = provider_profile
         self._model_role_lock = (
             dict(self.config.get("model_role_lock"))
             if isinstance(self.config, dict) and isinstance(self.config.get("model_role_lock"), dict)
@@ -5540,10 +5534,15 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
         context: Optional[Dict[str, Any]] = None,
         kernel_emitter_run_dir: Optional[str] = None,
         kernel_emitter_mode: Optional[str] = None,
+        provider_profile: Optional[OpenAICompletionsProviderProfile] = None,
     ) -> Dict[str, Any]:
         # Clear any prior stop request from earlier runs (Esc in the TUI should only
         # interrupt the current in-flight run, not permanently disable the session).
         self._stop_requested = False
+        if provider_profile is not None and not isinstance(
+            provider_profile, OpenAICompletionsProviderProfile
+        ):
+            raise ProviderContractError("provider_profile is invalid")
         # Initialize components
         emitter = event_emitter
         if emitter is None and event_queue is not None:
@@ -5567,7 +5566,13 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
                 kernel_emitter = JsonlKernelEmitter(_Path(kernel_emitter_run_dir), mode=mode)  # type: ignore[arg-type]
             except Exception:
                 kernel_emitter = None
-        session_state = SessionState(self.workspace, self.image, self.config, event_emitter=emitter, kernel_emitter=kernel_emitter,
+        session_state = SessionState(
+            self.workspace,
+            self.image,
+            self.config,
+            event_emitter=emitter,
+            kernel_emitter=kernel_emitter,
+            episode_provider_profile=provider_profile,
         )
         self._active_session_state = session_state
         if not isinstance(context, dict):

--- a/breadboard_engine/agent_llm_openai.py
+++ b/breadboard_engine/agent_llm_openai.py
@@ -50,6 +50,7 @@ from .provider.runtime import (
     ProviderRuntimeError,
 )
 from .provider.contracts import (
+    OpenAICompletionsProviderProfile,
     ProviderContractError,
     normalize_content,
     strip_provider_exchange_completion_sentinels,
@@ -364,6 +365,7 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
         local_mode: bool = False,
         prompt_base_dirs: Optional[List[Path]] = None,
         protected_paths: Optional[Sequence[str]] = None,
+        provider_profile: Optional[OpenAICompletionsProviderProfile] = None,
     ) -> None:
         """Initialize conductor with workspace, image, and configuration."""
         captured_protected_paths = tuple(
@@ -389,6 +391,11 @@ class OpenAIConductor(OpenAIConductorFacadeMethods):
             zero_tool_abort_message=ZERO_TOOL_ABORT_MESSAGE,
             completion_guard_abort_threshold=COMPLETION_GUARD_ABORT_THRESHOLD,
         )
+        if provider_profile is not None and not isinstance(
+            provider_profile, OpenAICompletionsProviderProfile
+        ):
+            raise ProviderContractError("provider_profile is invalid")
+        self._provider_profile = provider_profile
         self._model_role_lock = (
             dict(self.config.get("model_role_lock"))
             if isinstance(self.config, dict) and isinstance(self.config.get("model_role_lock"), dict)

--- a/breadboard_engine/conductor/modes.py
+++ b/breadboard_engine/conductor/modes.py
@@ -31,6 +31,7 @@ from .components import (
     log_routing_event,
 )
 from ..surface import record_tool_schema_snapshot
+from ..security import redaction
 
 
 def _record_raw_provider_response(
@@ -70,6 +71,49 @@ def _bind_episode_provider_profile(
             "episode provider profile does not match the selected route"
         )
     return runtime.create_client_from_profile(profile), True, profile
+
+
+def _provider_wire_evidence(
+    *,
+    profile: Any,
+    provider_id: str,
+    model: str,
+    messages: List[Dict[str, Any]],
+    tools: Optional[List[Dict[str, Any]]],
+    stream: bool,
+    client_config: Dict[str, Any],
+) -> Tuple[Dict[str, Any], Dict[str, Any], Optional[str], Optional[Dict[str, Any]]]:
+    if profile is not None:
+        request_headers = {"Authorization": redaction.REDACTED}
+        request_headers.update(
+            {name: redaction.REDACTED for name in profile.caller_headers}
+        )
+        return (
+            profile.chat_request(messages, tools),
+            request_headers,
+            profile.base_url,
+            profile.identity_dict(),
+        )
+    try:
+        request_headers = dict(client_config.get("default_headers") or {})
+        if provider_id == "openrouter":
+            request_headers.setdefault("Accept", "application/json; charset=utf-8")
+            request_headers.setdefault("Accept-Encoding", "identity")
+        endpoint = client_config.get("base_url")
+    except Exception:
+        request_headers = {}
+        endpoint = None
+    return (
+        {
+            "model": model,
+            "messages": messages,
+            "tools": tools,
+            "stream": stream,
+        },
+        request_headers,
+        endpoint,
+        None,
+    )
 
 
 
@@ -307,6 +351,20 @@ def get_model_response(
             effective_stream_responses,
         )
     )
+    (
+        wire_request_body,
+        request_headers,
+        request_endpoint,
+        profile_identity,
+    ) = _provider_wire_evidence(
+        profile=provider_profile,
+        provider_id=provider_id,
+        model=model,
+        messages=send_messages,
+        tools=tools_schema,
+        stream=effective_stream_responses,
+        client_config=client_config,
+    )
     try:
         session_state.set_provider_metadata("current_stream_requested", stream_responses)
         session_state.set_provider_metadata("current_stream_effective", effective_stream_responses)
@@ -327,12 +385,7 @@ def get_model_response(
         if conductor.logger_v2.include_raw:
             conductor.api_recorder.save_request(
                 turn_index,
-                {
-                    "model": model,
-                    "messages": send_messages,
-                    "tools": tools_schema,
-                    "stream": effective_stream_responses,
-                },
+                wire_request_body,
             )
     except Exception:
         pass
@@ -367,15 +420,6 @@ def get_model_response(
         provider_profile=provider_profile,
     )
 
-    try:
-        request_headers = dict(client_config.get("default_headers") or {})
-        if (
-            getattr(runtime, "descriptor", None) and getattr(runtime.descriptor, "provider_id", None) == "openrouter"
-        ):
-            request_headers.setdefault("Accept", "application/json; charset=utf-8")
-            request_headers.setdefault("Accept-Encoding", "identity")
-    except Exception:
-        request_headers = {}
 
     try:
         if getattr(conductor.logger_v2, "include_structured_requests", True):
@@ -383,6 +427,8 @@ def get_model_response(
                 "message_count": len(send_messages or []),
                 "has_tools": bool(tools_schema),
             }
+            if profile_identity is not None:
+                extra_meta["provider_profile_identity"] = profile_identity
             if stream_policy:
                 extra_meta["stream_policy"] = {
                     "reason": stream_policy.get("reason"),
@@ -394,15 +440,10 @@ def get_model_response(
                 runtime_id=getattr(runtime.descriptor, "runtime_id", "unknown"),
                 model=model,
                 request_headers=request_headers,
-                request_body={
-                    "model": model,
-                    "messages": send_messages,
-                    "tools": tools_schema,
-                    "stream": effective_stream_responses,
-                },
+                request_body=wire_request_body,
                 stream=effective_stream_responses,
                 tool_count=len(tools_schema or []),
-                endpoint=client_config.get("base_url"),
+                endpoint=request_endpoint,
                 attempt=0,
                 extra=extra_meta,
             )

--- a/breadboard_engine/conductor/modes.py
+++ b/breadboard_engine/conductor/modes.py
@@ -88,15 +88,29 @@ def _provider_wire_evidence(
     client_config: Dict[str, Any],
 ) -> Tuple[Dict[str, Any], Dict[str, Any], Optional[str], Optional[Dict[str, Any]]]:
     if profile is not None:
+        profile_identity = profile.identity_dict()
         request_headers = {"Authorization": redaction.REDACTED}
         request_headers.update(
             {name: redaction.REDACTED for name in profile.caller_headers}
         )
+        secret_values = [
+            profile.scoped_credential,
+            *profile.caller_headers.values(),
+        ]
+        with redaction.secret_value_scope(*secret_values):
+            request_body, _redaction_problems = redaction.scrub_structure(
+                profile.chat_request(messages, tools),
+                path="$.provider_request",
+            )
+        if not isinstance(request_body, dict):
+            raise ProviderContractError(
+                "profile request evidence must remain an object after redaction"
+            )
         return (
-            profile.chat_request(messages, tools),
+            request_body,
             request_headers,
-            profile.base_url,
-            profile.identity_dict(),
+            f"sha256:{profile_identity['base_url_sha256']}",
+            profile_identity,
         )
     try:
         request_headers = dict(client_config.get("default_headers") or {})

--- a/breadboard_engine/conductor/modes.py
+++ b/breadboard_engine/conductor/modes.py
@@ -70,7 +70,11 @@ def _bind_episode_provider_profile(
         raise ProviderContractError(
             "episode provider profile does not match the selected route"
         )
-    return runtime.create_client_from_profile(profile), True, profile
+    profile_client = getattr(episode, "_episode_provider_client", None)
+    if profile_client is None:
+        profile_client = runtime.create_client_from_profile(profile)
+        episode._episode_provider_client = profile_client
+    return profile_client, True, profile
 
 
 def _provider_wire_evidence(

--- a/breadboard_engine/conductor/modes.py
+++ b/breadboard_engine/conductor/modes.py
@@ -97,7 +97,7 @@ def _provider_wire_evidence(
             profile.scoped_credential,
             *profile.caller_headers.values(),
         ]
-        with redaction.secret_value_scope(*secret_values):
+        with redaction.secret_value_scope(*secret_values, allow_short=True):
             request_body, _redaction_problems = redaction.scrub_structure(
                 profile.chat_request(messages, tools),
                 path="$.provider_request",

--- a/breadboard_engine/conductor/modes.py
+++ b/breadboard_engine/conductor/modes.py
@@ -80,12 +80,14 @@ def _bind_episode_provider_profile(
 def _provider_wire_evidence(
     *,
     profile: Any,
+    runtime: Any,
     provider_id: str,
     model: str,
     messages: List[Dict[str, Any]],
     tools: Optional[List[Dict[str, Any]]],
     stream: bool,
     client_config: Dict[str, Any],
+    context: ProviderRuntimeContext,
 ) -> Tuple[Dict[str, Any], Dict[str, Any], Optional[str], Optional[Dict[str, Any]]]:
     if profile is not None:
         profile_identity = profile.identity_dict()
@@ -99,7 +101,12 @@ def _provider_wire_evidence(
         ]
         with redaction.secret_value_scope(*secret_values, allow_short=True):
             request_body, _redaction_problems = redaction.scrub_structure(
-                profile.chat_request(messages, tools),
+                runtime.profile_chat_request(
+                    profile,
+                    messages,
+                    tools,
+                    context=context,
+                ),
                 path="$.provider_request",
             )
         if not isinstance(request_body, dict):
@@ -369,45 +376,6 @@ def get_model_response(
             effective_stream_responses,
         )
     )
-    (
-        wire_request_body,
-        request_headers,
-        request_endpoint,
-        profile_identity,
-    ) = _provider_wire_evidence(
-        profile=provider_profile,
-        provider_id=provider_id,
-        model=model,
-        messages=send_messages,
-        tools=tools_schema,
-        stream=effective_stream_responses,
-        client_config=client_config,
-    )
-    try:
-        session_state.set_provider_metadata("current_stream_requested", stream_responses)
-        session_state.set_provider_metadata("current_stream_effective", effective_stream_responses)
-    except Exception:
-        pass
-
-    try:
-        provider_messages = getattr(session_state, "provider_messages", []) or []
-        if provider_messages:
-            last_message = provider_messages[-1]
-            if isinstance(last_message, dict) and last_message.get("tool_calls"):
-                for _ in last_message.get("tool_calls", []):
-                    conductor.loop_detector.observe_tool_call()
-    except Exception:
-        pass
-
-    try:
-        if conductor.logger_v2.include_raw:
-            conductor.api_recorder.save_request(
-                turn_index,
-                wire_request_body,
-            )
-    except Exception:
-        pass
-
     runtime_extra = {
         "turn_index": turn_index,
         "model": model,
@@ -437,6 +405,47 @@ def get_model_response(
         turn_id=session_state.get_provider_metadata("turn_id"),
         provider_profile=provider_profile,
     )
+    (
+        wire_request_body,
+        request_headers,
+        request_endpoint,
+        profile_identity,
+    ) = _provider_wire_evidence(
+        profile=provider_profile,
+        runtime=runtime,
+        provider_id=provider_id,
+        model=model,
+        messages=send_messages,
+        tools=tools_schema,
+        stream=effective_stream_responses,
+        client_config=client_config,
+        context=runtime_context,
+    )
+    try:
+        session_state.set_provider_metadata("current_stream_requested", stream_responses)
+        session_state.set_provider_metadata("current_stream_effective", effective_stream_responses)
+    except Exception:
+        pass
+
+    try:
+        provider_messages = getattr(session_state, "provider_messages", []) or []
+        if provider_messages:
+            last_message = provider_messages[-1]
+            if isinstance(last_message, dict) and last_message.get("tool_calls"):
+                for _ in last_message.get("tool_calls", []):
+                    conductor.loop_detector.observe_tool_call()
+    except Exception:
+        pass
+
+    try:
+        if conductor.logger_v2.include_raw:
+            conductor.api_recorder.save_request(
+                turn_index,
+                wire_request_body,
+            )
+    except Exception:
+        pass
+
 
 
     try:

--- a/breadboard_engine/conductor/modes.py
+++ b/breadboard_engine/conductor/modes.py
@@ -17,6 +17,7 @@ from ..provider.ir import IRDeltaEvent
 from ..provider.routing import provider_router
 from ..provider import provider_adapter_manager, sanitize_openai_tool_name
 from ..provider.contracts import (
+    ProviderContractError,
     ProviderResult,
     ProviderRuntimeContext,
     sanitize_provider_result,
@@ -49,6 +50,27 @@ def _record_raw_provider_response(
             )
     except Exception:
         pass
+
+def _bind_episode_provider_profile(
+    conductor: Any,
+    runtime: Any,
+    client: Any,
+    model: str,
+    stream: bool,
+) -> Tuple[Any, bool, Any]:
+    profile = getattr(conductor, "_provider_profile", None)
+    if profile is None:
+        return client, stream, None
+    if (
+        getattr(runtime.descriptor, "provider_id", None) != profile.provider_id
+        or getattr(runtime.descriptor, "runtime_id", None) != profile.runtime_id
+        or model != profile.model
+    ):
+        raise ProviderContractError(
+            "episode provider profile does not match the selected route"
+        )
+    return runtime.create_client_from_profile(profile), True, profile
+
 
 
 def get_model_response(
@@ -276,6 +298,15 @@ def get_model_response(
         turn_index,
         getattr(conductor, "_current_route_id", None),
     )
+    client, effective_stream_responses, provider_profile = (
+        _bind_episode_provider_profile(
+            conductor,
+            runtime,
+            client,
+            model,
+            effective_stream_responses,
+        )
+    )
     try:
         session_state.set_provider_metadata("current_stream_requested", stream_responses)
         session_state.set_provider_metadata("current_stream_effective", effective_stream_responses)
@@ -333,6 +364,7 @@ def get_model_response(
         or getattr(session_state, "session_id", None),
         input_id=session_state.get_provider_metadata("input_id"),
         turn_id=session_state.get_provider_metadata("turn_id"),
+        provider_profile=provider_profile,
     )
 
     try:

--- a/breadboard_engine/conductor/modes.py
+++ b/breadboard_engine/conductor/modes.py
@@ -52,13 +52,13 @@ def _record_raw_provider_response(
         pass
 
 def _bind_episode_provider_profile(
-    conductor: Any,
+    episode: Any,
     runtime: Any,
     client: Any,
     model: str,
     stream: bool,
 ) -> Tuple[Any, bool, Any]:
-    profile = getattr(conductor, "_provider_profile", None)
+    profile = getattr(episode, "_episode_provider_profile", None)
     if profile is None:
         return client, stream, None
     if (
@@ -300,7 +300,7 @@ def get_model_response(
     )
     client, effective_stream_responses, provider_profile = (
         _bind_episode_provider_profile(
-            conductor,
+            session_state,
             runtime,
             client,
             model,

--- a/breadboard_engine/provider/contract_runtime.py
+++ b/breadboard_engine/provider/contract_runtime.py
@@ -10,6 +10,7 @@ from .contract_wire import ProviderContractError, canonical_json
 from .contract_events import _safe_error_code
 from .contract_messages import ProviderMessage, ProviderResult
 from .contract_recorder import ProviderExchangeRecorder
+from .profiles import OpenAICompletionsProviderProfile
 from .routing import ProviderDescriptor
 
 
@@ -144,6 +145,7 @@ class ProviderRuntimeContext:
     turn_id: Optional[str] = None
     exchange_recorder: Optional[ProviderExchangeRecorder] = None
     cancel_requested: Optional[Callable[[], bool]] = None
+    provider_profile: Optional[OpenAICompletionsProviderProfile] = None
 
     def record_provider_event(
         self, kind: str, payload: Optional[Mapping[str, Any]] = None

--- a/breadboard_engine/provider/contracts.py
+++ b/breadboard_engine/provider/contracts.py
@@ -43,6 +43,12 @@ from .contract_exchange import (
     strip_public_completion_sentinel_tree,
 )
 from .contract_recorder import ProviderExchangeRecorder
+from .profiles import (
+    OpenAICompletionsCapabilities,
+    OpenAICompletionsCompatibility,
+    OpenAICompletionsProviderProfile,
+    OpenAICompletionsSampling,
+)
 from .contract_runtime import (
     ProviderErrorKind,
     ProviderRuntime,
@@ -73,6 +79,10 @@ __all__ = [
     "ProviderToolCall",
     "ProviderMessage",
     "ProviderResult",
+    "OpenAICompletionsCapabilities",
+    "OpenAICompletionsCompatibility",
+    "OpenAICompletionsProviderProfile",
+    "OpenAICompletionsSampling",
     "ProviderRuntimeContext",
     "ProviderRuntimeError",
     "ProviderRuntime",

--- a/breadboard_engine/provider/invoker.py
+++ b/breadboard_engine/provider/invoker.py
@@ -200,6 +200,16 @@ class ProviderInvoker:
                 failure = _contract_failure()
                 _terminalize_error(failure)
                 raise failure from None
+        profile_bound = runtime_context.provider_profile is not None
+        if profile_bound and not stream_responses:
+            profile_error = ProviderRuntimeError(
+                "profile-bound provider invocation requires streaming",
+                details={"code": "profile_requires_streaming"},
+                kind="configuration",
+            )
+            _terminalize_error(profile_error)
+            raise profile_error
+
 
         if self.route_health.is_circuit_open(model):
             notice = f"[circuit-open] Skipping direct call for route {model}; attempting fallback."
@@ -217,6 +227,9 @@ class ProviderInvoker:
                 details={"code": "route_circuit_open"},
                 kind="transport",
             )
+            if profile_bound:
+                _terminalize_error(circuit_error)
+                raise circuit_error
             recorder.rebind_request_stream(False)
             try:
                 fallback_result = self.retry_with_fallback(
@@ -275,7 +288,7 @@ class ProviderInvoker:
         def _call_runtime(target_model: str, use_stream: bool) -> ProviderResult:
             start_time = time.time()
             try:
-                if self.client_lease is None:
+                if self.client_lease is None or profile_bound:
                     call_result = sanitize_provider_result(
                         runtime.invoke(
                             client=client,
@@ -425,6 +438,8 @@ class ProviderInvoker:
             )
 
         def _can_retry_without_stream(exc: ProviderRuntimeError) -> bool:
+            if profile_bound:
+                return False
             if not _replay_safe(exc):
                 return False
             details = exc.details if isinstance(exc.details, Mapping) else {}
@@ -437,6 +452,8 @@ class ProviderInvoker:
             }
 
         def _can_model_fallback(exc: ProviderRuntimeError) -> bool:
+            if profile_bound:
+                return False
             if not _replay_safe(exc) or exc.kind == "protocol":
                 return False
             config = getattr(runtime_context, "agent_config", None)

--- a/breadboard_engine/provider/profiles.py
+++ b/breadboard_engine/provider/profiles.py
@@ -291,14 +291,14 @@ class OpenAICompletionsProviderProfile:
     """Immutable, episode-scoped authority for one Chat Completions route."""
 
     model: str
-    scoped_credential: str
+    scoped_credential: str = field(repr=False)
     base_url: str
     context_window: int
     max_output_tokens: int
     sampling: OpenAICompletionsSampling | Mapping[str, Any] = field(
         default_factory=OpenAICompletionsSampling
     )
-    caller_headers: Mapping[str, str] = field(default_factory=dict)
+    caller_headers: Mapping[str, str] = field(default_factory=dict, repr=False)
     capabilities: OpenAICompletionsCapabilities | Mapping[str, Any] = field(
         default_factory=OpenAICompletionsCapabilities
     )

--- a/breadboard_engine/provider/profiles.py
+++ b/breadboard_engine/provider/profiles.py
@@ -11,7 +11,6 @@ import hashlib
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from types import MappingProxyType
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -48,6 +47,23 @@ _REQUIRED_CAPABILITIES = (
     "supports_n",
     "supports_max_tokens",
 )
+
+
+@dataclass(frozen=True, slots=True)
+class _FrozenHeaders(Mapping[str, str]):
+    _items: tuple[tuple[str, str], ...]
+
+    def __getitem__(self, key: str) -> str:
+        for name, value in self._items:
+            if name == key:
+                return value
+        raise KeyError(key)
+
+    def __iter__(self):
+        return (name for name, _value in self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
 
 
 def _text(value: Any, field_name: str, *, max_length: int) -> str:
@@ -365,7 +381,9 @@ class OpenAICompletionsProviderProfile:
                     "profile.caller_headers contains duplicate names"
                 )
             headers[header_name] = header_value
-        object.__setattr__(self, "caller_headers", MappingProxyType(headers))
+        object.__setattr__(
+            self, "caller_headers", _FrozenHeaders(tuple(headers.items()))
+        )
         _text(self.provider_id, "profile.provider_id", max_length=128)
         _text(self.runtime_id, "profile.runtime_id", max_length=128)
         if self.provider_id != "openai":

--- a/breadboard_engine/provider/profiles.py
+++ b/breadboard_engine/provider/profiles.py
@@ -1,0 +1,422 @@
+"""Episode-scoped provider profiles for exact OpenAI Chat Completions calls.
+
+Profiles are immutable request authority.  They carry the short-lived credential
+needed to construct one client, but their identity projection never contains
+credential material (or caller auth headers).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Any
+from urllib.parse import urlsplit
+
+from ..security import redaction
+from .contract_wire import ProviderContractError, canonical_json
+
+
+def _text(value: Any, field_name: str, *, max_length: int) -> str:
+    if not isinstance(value, str) or not value or len(value) > max_length:
+        raise ProviderContractError(f"{field_name} must be non-empty text")
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in value):
+        raise ProviderContractError(f"{field_name} contains control characters")
+    return value
+
+
+def _bounded_int(value: Any, field_name: str, *, minimum: int, maximum: int) -> int:
+    if type(value) is not int or value < minimum or value > maximum:
+        raise ProviderContractError(f"{field_name} is outside its supported range")
+    return value
+
+
+def _bounded_float(
+    value: Any,
+    field_name: str,
+    *,
+    minimum: float,
+    maximum: float,
+) -> float:
+    if type(value) not in (int, float) or not minimum <= float(value) <= maximum:
+        raise ProviderContractError(f"{field_name} is outside its supported range")
+    return float(value)
+
+
+@dataclass(frozen=True)
+class OpenAICompletionsSampling:
+    """Sampling controls emitted in a Chat Completions request."""
+
+    temperature: float | None = None
+    top_p: float | None = None
+    seed: int | None = None
+    frequency_penalty: float | None = None
+    presence_penalty: float | None = None
+    n: int = 1
+
+    def __post_init__(self) -> None:
+        if self.temperature is not None:
+            object.__setattr__(
+                self,
+                "temperature",
+                _bounded_float(
+                    self.temperature,
+                    "sampling.temperature",
+                    minimum=0.0,
+                    maximum=2.0,
+                ),
+            )
+        if self.top_p is not None:
+            object.__setattr__(
+                self,
+                "top_p",
+                _bounded_float(self.top_p, "sampling.top_p", minimum=0.0, maximum=1.0),
+            )
+        if self.seed is not None:
+            object.__setattr__(
+                self,
+                "seed",
+                _bounded_int(self.seed, "sampling.seed", minimum=0, maximum=2**31 - 1),
+            )
+        for field_name in ("frequency_penalty", "presence_penalty"):
+            value = getattr(self, field_name)
+            if value is not None:
+                object.__setattr__(
+                    self,
+                    field_name,
+                    _bounded_float(
+                        value,
+                        f"sampling.{field_name}",
+                        minimum=-2.0,
+                        maximum=2.0,
+                    ),
+                )
+        _bounded_int(self.n, "sampling.n", minimum=1, maximum=1)
+
+    @classmethod
+    def from_value(
+        cls, value: OpenAICompletionsSampling | Mapping[str, Any]
+    ) -> OpenAICompletionsSampling:
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, Mapping):
+            raise ProviderContractError("sampling must be an object")
+        allowed = {
+            "temperature",
+            "top_p",
+            "seed",
+            "frequency_penalty",
+            "presence_penalty",
+            "n",
+        }
+        unknown = sorted(str(key) for key in value if key not in allowed)
+        if unknown:
+            raise ProviderContractError(
+                f"sampling contains unsupported fields: {', '.join(unknown)}"
+            )
+        return cls(**{str(key): item for key, item in value.items()})
+
+    def as_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"n": self.n}
+        for field_name in (
+            "temperature",
+            "top_p",
+            "seed",
+            "frequency_penalty",
+            "presence_penalty",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                result[field_name] = value
+        return result
+
+
+@dataclass(frozen=True)
+class OpenAICompletionsCapabilities:
+    """Explicit wire capabilities for one OpenAI-compatible endpoint."""
+
+    supports_tools: bool = True
+    supports_strict_tools: bool = True
+    supports_stream_options: bool = True
+    supports_thinking_control: bool = True
+    supports_store: bool = False
+    supports_n: bool = True
+    supports_max_tokens: bool = True
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "supports_tools",
+            "supports_strict_tools",
+            "supports_stream_options",
+            "supports_thinking_control",
+            "supports_store",
+            "supports_n",
+            "supports_max_tokens",
+        ):
+            if type(getattr(self, field_name)) is not bool:
+                raise ProviderContractError(
+                    f"capabilities.{field_name} must be boolean"
+                )
+
+    @classmethod
+    def from_value(
+        cls,
+        value: OpenAICompletionsCapabilities | Mapping[str, Any],
+    ) -> OpenAICompletionsCapabilities:
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, Mapping):
+            raise ProviderContractError("capabilities must be an object")
+        allowed = set(cls.__dataclass_fields__)
+        unknown = sorted(str(key) for key in value if key not in allowed)
+        if unknown:
+            raise ProviderContractError(
+                f"capabilities contains unsupported fields: {', '.join(unknown)}"
+            )
+        return cls(**{str(key): item for key, item in value.items()})
+
+    def as_dict(self) -> dict[str, bool]:
+        return {
+            field_name: bool(getattr(self, field_name))
+            for field_name in self.__dataclass_fields__
+        }
+
+
+@dataclass(frozen=True)
+class OpenAICompletionsCompatibility:
+    """Compatibility contract that prevents implicit SDK/runtime behavior."""
+
+    api_variant: str = "chat_completions"
+    sdk_max_retries: int = 0
+    transport_max_retries: int = 0
+    provider_fallback: bool = False
+
+    def __post_init__(self) -> None:
+        if self.api_variant != "chat_completions":
+            raise ProviderContractError(
+                "compatibility.api_variant must be chat_completions"
+            )
+        _bounded_int(
+            self.sdk_max_retries,
+            "compatibility.sdk_max_retries",
+            minimum=0,
+            maximum=0,
+        )
+        _bounded_int(
+            self.transport_max_retries,
+            "compatibility.transport_max_retries",
+            minimum=0,
+            maximum=0,
+        )
+        if type(self.provider_fallback) is not bool or self.provider_fallback:
+            raise ProviderContractError("compatibility.provider_fallback must be false")
+
+    @classmethod
+    def from_value(
+        cls,
+        value: OpenAICompletionsCompatibility | Mapping[str, Any],
+    ) -> OpenAICompletionsCompatibility:
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, Mapping):
+            raise ProviderContractError("compatibility must be an object")
+        allowed = set(cls.__dataclass_fields__)
+        unknown = sorted(str(key) for key in value if key not in allowed)
+        if unknown:
+            raise ProviderContractError(
+                f"compatibility contains unsupported fields: {', '.join(unknown)}"
+            )
+        return cls(**{str(key): item for key, item in value.items()})
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "api_variant": self.api_variant,
+            "sdk_max_retries": self.sdk_max_retries,
+            "transport_max_retries": self.transport_max_retries,
+            "provider_fallback": self.provider_fallback,
+        }
+
+
+@dataclass(frozen=True)
+class OpenAICompletionsProviderProfile:
+    """Immutable, episode-scoped authority for one Chat Completions route."""
+
+    model: str
+    scoped_credential: str
+    base_url: str
+    context_window: int
+    max_output_tokens: int
+    sampling: OpenAICompletionsSampling | Mapping[str, Any] = field(
+        default_factory=OpenAICompletionsSampling
+    )
+    caller_headers: Mapping[str, str] = field(default_factory=dict)
+    capabilities: OpenAICompletionsCapabilities | Mapping[str, Any] = field(
+        default_factory=OpenAICompletionsCapabilities
+    )
+    compatibility: OpenAICompletionsCompatibility | Mapping[str, Any] = field(
+        default_factory=OpenAICompletionsCompatibility
+    )
+    provider_id: str = "openai"
+    runtime_id: str = "openai_chat"
+
+    def __post_init__(self) -> None:
+        _text(self.model, "profile.model", max_length=256)
+
+        base_url = _text(self.base_url, "profile.base_url", max_length=2048)
+        parsed = urlsplit(base_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ProviderContractError("profile.base_url must be an HTTP(S) URL")
+        if parsed.username is not None or parsed.password is not None:
+            raise ProviderContractError("profile.base_url must not contain credentials")
+        if parsed.query or parsed.fragment:
+            raise ProviderContractError(
+                "profile.base_url must not contain a query or fragment"
+            )
+        _text(
+            self.scoped_credential,
+            "profile.scoped_credential",
+            max_length=8192,
+        )
+        _bounded_int(
+            self.context_window,
+            "profile.context_window",
+            minimum=1,
+            maximum=2**31 - 1,
+        )
+        _bounded_int(
+            self.max_output_tokens,
+            "profile.max_output_tokens",
+            minimum=1,
+            maximum=2**31 - 1,
+        )
+        if self.max_output_tokens > self.context_window:
+            raise ProviderContractError(
+                "profile.max_output_tokens cannot exceed context_window"
+            )
+        object.__setattr__(
+            self, "sampling", OpenAICompletionsSampling.from_value(self.sampling)
+        )
+        object.__setattr__(
+            self,
+            "capabilities",
+            OpenAICompletionsCapabilities.from_value(self.capabilities),
+        )
+        object.__setattr__(
+            self,
+            "compatibility",
+            OpenAICompletionsCompatibility.from_value(self.compatibility),
+        )
+        if not isinstance(self.caller_headers, Mapping):
+            raise ProviderContractError("profile.caller_headers must be an object")
+        if len(self.caller_headers) > 128:
+            raise ProviderContractError(
+                "profile.caller_headers cannot contain more than 128 entries"
+            )
+        headers: dict[str, str] = {}
+        for key, value in self.caller_headers.items():
+            header_name = _text(key, "profile.caller_headers key", max_length=256)
+            header_value = _text(
+                value,
+                f"profile.caller_headers[{header_name!r}]",
+                max_length=8192,
+            )
+            if header_name.lower() in {existing.lower() for existing in headers}:
+                raise ProviderContractError(
+                    "profile.caller_headers contains duplicate names"
+                )
+            headers[header_name] = header_value
+        object.__setattr__(self, "caller_headers", MappingProxyType(headers))
+        _text(self.provider_id, "profile.provider_id", max_length=128)
+        _text(self.runtime_id, "profile.runtime_id", max_length=128)
+        if self.provider_id != "openai":
+            raise ProviderContractError("profile.provider_id must be openai")
+        if self.runtime_id != "openai_chat":
+            raise ProviderContractError("profile.runtime_id must be openai_chat")
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return deterministic, secret-free profile identity data."""
+        return self.identity_dict()
+
+    def identity_dict(self) -> dict[str, Any]:
+        """Return deterministic, secret-free profile identity data."""
+        safe_headers = {
+            name: redaction.REDACTED
+            for name in sorted(self.caller_headers, key=str.casefold)
+        }
+        return {
+            "base_url": self.base_url,
+            "caller_headers": safe_headers,
+            "capabilities": self.capabilities.as_dict(),
+            "compatibility": self.compatibility.as_dict(),
+            "context_window": self.context_window,
+            "max_output_tokens": self.max_output_tokens,
+            "model": self.model,
+            "provider_id": self.provider_id,
+            "runtime_id": self.runtime_id,
+            "sampling": self.sampling.as_dict(),
+        }
+
+    def identity_json(self) -> str:
+        """Return canonical JSON identity with no credential material."""
+        return canonical_json(self.identity_dict())
+
+    def chat_request(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+    ) -> dict[str, Any]:
+        """Build the exact streamed Chat Completions payload for this profile."""
+        if not isinstance(messages, list):
+            raise ProviderContractError("profile messages must be an array")
+        copied_messages = [dict(message) for message in messages]
+        request: dict[str, Any] = {
+            "model": self.model,
+            "messages": copied_messages,
+        }
+        if tools:
+            if not self.capabilities.supports_tools:
+                raise ProviderContractError("profile does not support tools")
+            copied_tools: list[dict[str, Any]] = []
+            for tool in tools:
+                copied = dict(tool)
+                function = copied.get("function")
+                if self.capabilities.supports_strict_tools and isinstance(
+                    function, Mapping
+                ):
+                    function_copy = dict(function)
+                    function_copy["strict"] = False
+                    copied["function"] = function_copy
+                copied_tools.append(copied)
+            request["tools"] = copied_tools
+        request["stream"] = True
+        if self.capabilities.supports_stream_options:
+            request["stream_options"] = {"include_usage": True}
+        if self.capabilities.supports_max_tokens:
+            request["max_tokens"] = self.max_output_tokens
+        if self.capabilities.supports_n:
+            request["n"] = self.sampling.n
+        for field_name in (
+            "temperature",
+            "top_p",
+            "seed",
+            "frequency_penalty",
+            "presence_penalty",
+        ):
+            value = getattr(self.sampling, field_name)
+            if value is not None:
+                request[field_name] = value
+        # Qwen's OpenAI-compatible endpoint recognizes this explicit control;
+        # unsupported endpoints omit it rather than sending an invalid field.
+        if self.capabilities.supports_thinking_control:
+            request["enable_thinking"] = False
+        if self.capabilities.supports_store:
+            request["store"] = False
+        return request
+
+
+__all__ = [
+    "OpenAICompletionsCapabilities",
+    "OpenAICompletionsCompatibility",
+    "OpenAICompletionsProviderProfile",
+    "OpenAICompletionsSampling",
+]

--- a/breadboard_engine/provider/profiles.py
+++ b/breadboard_engine/provider/profiles.py
@@ -7,6 +7,8 @@ credential material (or caller auth headers).
 
 from __future__ import annotations
 
+import hashlib
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
@@ -15,6 +17,37 @@ from urllib.parse import urlsplit
 
 from ..security import redaction
 from .contract_wire import ProviderContractError, canonical_json
+
+_EXACT_MODEL = "Qwen/Qwen3.5-35B-A3B"
+_EXACT_CONTEXT_WINDOW = 131_072
+_EXACT_MAX_OUTPUT_TOKENS = 32_000
+_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
+_RESERVED_CALLER_HEADERS = frozenset(
+    {
+        "accept",
+        "authorization",
+        "connection",
+        "content-length",
+        "content-type",
+        "cookie",
+        "host",
+        "keep-alive",
+        "proxy-authorization",
+        "set-cookie",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+_REQUIRED_CAPABILITIES = (
+    "supports_tools",
+    "supports_strict_tools",
+    "supports_stream_options",
+    "supports_thinking_control",
+    "supports_n",
+    "supports_max_tokens",
+)
 
 
 def _text(value: Any, field_name: str, *, max_length: int) -> str:
@@ -260,8 +293,9 @@ class OpenAICompletionsProviderProfile:
     runtime_id: str = "openai_chat"
 
     def __post_init__(self) -> None:
-        _text(self.model, "profile.model", max_length=256)
-
+        model = _text(self.model, "profile.model", max_length=256)
+        if model != _EXACT_MODEL:
+            raise ProviderContractError(f"profile.model must be {_EXACT_MODEL}")
         base_url = _text(self.base_url, "profile.base_url", max_length=2048)
         parsed = urlsplit(base_url)
         if parsed.scheme not in {"http", "https"} or not parsed.netloc:
@@ -277,21 +311,13 @@ class OpenAICompletionsProviderProfile:
             "profile.scoped_credential",
             max_length=8192,
         )
-        _bounded_int(
-            self.context_window,
-            "profile.context_window",
-            minimum=1,
-            maximum=2**31 - 1,
-        )
-        _bounded_int(
-            self.max_output_tokens,
-            "profile.max_output_tokens",
-            minimum=1,
-            maximum=2**31 - 1,
-        )
-        if self.max_output_tokens > self.context_window:
+        if self.context_window != _EXACT_CONTEXT_WINDOW:
             raise ProviderContractError(
-                "profile.max_output_tokens cannot exceed context_window"
+                f"profile.context_window must be {_EXACT_CONTEXT_WINDOW}"
+            )
+        if self.max_output_tokens != _EXACT_MAX_OUTPUT_TOKENS:
+            raise ProviderContractError(
+                f"profile.max_output_tokens must be {_EXACT_MAX_OUTPUT_TOKENS}"
             )
         object.__setattr__(
             self, "sampling", OpenAICompletionsSampling.from_value(self.sampling)
@@ -301,6 +327,11 @@ class OpenAICompletionsProviderProfile:
             "capabilities",
             OpenAICompletionsCapabilities.from_value(self.capabilities),
         )
+        for field_name in _REQUIRED_CAPABILITIES:
+            if not getattr(self.capabilities, field_name):
+                raise ProviderContractError(f"capabilities.{field_name} must be true")
+        if self.capabilities.supports_store:
+            raise ProviderContractError("capabilities.supports_store must be false")
         object.__setattr__(
             self,
             "compatibility",
@@ -315,12 +346,21 @@ class OpenAICompletionsProviderProfile:
         headers: dict[str, str] = {}
         for key, value in self.caller_headers.items():
             header_name = _text(key, "profile.caller_headers key", max_length=256)
+            normalized_name = header_name.casefold()
+            if (
+                _HEADER_NAME_RE.fullmatch(header_name) is None
+                or normalized_name in _RESERVED_CALLER_HEADERS
+                or redaction.is_secret_key(normalized_name)
+            ):
+                raise ProviderContractError(
+                    f"profile.caller_headers contains reserved header {header_name!r}"
+                )
             header_value = _text(
                 value,
                 f"profile.caller_headers[{header_name!r}]",
                 max_length=8192,
             )
-            if header_name.lower() in {existing.lower() for existing in headers}:
+            if normalized_name in {existing.casefold() for existing in headers}:
                 raise ProviderContractError(
                     "profile.caller_headers contains duplicate names"
                 )
@@ -339,13 +379,17 @@ class OpenAICompletionsProviderProfile:
 
     def identity_dict(self) -> dict[str, Any]:
         """Return deterministic, secret-free profile identity data."""
-        safe_headers = {
-            name: redaction.REDACTED
-            for name in sorted(self.caller_headers, key=str.casefold)
-        }
+        header_names = sorted(
+            (name.casefold() for name in self.caller_headers),
+        )
         return {
-            "base_url": self.base_url,
-            "caller_headers": safe_headers,
+            "base_url_sha256": hashlib.sha256(
+                self.base_url.encode("utf-8")
+            ).hexdigest(),
+            "caller_header_count": len(header_names),
+            "caller_header_names_sha256": hashlib.sha256(
+                canonical_json(header_names).encode("utf-8")
+            ).hexdigest(),
             "capabilities": self.capabilities.as_dict(),
             "compatibility": self.compatibility.as_dict(),
             "context_window": self.context_window,
@@ -366,35 +410,36 @@ class OpenAICompletionsProviderProfile:
         tools: list[dict[str, Any]] | None,
     ) -> dict[str, Any]:
         """Build the exact streamed Chat Completions payload for this profile."""
-        if not isinstance(messages, list):
-            raise ProviderContractError("profile messages must be an array")
+        if type(messages) is not list or any(
+            type(message) is not dict for message in messages
+        ):
+            raise ProviderContractError(
+                "profile messages must be an exact array of objects"
+            )
         copied_messages = [dict(message) for message in messages]
         request: dict[str, Any] = {
             "model": self.model,
             "messages": copied_messages,
         }
+        if tools is not None and type(tools) is not list:
+            raise ProviderContractError("profile tools must be an exact array")
         if tools:
-            if not self.capabilities.supports_tools:
-                raise ProviderContractError("profile does not support tools")
             copied_tools: list[dict[str, Any]] = []
             for tool in tools:
+                if type(tool) is not dict or type(tool.get("function")) is not dict:
+                    raise ProviderContractError(
+                        "profile tools must contain exact function objects"
+                    )
                 copied = dict(tool)
-                function = copied.get("function")
-                if self.capabilities.supports_strict_tools and isinstance(
-                    function, Mapping
-                ):
-                    function_copy = dict(function)
-                    function_copy["strict"] = False
-                    copied["function"] = function_copy
+                function_copy = dict(tool["function"])
+                function_copy["strict"] = False
+                copied["function"] = function_copy
                 copied_tools.append(copied)
             request["tools"] = copied_tools
         request["stream"] = True
-        if self.capabilities.supports_stream_options:
-            request["stream_options"] = {"include_usage": True}
-        if self.capabilities.supports_max_tokens:
-            request["max_tokens"] = self.max_output_tokens
-        if self.capabilities.supports_n:
-            request["n"] = self.sampling.n
+        request["stream_options"] = {"include_usage": True}
+        request["max_tokens"] = self.max_output_tokens
+        request["n"] = self.sampling.n
         for field_name in (
             "temperature",
             "top_p",
@@ -405,12 +450,7 @@ class OpenAICompletionsProviderProfile:
             value = getattr(self.sampling, field_name)
             if value is not None:
                 request[field_name] = value
-        # Qwen's OpenAI-compatible endpoint recognizes this explicit control;
-        # unsupported endpoints omit it rather than sending an invalid field.
-        if self.capabilities.supports_thinking_control:
-            request["enable_thinking"] = False
-        if self.capabilities.supports_store:
-            request["store"] = False
+        request["enable_thinking"] = False
         return request
 
 

--- a/breadboard_engine/provider/runtimes/openai/chat.py
+++ b/breadboard_engine/provider/runtimes/openai/chat.py
@@ -6,6 +6,7 @@ import os
 from typing import Any, Dict, List, Optional, Tuple
 
 from ...contracts import (
+    OpenAICompletionsProviderProfile,
     ProviderMessage,
     ProviderResult,
     ProviderRuntimeContext,
@@ -44,6 +45,24 @@ class OpenAIChatRuntime(OpenAIBaseRuntime):
                 pass
         return provider_sdk_bindings.openai(**kwargs)
 
+    def create_client_from_profile(
+        self, profile: OpenAICompletionsProviderProfile
+    ) -> Any:
+        """Create a zero-retry SDK client from one immutable episode profile."""
+        if not isinstance(profile, OpenAICompletionsProviderProfile):
+            raise ProviderRuntimeError(
+                "OpenAI Chat profile is invalid",
+                kind="configuration",
+                details={"code": "invalid_provider_profile"},
+            )
+        self._require_openai()
+        return provider_sdk_bindings.openai(
+            api_key=profile.scoped_credential,
+            base_url=profile.base_url,
+            default_headers=dict(profile.caller_headers),
+            max_retries=0,
+        )
+
     def _stream_chat_completion(
         self,
         client: Any,
@@ -76,25 +95,54 @@ class OpenAIChatRuntime(OpenAIBaseRuntime):
         context: ProviderRuntimeContext,
     ) -> ProviderResult:
         context.raise_if_cancelled()
+        profile = context.provider_profile
         request_messages = self._convert_messages_to_chat(
             messages, context=context
         )
         request_tools = self._convert_tools_to_openai(tools)
-        extra_body: Optional[Dict[str, Any]] = None
-        if (
-            self.descriptor.provider_id == "openrouter"
-            and isinstance(model, str)
-            and model.startswith("openai/gpt-5")
-        ):
-            # Force provider routing away from Azure for GPT-5 OpenAI models on OpenRouter,
-            # since some upstreams reject tool outputs.
-            extra_body = {"provider": {"order": ["openai"], "allow_fallbacks": False}}
-        role_request, role_extra_body = openai_chat_role_options(
-            context,
-            provider_id=self.descriptor.provider_id,
-        )
-        if role_extra_body:
-            extra_body = {**(extra_body or {}), **role_extra_body}
+        if profile is not None:
+            if not stream:
+                raise ProviderRuntimeError(
+                    "OpenAI Completions profile requires streaming",
+                    kind="configuration",
+                    details={"code": "profile_requires_streaming"},
+                )
+            if model != profile.model:
+                raise ProviderRuntimeError(
+                    "OpenAI Completions profile model does not match invocation",
+                    kind="configuration",
+                    details={"code": "profile_model_mismatch"},
+                )
+            profile_request = profile.chat_request(request_messages, request_tools)
+            profile_request.pop("model")
+            profile_request.pop("messages")
+            profile_request.pop("stream")
+            request_tools = profile_request.pop("tools", None)
+            thinking_control = profile_request.pop("enable_thinking", None)
+            extra_body = (
+                {"enable_thinking": thinking_control}
+                if thinking_control is not None
+                else None
+            )
+            role_request = profile_request
+        else:
+            extra_body: Optional[Dict[str, Any]] = None
+            if (
+                self.descriptor.provider_id == "openrouter"
+                and isinstance(model, str)
+                and model.startswith("openai/gpt-5")
+            ):
+                # Force provider routing away from Azure for GPT-5 OpenAI models on OpenRouter,
+                # since some upstreams reject tool outputs.
+                extra_body = {
+                    "provider": {"order": ["openai"], "allow_fallbacks": False}
+                }
+            role_request, role_extra_body = openai_chat_role_options(
+                context,
+                provider_id=self.descriptor.provider_id,
+            )
+            if role_extra_body:
+                extra_body = {**(extra_body or {}), **role_extra_body}
 
         response: Any = None
         streamed_reasoning: Dict[int, Dict[str, Any]] = {}

--- a/breadboard_engine/provider/runtimes/openai/chat.py
+++ b/breadboard_engine/provider/runtimes/openai/chat.py
@@ -12,6 +12,7 @@ from ...contracts import (
     ProviderResult,
     ProviderRuntimeContext,
     ProviderRuntimeError,
+    sanitize_provider_result,
 )
 from ...model_role_options import openai_chat_role_options
 from ...sdk_bindings import provider_sdk_bindings
@@ -129,13 +130,15 @@ class OpenAIChatRuntime(OpenAIBaseRuntime):
             *profile.caller_headers.values(),
             allow_short=True,
         ):
-            return self._invoke(
-                client=client,
-                model=model,
-                messages=messages,
-                tools=tools,
-                stream=stream,
-                context=context,
+            return sanitize_provider_result(
+                self._invoke(
+                    client=client,
+                    model=model,
+                    messages=messages,
+                    tools=tools,
+                    stream=stream,
+                    context=context,
+                )
             )
 
     def _invoke(

--- a/breadboard_engine/provider/runtimes/openai/chat.py
+++ b/breadboard_engine/provider/runtimes/openai/chat.py
@@ -145,6 +145,20 @@ class OpenAIChatRuntime(OpenAIBaseRuntime):
                 )
             )
 
+    def profile_chat_request(
+        self,
+        profile: OpenAICompletionsProviderProfile,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]],
+        *,
+        context: ProviderRuntimeContext,
+    ) -> Dict[str, Any]:
+        """Project the exact request used by a profile-bound invocation."""
+        return profile.chat_request(
+            self._convert_messages_to_chat(messages, context=context),
+            self._convert_tools_to_openai(tools),
+        )
+
     def _invoke(
         self,
         *,
@@ -157,10 +171,20 @@ class OpenAIChatRuntime(OpenAIBaseRuntime):
     ) -> ProviderResult:
         context.raise_if_cancelled()
         profile = context.provider_profile
-        request_messages = self._convert_messages_to_chat(
-            messages, context=context
-        )
-        request_tools = self._convert_tools_to_openai(tools)
+        if profile is not None:
+            profile_request = self.profile_chat_request(
+                profile,
+                messages,
+                tools,
+                context=context,
+            )
+            request_messages = profile_request["messages"]
+            request_tools = profile_request.get("tools")
+        else:
+            request_messages = self._convert_messages_to_chat(
+                messages, context=context
+            )
+            request_tools = self._convert_tools_to_openai(tools)
         if profile is not None:
             if not isinstance(client, _ProfileClient) or client.profile is not profile:
                 raise ProviderRuntimeError(

--- a/breadboard_engine/provider/runtimes/openai/chat.py
+++ b/breadboard_engine/provider/runtimes/openai/chat.py
@@ -25,6 +25,10 @@ from .chat_stream_decoder import OpenAIChatStreamDecoder
 class _ProfileClient:
     transport: Any
     profile: OpenAICompletionsProviderProfile
+    def close(self) -> None:
+        close = getattr(self.transport, "close", None)
+        if callable(close):
+            close()
 
 
 class OpenAIChatRuntime(OpenAIBaseRuntime):

--- a/breadboard_engine/provider/runtimes/openai/chat.py
+++ b/breadboard_engine/provider/runtimes/openai/chat.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 from ...contracts import (
@@ -17,6 +18,12 @@ from ...sdk_bindings import provider_sdk_bindings
 from ....security import redaction
 from .streaming import OpenAIBaseRuntime
 from .chat_stream_decoder import OpenAIChatStreamDecoder
+
+
+@dataclass(frozen=True, slots=True)
+class _ProfileClient:
+    transport: Any
+    profile: OpenAICompletionsProviderProfile
 
 
 class OpenAIChatRuntime(OpenAIBaseRuntime):
@@ -56,12 +63,25 @@ class OpenAIChatRuntime(OpenAIBaseRuntime):
                 details={"code": "invalid_provider_profile"},
             )
         self._require_openai()
-        return provider_sdk_bindings.openai(
-            api_key=profile.scoped_credential,
-            base_url=profile.base_url,
-            default_headers=dict(profile.caller_headers),
-            max_retries=0,
-        )
+        with redaction.secret_value_scope(
+            profile.scoped_credential,
+            *profile.caller_headers.values(),
+            allow_short=True,
+        ):
+            try:
+                transport = provider_sdk_bindings.openai(
+                    api_key=profile.scoped_credential,
+                    base_url=profile.base_url,
+                    default_headers=dict(profile.caller_headers),
+                    max_retries=0,
+                )
+            except Exception as exc:
+                raise ProviderRuntimeError(
+                    redaction.safe_exception_message(exc),
+                    kind="configuration",
+                    details={"code": "profile_client_creation_failed"},
+                ) from None
+        return _ProfileClient(transport, profile)
 
     def _stream_chat_completion(
         self,
@@ -94,6 +114,40 @@ class OpenAIChatRuntime(OpenAIBaseRuntime):
         stream: bool,
         context: ProviderRuntimeContext,
     ) -> ProviderResult:
+        profile = context.provider_profile
+        if profile is None:
+            return self._invoke(
+                client=client,
+                model=model,
+                messages=messages,
+                tools=tools,
+                stream=stream,
+                context=context,
+            )
+        with redaction.secret_value_scope(
+            profile.scoped_credential,
+            *profile.caller_headers.values(),
+            allow_short=True,
+        ):
+            return self._invoke(
+                client=client,
+                model=model,
+                messages=messages,
+                tools=tools,
+                stream=stream,
+                context=context,
+            )
+
+    def _invoke(
+        self,
+        *,
+        client: Any,
+        model: str,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]],
+        stream: bool,
+        context: ProviderRuntimeContext,
+    ) -> ProviderResult:
         context.raise_if_cancelled()
         profile = context.provider_profile
         request_messages = self._convert_messages_to_chat(
@@ -101,6 +155,13 @@ class OpenAIChatRuntime(OpenAIBaseRuntime):
         )
         request_tools = self._convert_tools_to_openai(tools)
         if profile is not None:
+            if not isinstance(client, _ProfileClient) or client.profile is not profile:
+                raise ProviderRuntimeError(
+                    "OpenAI Completions profile client does not match the episode",
+                    kind="configuration",
+                    details={"code": "profile_client_mismatch"},
+                )
+            client = client.transport
             if not stream:
                 raise ProviderRuntimeError(
                     "OpenAI Completions profile requires streaming",
@@ -125,6 +186,12 @@ class OpenAIChatRuntime(OpenAIBaseRuntime):
                 else None
             )
             role_request = profile_request
+        elif isinstance(client, _ProfileClient):
+            raise ProviderRuntimeError(
+                "OpenAI Completions profile client requires its episode profile",
+                kind="configuration",
+                details={"code": "profile_context_missing"},
+            )
         else:
             extra_body: Optional[Dict[str, Any]] = None
             if (

--- a/breadboard_engine/provider/runtimes/openai/chat_stream_decoder.py
+++ b/breadboard_engine/provider/runtimes/openai/chat_stream_decoder.py
@@ -12,6 +12,22 @@ from ...contracts import (
 )
 from ....security import redaction
 
+_OPENAI_DERIVED_CHAT_EVENT_TYPES = frozenset(
+    {
+        "content.delta",
+        "content.done",
+        "tool_calls.function.arguments.delta",
+        "tool_calls.function.arguments.done",
+        "logprobs.content.delta",
+        "logprobs.content.done",
+        "logprobs.refusal.delta",
+        "logprobs.refusal.done",
+        "refusal.delta",
+        "refusal.done",
+    }
+)
+
+
 
 class _ChatStreamHost(Protocol):
     """OpenAIBaseRuntime operations needed by the decoder."""
@@ -351,6 +367,8 @@ class OpenAIChatStreamDecoder:
         state: _ChatStreamState,
     ) -> None:
         event_type = self._host._get_attr(event, "type")
+        if event_type in _OPENAI_DERIVED_CHAT_EVENT_TYPES:
+            return
         chunk = (
             self._host._get_attr(event, "chunk")
             if event_type == "chunk"

--- a/breadboard_engine/provider/runtimes/openai/streaming.py
+++ b/breadboard_engine/provider/runtimes/openai/streaming.py
@@ -1029,6 +1029,17 @@ class OpenAIBaseRuntime(OpenAIConversionMixin, ProviderRuntime):
         record: bool = True,
     ) -> None:
         """Capture provider events before projecting them to SessionState."""
+        payload, _redaction_problems = redaction.scrub_structure(
+            payload,
+            path="$.provider_event",
+        )
+        if not isinstance(payload, dict):
+            raise ProviderRuntimeError(
+                "Provider event payload is invalid",
+                kind="protocol",
+                output_emitted=True,
+                details={"code": "invalid_provider_event"},
+            )
         recorder = getattr(context, "exchange_recorder", None)
         if recorder is not None and record:
             mapping = {

--- a/breadboard_engine/state/session_state.py
+++ b/breadboard_engine/state/session_state.py
@@ -122,10 +122,12 @@ class SessionState:
         event_emitter: Optional[Callable[[str, Dict[str, Any], Optional[int]], None]] = None,
         kernel_emitter: Optional[Any] = None,
         clock: Optional[Callable[[], str]] = None,
+        episode_provider_profile: Optional[Any] = None,
     ):
         self.workspace = workspace
         self.image = image
         self.config = config or {}
+        self._episode_provider_profile = episode_provider_profile
         self.messages: List[Dict[str, Any]] = []
         self.provider_messages: List[Dict[str, Any]] = []
         self.transcript: List[Dict[str, Any]] = []

--- a/breadboard_engine/state/session_state.py
+++ b/breadboard_engine/state/session_state.py
@@ -128,6 +128,7 @@ class SessionState:
         self.image = image
         self.config = config or {}
         self._episode_provider_profile = episode_provider_profile
+        self._episode_provider_client: Optional[Any] = None
         self.messages: List[Dict[str, Any]] = []
         self.provider_messages: List[Dict[str, Any]] = []
         self.transcript: List[Dict[str, Any]] = []

--- a/tests/providers/test_openai_profile.py
+++ b/tests/providers/test_openai_profile.py
@@ -387,6 +387,9 @@ def test_setup_failure_does_not_retain_provider_profile(tmp_path):
         config={},
         local_mode=True,
     )
+    conductor._ensure_capability_probes = lambda *_args: (_ for _ in ()).throw(
+        AssertionError("profile-bound episodes must not perform capability probes")
+    )
 
     with pytest.raises(AttributeError):
         conductor.run_agentic_loop(

--- a/tests/providers/test_openai_profile.py
+++ b/tests/providers/test_openai_profile.py
@@ -4,12 +4,14 @@ import types
 
 import pytest
 
+from breadboard_engine.conductor.modes import _bind_episode_provider_profile
 from breadboard_engine.provider import sdk_bindings
 from breadboard_engine.provider.contracts import (
     OpenAICompletionsCapabilities,
     OpenAICompletionsProviderProfile,
     ProviderContractError,
     ProviderRuntimeContext,
+    ProviderRuntimeError,
 )
 from breadboard_engine.provider.routing import ProviderDescriptor
 from breadboard_engine.provider.runtimes.openai import OpenAIChatRuntime
@@ -24,10 +26,28 @@ def _profile(**overrides):
         "scoped_credential": "episode-secret",
         "context_window": 131072,
         "max_output_tokens": 32000,
-        "caller_headers": {"X-Episode": "one", "Authorization": "Bearer secret"},
+        "caller_headers": {"X-Request-ID": "episode-one"},
     }
     values.update(overrides)
     return OpenAICompletionsProviderProfile(**values)
+
+
+def _runtime():
+    return OpenAIChatRuntime(
+        ProviderDescriptor(
+            provider_id="openai",
+            runtime_id="openai_chat",
+            default_api_variant="chat",
+            supports_native_tools=True,
+            supports_streaming=True,
+            supports_reasoning_traces=True,
+            supports_cache_control=False,
+            tool_schema_format="openai",
+            base_url=None,
+            api_key_env=None,
+            default_headers={},
+        )
+    )
 
 
 def test_profile_builds_exact_qwen_stream_request_without_fallback():
@@ -76,21 +96,7 @@ def test_profile_builds_exact_qwen_stream_request_without_fallback():
 
 def test_profile_projects_exact_sdk_stream_request(monkeypatch):
     profile = _profile(sampling={"temperature": 0.2})
-    runtime = OpenAIChatRuntime(
-        ProviderDescriptor(
-            provider_id="openai",
-            runtime_id="openai_chat",
-            default_api_variant="chat",
-            supports_native_tools=True,
-            supports_streaming=True,
-            supports_reasoning_traces=True,
-            supports_cache_control=False,
-            tool_schema_format="openai",
-            base_url=None,
-            api_key_env=None,
-            default_headers={},
-        )
-    )
+    runtime = _runtime()
     captured = {}
 
     def fake_stream(_client, **kwargs):
@@ -112,9 +118,15 @@ def test_profile_projects_exact_sdk_stream_request(monkeypatch):
         return response, {}
 
     monkeypatch.setattr(runtime, "_stream_chat_completion", fake_stream)
+    monkeypatch.setattr(
+        sdk_bindings.provider_sdk_bindings,
+        "openai",
+        lambda **_kwargs: object(),
+    )
+    client = runtime.create_client_from_profile(profile)
     context = ProviderRuntimeContext(None, {}, stream=True, provider_profile=profile)
     result = runtime.invoke(
-        client=object(),
+        client=client,
         model=MODEL,
         messages=[{"role": "user", "content": "hi"}],
         tools=None,
@@ -136,23 +148,22 @@ def test_profile_projects_exact_sdk_stream_request(monkeypatch):
 
 def test_profile_identity_is_deterministic_and_secret_free():
     first = _profile(
-        caller_headers={
-            "Authorization": "Bearer episode-secret",
-            "X-Custom": "also-secret",
-        }
+        base_url="https://episode-secret.provider.example/v1",
+        caller_headers={"X-Custom-Trace": "also-secret"},
     )
     second = _profile(
-        caller_headers={
-            "Authorization": "Bearer episode-secret",
-            "X-Custom": "also-secret",
-        }
+        base_url="https://episode-secret.provider.example/v1",
+        caller_headers={"X-Custom-Trace": "also-secret"},
     )
     identity = first.identity_dict()
     assert first.identity_json() == second.identity_json()
     assert "episode-secret" not in first.identity_json()
     assert "also-secret" not in first.identity_json()
     assert "scoped_credential" not in identity
-    assert set(identity["caller_headers"].values()) == {"***REDACTED***"}
+    assert "base_url" not in identity
+    assert "caller_headers" not in identity
+    assert identity["base_url_sha256"]
+    assert identity["caller_header_names_sha256"]
 
 
 def test_profile_rejects_nonzero_retry_and_unsupported_tools():
@@ -162,17 +173,27 @@ def test_profile_rejects_nonzero_retry_and_unsupported_tools():
         _profile(scoped_credential="")
     with pytest.raises(ProviderContractError):
         _profile(base_url="https://provider.example/v1?api_key=secret")
-    profile = _profile(
-        capabilities=OpenAICompletionsCapabilities(
-            supports_tools=False,
-            supports_strict_tools=False,
-            supports_stream_options=True,
-            supports_thinking_control=True,
-            supports_store=False,
-            supports_n=True,
-            supports_max_tokens=True,
+    with pytest.raises(ProviderContractError):
+        _profile(
+            capabilities=OpenAICompletionsCapabilities(
+                supports_tools=False,
+                supports_strict_tools=True,
+                supports_stream_options=True,
+                supports_thinking_control=True,
+                supports_store=False,
+                supports_n=True,
+                supports_max_tokens=True,
+            )
         )
-    )
+    with pytest.raises(ProviderContractError):
+        _profile(caller_headers={"Authorization": "Bearer override"})
+    with pytest.raises(ProviderContractError):
+        _profile(caller_headers={"Host": "attacker.example"})
+    with pytest.raises(ProviderContractError):
+        _profile(context_window=1)
+    profile = _profile()
+    with pytest.raises(ProviderContractError):
+        profile.chat_request([("user", "bad")], None)
     with pytest.raises(ProviderContractError):
         profile.chat_request([], [{"type": "function"}])
 
@@ -185,25 +206,63 @@ def test_profile_client_sets_sdk_retries_to_zero(monkeypatch):
             captured.update(kwargs)
 
     monkeypatch.setattr(sdk_bindings.provider_sdk_bindings, "openai", FakeOpenAI)
-    runtime = OpenAIChatRuntime(
-        ProviderDescriptor(
-            provider_id="openai",
-            runtime_id="openai_chat",
-            default_api_variant="chat",
-            supports_native_tools=True,
-            supports_streaming=True,
-            supports_reasoning_traces=True,
-            supports_cache_control=False,
-            tool_schema_format="openai",
-            base_url=None,
-            api_key_env=None,
-            default_headers={},
-        )
-    )
+    runtime = _runtime()
     runtime.create_client_from_profile(_profile())
     assert captured["api_key"] == "episode-secret"
     assert captured["base_url"] == "http://127.0.0.1:8111/v1"
     assert captured["max_retries"] == 0
+    assert "Authorization" not in captured["default_headers"]
+
+
+def test_profile_binds_production_runtime_client(monkeypatch):
+    transport = object()
+    monkeypatch.setattr(
+        sdk_bindings.provider_sdk_bindings,
+        "openai",
+        lambda **_kwargs: transport,
+    )
+    profile = _profile()
+    client, stream, bound_profile = _bind_episode_provider_profile(
+        types.SimpleNamespace(_provider_profile=profile),
+        _runtime(),
+        object(),
+        MODEL,
+        False,
+    )
+
+    assert stream is True
+    assert bound_profile is profile
+    assert client.transport is transport
+    assert client.profile is profile
+
+
+def test_profile_client_is_bound_to_one_episode(monkeypatch):
+    monkeypatch.setattr(
+        sdk_bindings.provider_sdk_bindings,
+        "openai",
+        lambda **_kwargs: object(),
+    )
+    runtime = _runtime()
+    first = _profile(base_url="http://127.0.0.1:8111/v1", scoped_credential="one")
+    second = _profile(base_url="http://127.0.0.1:8222/v1", scoped_credential="two")
+    first_client = runtime.create_client_from_profile(first)
+
+    with pytest.raises(ProviderRuntimeError) as exc_info:
+        runtime.invoke(
+            client=first_client,
+            model=MODEL,
+            messages=[],
+            tools=None,
+            stream=True,
+            context=ProviderRuntimeContext(
+                None,
+                {},
+                stream=True,
+                provider_profile=second,
+            ),
+        )
+
+    assert exc_info.value.safe_code == "profile_client_mismatch"
 
 
 def test_context_profile_is_episode_scoped():

--- a/tests/providers/test_openai_profile.py
+++ b/tests/providers/test_openai_profile.py
@@ -378,3 +378,28 @@ def test_rejected_episode_does_not_retain_provider_profile():
         )
 
     assert conductor._active_session_state is None
+
+
+def test_setup_failure_does_not_retain_provider_profile(tmp_path):
+    conductor_class = OpenAIConductor.__ray_metadata__.modified_class
+    conductor = conductor_class(
+        workspace=str(tmp_path / "workspace"),
+        config={},
+        local_mode=True,
+    )
+
+    with pytest.raises(AttributeError):
+        conductor.run_agentic_loop(
+            "",
+            "",
+            MODEL,
+            completion_config="invalid",
+            context={
+                "session_id": "session",
+                "input_id": "input",
+                "turn_id": "turn",
+            },
+            provider_profile=_profile(),
+        )
+
+    assert conductor._active_session_state is None

--- a/tests/providers/test_openai_profile.py
+++ b/tests/providers/test_openai_profile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pickle
 import types
 
 import pytest
@@ -280,3 +281,13 @@ def test_context_profile_is_episode_scoped():
         first_context.provider_profile.scoped_credential
         != second_context.provider_profile.scoped_credential
     )
+
+
+def test_profile_is_pickle_safe_for_ray_actor_admission():
+    profile = _profile()
+
+    restored = pickle.loads(pickle.dumps(profile))
+
+    assert restored == profile
+    assert dict(restored.caller_headers) == {"X-Request-ID": "episode-one"}
+    assert restored.scoped_credential == "episode-secret"

--- a/tests/providers/test_openai_profile.py
+++ b/tests/providers/test_openai_profile.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from breadboard_engine.provider import sdk_bindings
+from breadboard_engine.provider.contracts import (
+    OpenAICompletionsCapabilities,
+    OpenAICompletionsProviderProfile,
+    ProviderContractError,
+    ProviderRuntimeContext,
+)
+from breadboard_engine.provider.routing import ProviderDescriptor
+from breadboard_engine.provider.runtimes.openai import OpenAIChatRuntime
+
+MODEL = "Qwen/Qwen3.5-35B-A3B"
+
+
+def _profile(**overrides):
+    values = {
+        "base_url": "http://127.0.0.1:8111/v1",
+        "model": MODEL,
+        "scoped_credential": "episode-secret",
+        "context_window": 131072,
+        "max_output_tokens": 32000,
+        "caller_headers": {"X-Episode": "one", "Authorization": "Bearer secret"},
+    }
+    values.update(overrides)
+    return OpenAICompletionsProviderProfile(**values)
+
+
+def test_profile_builds_exact_qwen_stream_request_without_fallback():
+    profile = _profile(sampling={"temperature": 0.2})
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "read",
+                "description": "Read a file",
+                "parameters": {"type": "object"},
+            },
+        }
+    ]
+    request = profile.chat_request(
+        [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}],
+        tools,
+    )
+    assert request == {
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+        ],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "read",
+                    "description": "Read a file",
+                    "parameters": {"type": "object"},
+                    "strict": False,
+                },
+            }
+        ],
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "max_tokens": 32000,
+        "n": 1,
+        "temperature": 0.2,
+        "enable_thinking": False,
+    }
+    assert "store" not in request
+    assert "provider" not in request
+
+
+def test_profile_projects_exact_sdk_stream_request(monkeypatch):
+    profile = _profile(sampling={"temperature": 0.2})
+    runtime = OpenAIChatRuntime(
+        ProviderDescriptor(
+            provider_id="openai",
+            runtime_id="openai_chat",
+            default_api_variant="chat",
+            supports_native_tools=True,
+            supports_streaming=True,
+            supports_reasoning_traces=True,
+            supports_cache_control=False,
+            tool_schema_format="openai",
+            base_url=None,
+            api_key_env=None,
+            default_headers={},
+        )
+    )
+    captured = {}
+
+    def fake_stream(_client, **kwargs):
+        captured.update(kwargs)
+        response = types.SimpleNamespace(
+            id="chatcmpl-profile",
+            choices=[
+                types.SimpleNamespace(
+                    index=0,
+                    message={"role": "assistant", "content": "done", "tool_calls": []},
+                    finish_reason="stop",
+                    logprobs=None,
+                    error=None,
+                )
+            ],
+            model=MODEL,
+            usage={"prompt_tokens": 2, "completion_tokens": 1},
+        )
+        return response, {}
+
+    monkeypatch.setattr(runtime, "_stream_chat_completion", fake_stream)
+    context = ProviderRuntimeContext(None, {}, stream=True, provider_profile=profile)
+    result = runtime.invoke(
+        client=object(),
+        model=MODEL,
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        stream=True,
+        context=context,
+    )
+
+    assert captured["request_options"] == {
+        "stream_options": {"include_usage": True},
+        "max_tokens": 32000,
+        "n": 1,
+        "temperature": 0.2,
+    }
+    assert captured["extra_body"] == {"enable_thinking": False}
+    assert "stream" not in captured["request_options"]
+    assert "enable_thinking" not in captured["request_options"]
+    assert result.messages[0].content == "done"
+
+
+def test_profile_identity_is_deterministic_and_secret_free():
+    first = _profile(
+        caller_headers={
+            "Authorization": "Bearer episode-secret",
+            "X-Custom": "also-secret",
+        }
+    )
+    second = _profile(
+        caller_headers={
+            "Authorization": "Bearer episode-secret",
+            "X-Custom": "also-secret",
+        }
+    )
+    identity = first.identity_dict()
+    assert first.identity_json() == second.identity_json()
+    assert "episode-secret" not in first.identity_json()
+    assert "also-secret" not in first.identity_json()
+    assert "scoped_credential" not in identity
+    assert set(identity["caller_headers"].values()) == {"***REDACTED***"}
+
+
+def test_profile_rejects_nonzero_retry_and_unsupported_tools():
+    with pytest.raises(ProviderContractError):
+        _profile(compatibility={"sdk_max_retries": 1})
+    with pytest.raises(ProviderContractError):
+        _profile(scoped_credential="")
+    with pytest.raises(ProviderContractError):
+        _profile(base_url="https://provider.example/v1?api_key=secret")
+    profile = _profile(
+        capabilities=OpenAICompletionsCapabilities(
+            supports_tools=False,
+            supports_strict_tools=False,
+            supports_stream_options=True,
+            supports_thinking_control=True,
+            supports_store=False,
+            supports_n=True,
+            supports_max_tokens=True,
+        )
+    )
+    with pytest.raises(ProviderContractError):
+        profile.chat_request([], [{"type": "function"}])
+
+
+def test_profile_client_sets_sdk_retries_to_zero(monkeypatch):
+    captured = {}
+
+    class FakeOpenAI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(sdk_bindings.provider_sdk_bindings, "openai", FakeOpenAI)
+    runtime = OpenAIChatRuntime(
+        ProviderDescriptor(
+            provider_id="openai",
+            runtime_id="openai_chat",
+            default_api_variant="chat",
+            supports_native_tools=True,
+            supports_streaming=True,
+            supports_reasoning_traces=True,
+            supports_cache_control=False,
+            tool_schema_format="openai",
+            base_url=None,
+            api_key_env=None,
+            default_headers={},
+        )
+    )
+    runtime.create_client_from_profile(_profile())
+    assert captured["api_key"] == "episode-secret"
+    assert captured["base_url"] == "http://127.0.0.1:8111/v1"
+    assert captured["max_retries"] == 0
+
+
+def test_context_profile_is_episode_scoped():
+    first = _profile(base_url="http://127.0.0.1:8111/v1", scoped_credential="one")
+    second = _profile(base_url="http://127.0.0.1:8222/v1", scoped_credential="two")
+    first_context = ProviderRuntimeContext(None, {}, provider_profile=first)
+    second_context = ProviderRuntimeContext(None, {}, provider_profile=second)
+    assert first_context.provider_profile is first
+    assert second_context.provider_profile is second
+    assert (
+        first_context.provider_profile.base_url
+        != second_context.provider_profile.base_url
+    )
+    assert (
+        first_context.provider_profile.scoped_credential
+        != second_context.provider_profile.scoped_credential
+    )

--- a/tests/providers/test_openai_profile.py
+++ b/tests/providers/test_openai_profile.py
@@ -11,6 +11,8 @@ from breadboard_engine.provider.contracts import (
     OpenAICompletionsCapabilities,
     OpenAICompletionsProviderProfile,
     ProviderContractError,
+    ProviderMessage,
+    ProviderResult,
     ProviderRuntimeContext,
     ProviderRuntimeError,
 )
@@ -224,7 +226,7 @@ def test_profile_binds_production_runtime_client(monkeypatch):
     )
     profile = _profile()
     client, stream, bound_profile = _bind_episode_provider_profile(
-        types.SimpleNamespace(_provider_profile=profile),
+        types.SimpleNamespace(_episode_provider_profile=profile),
         _runtime(),
         object(),
         MODEL,
@@ -235,6 +237,37 @@ def test_profile_binds_production_runtime_client(monkeypatch):
     assert bound_profile is profile
     assert client.transport is transport
     assert client.profile is profile
+
+
+def test_profile_binding_is_scoped_to_each_episode(monkeypatch):
+    monkeypatch.setattr(
+        sdk_bindings.provider_sdk_bindings,
+        "openai",
+        lambda **_kwargs: object(),
+    )
+    runtime = _runtime()
+    first = _profile(scoped_credential="first-secret")
+    second = _profile(scoped_credential="second-secret")
+
+    first_client, _, first_bound = _bind_episode_provider_profile(
+        types.SimpleNamespace(_episode_provider_profile=first),
+        runtime,
+        object(),
+        MODEL,
+        False,
+    )
+    second_client, _, second_bound = _bind_episode_provider_profile(
+        types.SimpleNamespace(_episode_provider_profile=second),
+        runtime,
+        object(),
+        MODEL,
+        False,
+    )
+
+    assert first_bound is first
+    assert first_client.profile is first
+    assert second_bound is second
+    assert second_client.profile is second
 
 
 def test_profile_client_is_bound_to_one_episode(monkeypatch):
@@ -291,3 +324,39 @@ def test_profile_is_pickle_safe_for_ray_actor_admission():
     assert restored == profile
     assert dict(restored.caller_headers) == {"X-Request-ID": "episode-one"}
     assert restored.scoped_credential == "episode-secret"
+
+
+def test_profile_response_is_sanitized_inside_secret_scope(monkeypatch):
+    profile = _profile(caller_headers={"X-Request-ID": "caller-secret"})
+    runtime = _runtime()
+    monkeypatch.setattr(
+        runtime,
+        "_invoke",
+        lambda **_kwargs: ProviderResult(
+            messages=[
+                ProviderMessage(
+                    role="assistant",
+                    content="episode-secret caller-secret",
+                )
+            ],
+            raw_response={"echo": "episode-secret caller-secret"},
+        ),
+    )
+
+    result = runtime.invoke(
+        client=object(),
+        model=MODEL,
+        messages=[],
+        tools=None,
+        stream=True,
+        context=ProviderRuntimeContext(
+            None,
+            {},
+            stream=True,
+            provider_profile=profile,
+        ),
+    )
+
+    rendered = repr(result)
+    assert "episode-secret" not in rendered
+    assert "caller-secret" not in rendered

--- a/tests/providers/test_openai_profile.py
+++ b/tests/providers/test_openai_profile.py
@@ -5,6 +5,7 @@ import types
 
 import pytest
 
+from breadboard.product.runtime.artifacts import ArtifactStore
 from breadboard_engine.agent_llm_openai import OpenAIConductor
 from breadboard_engine.conductor.modes import (
     _bind_episode_provider_profile,
@@ -436,9 +437,12 @@ def test_profile_wire_evidence_records_exact_authoritative_request():
             },
         }
     ]
+    runtime = _runtime()
+    context = ProviderRuntimeContext(None, {}, provider_profile=profile)
 
     body, headers, endpoint, identity = _provider_wire_evidence(
         profile=profile,
+        runtime=runtime,
         provider_id="openai",
         model=MODEL,
         messages=messages,
@@ -448,6 +452,7 @@ def test_profile_wire_evidence_records_exact_authoritative_request():
             "base_url": "https://wrong.example/v1",
             "default_headers": {"X-Wrong": "wrong"},
         },
+        context=context,
     )
 
     assert body == profile.chat_request(messages, tools)
@@ -486,8 +491,11 @@ def test_profile_wire_evidence_redacts_echoes_and_raw_endpoint(
         caller_headers={"X-Request-ID": header_value},
     )
 
+    runtime = _runtime()
+    context = ProviderRuntimeContext(None, {}, provider_profile=profile)
     evidence = _provider_wire_evidence(
         profile=profile,
+        runtime=runtime,
         provider_id="openai",
         model=MODEL,
         messages=[{"role": "user", "content": f"{credential} {header_value}"}],
@@ -503,12 +511,84 @@ def test_profile_wire_evidence_redacts_echoes_and_raw_endpoint(
         ],
         stream=True,
         client_config={},
+        context=context,
     )
 
     assert credential not in repr(evidence[0])
     assert header_value not in repr(evidence[0])
     assert profile.base_url not in repr(evidence)
     assert evidence[2] == f"sha256:{profile.identity_dict()['base_url_sha256']}"
+
+
+def test_profile_wire_evidence_matches_media_and_tool_result_projection(tmp_path):
+    workspace = tmp_path / "workspace"
+    artifact = ArtifactStore(workspace / ".breadboard" / "artifacts").put(
+        b"\x89PNG\r\n\x1a\nprofile-evidence",
+        media_type="image/png",
+    )
+    uri = f"attachment://{artifact.digest}"
+    metadata = {"attachment_capabilities": {uri: artifact.as_dict()}}
+    session_state = types.SimpleNamespace(
+        workspace=str(workspace),
+        get_provider_metadata=lambda key, default=None: metadata.get(key, default),
+    )
+    profile = _profile()
+    runtime = _runtime()
+    context = ProviderRuntimeContext(
+        session_state,
+        {},
+        provider_profile=profile,
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "thinking", "text": "inspect image"},
+                {
+                    "type": "media",
+                    "kind": "image",
+                    "uri": uri,
+                    "mime": "image/png",
+                },
+            ],
+        },
+        {
+            "role": "tool_result",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "call_id": "call_1",
+                    "content": {"status": "ok"},
+                }
+            ],
+        },
+    ]
+
+    body, _, _, _ = _provider_wire_evidence(
+        profile=profile,
+        runtime=runtime,
+        provider_id="openai",
+        model=MODEL,
+        messages=messages,
+        tools=None,
+        stream=True,
+        client_config={},
+        context=context,
+    )
+
+    assert body == runtime.profile_chat_request(
+        profile,
+        messages,
+        None,
+        context=context,
+    )
+    assert body["messages"][0]["content"][0]["type"] == "image_url"
+    assert body["messages"][0]["reasoning_content"] == "inspect image"
+    assert body["messages"][1] == {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "content": '{"status":"ok"}',
+    }
 
 
 def test_rejected_episode_does_not_retain_provider_profile():

--- a/tests/providers/test_openai_profile.py
+++ b/tests/providers/test_openai_profile.py
@@ -460,13 +460,44 @@ def test_profile_wire_evidence_records_exact_authoritative_request():
     assert body["seed"] == 7
     assert body["enable_thinking"] is False
     assert body["tools"][0]["function"]["strict"] is False
-    assert endpoint == profile.base_url
+    assert endpoint == f"sha256:{identity['base_url_sha256']}"
     assert identity == profile.identity_dict()
     assert headers == {
         "Authorization": "***REDACTED***",
         "X-Request-ID": "***REDACTED***",
     }
     assert "episode-secret" not in repr((body, headers, endpoint, identity))
+
+
+def test_profile_wire_evidence_redacts_echoes_and_raw_endpoint():
+    profile = _profile(
+        base_url="http://127.0.0.1:8111/caller-secret/v1",
+        caller_headers={"X-Request-ID": "caller-secret"},
+    )
+
+    evidence = _provider_wire_evidence(
+        profile=profile,
+        provider_id="openai",
+        model=MODEL,
+        messages=[{"role": "user", "content": "episode-secret caller-secret"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "read",
+                    "description": "episode-secret caller-secret",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+        stream=True,
+        client_config={},
+    )
+
+    assert "episode-secret" not in repr(evidence)
+    assert "caller-secret" not in repr(evidence)
+    assert profile.base_url not in repr(evidence)
+    assert evidence[2] == f"sha256:{profile.identity_dict()['base_url_sha256']}"
 
 
 def test_rejected_episode_does_not_retain_provider_profile():

--- a/tests/providers/test_openai_profile.py
+++ b/tests/providers/test_openai_profile.py
@@ -5,6 +5,7 @@ import types
 
 import pytest
 
+from breadboard_engine.agent_llm_openai import OpenAIConductor
 from breadboard_engine.conductor.modes import _bind_episode_provider_profile
 from breadboard_engine.provider import sdk_bindings
 from breadboard_engine.provider.contracts import (
@@ -360,3 +361,20 @@ def test_profile_response_is_sanitized_inside_secret_scope(monkeypatch):
     rendered = repr(result)
     assert "episode-secret" not in rendered
     assert "caller-secret" not in rendered
+
+
+def test_rejected_episode_does_not_retain_provider_profile():
+    conductor_class = OpenAIConductor.__ray_metadata__.modified_class
+    conductor = object.__new__(conductor_class)
+    conductor._active_session_state = None
+
+    with pytest.raises(ProviderContractError, match="run context requires"):
+        conductor.run_agentic_loop(
+            "",
+            "",
+            MODEL,
+            context=None,
+            provider_profile=_profile(),
+        )
+
+    assert conductor._active_session_state is None

--- a/tests/providers/test_openai_profile.py
+++ b/tests/providers/test_openai_profile.py
@@ -6,7 +6,10 @@ import types
 import pytest
 
 from breadboard_engine.agent_llm_openai import OpenAIConductor
-from breadboard_engine.conductor.modes import _bind_episode_provider_profile
+from breadboard_engine.conductor.modes import (
+    _bind_episode_provider_profile,
+    _provider_wire_evidence,
+)
 from breadboard_engine.provider import sdk_bindings
 from breadboard_engine.provider.contracts import (
     OpenAICompletionsCapabilities,
@@ -330,10 +333,25 @@ def test_profile_is_pickle_safe_for_ray_actor_admission():
 def test_profile_response_is_sanitized_inside_secret_scope(monkeypatch):
     profile = _profile(caller_headers={"X-Request-ID": "caller-secret"})
     runtime = _runtime()
-    monkeypatch.setattr(
-        runtime,
-        "_invoke",
-        lambda **_kwargs: ProviderResult(
+    emitted = []
+    recorded = []
+    session_state = types.SimpleNamespace(
+        _emit_event=lambda event_type, payload, turn: emitted.append(
+            (event_type, payload, turn)
+        )
+    )
+    exchange_recorder = types.SimpleNamespace(
+        record=lambda kind, payload: recorded.append((kind, payload))
+    )
+
+    def leaking_invoke(**kwargs):
+        runtime._stream_emit_event(
+            kwargs["context"],
+            "assistant.message.delta",
+            {"text": "episode-secret caller-secret"},
+            turn_index=0,
+        )
+        return ProviderResult(
             messages=[
                 ProviderMessage(
                     role="assistant",
@@ -341,8 +359,9 @@ def test_profile_response_is_sanitized_inside_secret_scope(monkeypatch):
                 )
             ],
             raw_response={"echo": "episode-secret caller-secret"},
-        ),
-    )
+        )
+
+    monkeypatch.setattr(runtime, "_invoke", leaking_invoke)
 
     result = runtime.invoke(
         client=object(),
@@ -351,9 +370,10 @@ def test_profile_response_is_sanitized_inside_secret_scope(monkeypatch):
         tools=None,
         stream=True,
         context=ProviderRuntimeContext(
-            None,
+            session_state,
             {},
             stream=True,
+            exchange_recorder=exchange_recorder,
             provider_profile=profile,
         ),
     )
@@ -361,6 +381,63 @@ def test_profile_response_is_sanitized_inside_secret_scope(monkeypatch):
     rendered = repr(result)
     assert "episode-secret" not in rendered
     assert "caller-secret" not in rendered
+    assert "episode-secret" not in repr(emitted)
+    assert "caller-secret" not in repr(emitted)
+    assert "episode-secret" not in repr(recorded)
+    assert "caller-secret" not in repr(recorded)
+
+
+def test_profile_wire_evidence_records_exact_authoritative_request():
+    profile = _profile(
+        sampling={
+            "temperature": 0.6,
+            "top_p": 0.95,
+            "seed": 7,
+        }
+    )
+    messages = [{"role": "user", "content": "fixture"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "read",
+                "description": "Read a file",
+                "parameters": {"type": "object"},
+                "strict": True,
+            },
+        }
+    ]
+
+    body, headers, endpoint, identity = _provider_wire_evidence(
+        profile=profile,
+        provider_id="openai",
+        model=MODEL,
+        messages=messages,
+        tools=tools,
+        stream=False,
+        client_config={
+            "base_url": "https://wrong.example/v1",
+            "default_headers": {"X-Wrong": "wrong"},
+        },
+    )
+
+    assert body == profile.chat_request(messages, tools)
+    assert body["stream"] is True
+    assert body["stream_options"] == {"include_usage": True}
+    assert body["max_tokens"] == 32_000
+    assert body["n"] == 1
+    assert body["temperature"] == 0.6
+    assert body["top_p"] == 0.95
+    assert body["seed"] == 7
+    assert body["enable_thinking"] is False
+    assert body["tools"][0]["function"]["strict"] is False
+    assert endpoint == profile.base_url
+    assert identity == profile.identity_dict()
+    assert headers == {
+        "Authorization": "***REDACTED***",
+        "X-Request-ID": "***REDACTED***",
+    }
+    assert "episode-secret" not in repr((body, headers, endpoint, identity))
 
 
 def test_rejected_episode_does_not_retain_provider_profile():

--- a/tests/providers/test_openai_profile.py
+++ b/tests/providers/test_openai_profile.py
@@ -222,16 +222,39 @@ def test_profile_client_sets_sdk_retries_to_zero(monkeypatch):
 
 
 def test_profile_binds_production_runtime_client(monkeypatch):
-    transport = object()
+    created = []
+
+    class FakeTransport:
+        def __init__(self):
+            self.close_calls = 0
+
+        def close(self):
+            self.close_calls += 1
+
+    transport = FakeTransport()
+
+    def create_transport(**_kwargs):
+        created.append(transport)
+        return transport
+
     monkeypatch.setattr(
         sdk_bindings.provider_sdk_bindings,
         "openai",
-        lambda **_kwargs: transport,
+        create_transport,
     )
     profile = _profile()
+    episode = types.SimpleNamespace(_episode_provider_profile=profile)
+    runtime = _runtime()
     client, stream, bound_profile = _bind_episode_provider_profile(
-        types.SimpleNamespace(_episode_provider_profile=profile),
-        _runtime(),
+        episode,
+        runtime,
+        object(),
+        MODEL,
+        False,
+    )
+    rebound_client, _, _ = _bind_episode_provider_profile(
+        episode,
+        runtime,
         object(),
         MODEL,
         False,
@@ -239,8 +262,12 @@ def test_profile_binds_production_runtime_client(monkeypatch):
 
     assert stream is True
     assert bound_profile is profile
+    assert client is rebound_client
     assert client.transport is transport
     assert client.profile is profile
+    assert created == [transport]
+    client.close()
+    assert transport.close_calls == 1
 
 
 def test_profile_binding_is_scoped_to_each_episode(monkeypatch):
@@ -328,6 +355,8 @@ def test_profile_is_pickle_safe_for_ray_actor_admission():
     assert restored == profile
     assert dict(restored.caller_headers) == {"X-Request-ID": "episode-one"}
     assert restored.scoped_credential == "episode-secret"
+    assert "episode-secret" not in repr(restored)
+    assert "episode-one" not in repr(restored)
 
 
 def test_profile_response_is_sanitized_inside_secret_scope(monkeypatch):

--- a/tests/providers/test_openai_profile.py
+++ b/tests/providers/test_openai_profile.py
@@ -469,23 +469,34 @@ def test_profile_wire_evidence_records_exact_authoritative_request():
     assert "episode-secret" not in repr((body, headers, endpoint, identity))
 
 
-def test_profile_wire_evidence_redacts_echoes_and_raw_endpoint():
+@pytest.mark.parametrize(
+    ("credential", "header_value"),
+    [
+        ("episode-secret", "caller-secret"),
+        ("xy", "z"),
+    ],
+)
+def test_profile_wire_evidence_redacts_echoes_and_raw_endpoint(
+    credential,
+    header_value,
+):
     profile = _profile(
+        scoped_credential=credential,
         base_url="http://127.0.0.1:8111/caller-secret/v1",
-        caller_headers={"X-Request-ID": "caller-secret"},
+        caller_headers={"X-Request-ID": header_value},
     )
 
     evidence = _provider_wire_evidence(
         profile=profile,
         provider_id="openai",
         model=MODEL,
-        messages=[{"role": "user", "content": "episode-secret caller-secret"}],
+        messages=[{"role": "user", "content": f"{credential} {header_value}"}],
         tools=[
             {
                 "type": "function",
                 "function": {
                     "name": "read",
-                    "description": "episode-secret caller-secret",
+                    "description": f"{credential} {header_value}",
                     "parameters": {"type": "object"},
                 },
             }
@@ -494,8 +505,8 @@ def test_profile_wire_evidence_redacts_echoes_and_raw_endpoint():
         client_config={},
     )
 
-    assert "episode-secret" not in repr(evidence)
-    assert "caller-secret" not in repr(evidence)
+    assert credential not in repr(evidence[0])
+    assert header_value not in repr(evidence[0])
     assert profile.base_url not in repr(evidence)
     assert evidence[2] == f"sha256:{profile.identity_dict()['base_url_sha256']}"
 

--- a/tests/providers/test_provider_runtime_openrouter.py
+++ b/tests/providers/test_provider_runtime_openrouter.py
@@ -727,7 +727,14 @@ def test_openrouter_chat_stream_omits_absent_tools_and_uses_chat_finalizer():
     runtime = provider_registry.create_runtime(descriptor)
     captured = {}
     response = _chat_response(content="hello")
-    stream = _FakeChatStream([_chat_chunk(content="hello")], response)
+    stream = _FakeChatStream(
+        [
+            _chat_chunk(content="hello"),
+            types.SimpleNamespace(type="content.delta"),
+            types.SimpleNamespace(type="content.done"),
+        ],
+        response,
+    )
 
     def open_stream(**kwargs):
         captured.update(kwargs)

--- a/tests/test_conductor_bootstrap.py
+++ b/tests/test_conductor_bootstrap.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from breadboard_engine.agent_llm_openai import OpenAIConductor
 from breadboard_engine.conductor_context import ConductorContext
+from breadboard_engine.provider.contracts import OpenAICompletionsProviderProfile
 
 ConductorClass = OpenAIConductor.__ray_metadata__.modified_class
 
@@ -45,6 +46,25 @@ def test_conductor_initialization_basic(ray_cluster, tmp_path):
     assert conductor.image == "python-dev:latest"
     assert isinstance(conductor.config, dict)
     assert conductor.local_mode is True
+
+
+def test_conductor_admits_episode_provider_profile(ray_cluster, tmp_path):
+    profile = OpenAICompletionsProviderProfile(
+        model="Qwen/Qwen3.5-35B-A3B",
+        scoped_credential="episode-secret",
+        base_url="http://127.0.0.1:8111/v1",
+        context_window=131_072,
+        max_output_tokens=32_000,
+    )
+    conductor = ConductorClass(
+        workspace=str(tmp_path / "profile_workspace"),
+        image="python-dev:latest",
+        config={},
+        local_mode=True,
+        provider_profile=profile,
+    )
+
+    assert conductor._provider_profile is profile
 
 
 def test_conductor_initialization_with_config(ray_cluster, tmp_path):

--- a/tests/test_conductor_bootstrap.py
+++ b/tests/test_conductor_bootstrap.py
@@ -15,7 +15,6 @@ from pathlib import Path
 
 from breadboard_engine.agent_llm_openai import OpenAIConductor
 from breadboard_engine.conductor_context import ConductorContext
-from breadboard_engine.provider.contracts import OpenAICompletionsProviderProfile
 
 ConductorClass = OpenAIConductor.__ray_metadata__.modified_class
 
@@ -48,23 +47,6 @@ def test_conductor_initialization_basic(ray_cluster, tmp_path):
     assert conductor.local_mode is True
 
 
-def test_conductor_admits_episode_provider_profile(ray_cluster, tmp_path):
-    profile = OpenAICompletionsProviderProfile(
-        model="Qwen/Qwen3.5-35B-A3B",
-        scoped_credential="episode-secret",
-        base_url="http://127.0.0.1:8111/v1",
-        context_window=131_072,
-        max_output_tokens=32_000,
-    )
-    conductor = ConductorClass(
-        workspace=str(tmp_path / "profile_workspace"),
-        image="python-dev:latest",
-        config={},
-        local_mode=True,
-        provider_profile=profile,
-    )
-
-    assert conductor._provider_profile is profile
 
 
 def test_conductor_initialization_with_config(ray_cluster, tmp_path):

--- a/tests/test_provider_invoker.py
+++ b/tests/test_provider_invoker.py
@@ -16,6 +16,7 @@ from breadboard_engine.provider_runtime import (
     ProviderToolCall,
 )
 from breadboard_engine.provider.contracts import ProviderContractError
+from breadboard_engine.provider.contracts import OpenAICompletionsProviderProfile
 from breadboard_engine.state.session_state import SessionState
 from breadboard_engine.messaging.markdown_logger import MarkdownLogger
 
@@ -119,6 +120,96 @@ def test_provider_invoker_stream_success():
     ]
     assert session_state.get_provider_metadata("last_provider_exchange") == exchange
 
+
+
+@pytest.mark.parametrize(
+    "runtime_error",
+    (
+        ProviderRuntimeError("provider_failed"),
+        ProviderRuntimeError("stream_failed", kind="protocol"),
+    ),
+)
+def test_profile_bound_invocation_never_leases_or_falls_back(runtime_error):
+    runtime = _mk_runtime()
+    runtime.invoke.side_effect = runtime_error
+    retry_with_fallback = Mock(return_value=_provider_result("must not run"))
+    def forbidden_lease(*_args, **_kwargs):
+        raise AssertionError("profile-bound invocation must use its bound client")
+
+    invoker = _make_invoker(
+        retry_with_fallback,
+        client_lease=forbidden_lease,
+    )
+    invoker.route_health.is_circuit_open.return_value = False
+    session_state = _session_state()
+    profile = OpenAICompletionsProviderProfile(
+        model="Qwen/Qwen3.5-35B-A3B",
+        scoped_credential="episode-secret",
+        base_url="http://127.0.0.1:8111/v1",
+        context_window=131_072,
+        max_output_tokens=32_000,
+    )
+
+    with pytest.raises(ProviderRuntimeError, match=str(runtime_error)):
+        invoker.invoke(
+            runtime=runtime,
+            client=object(),
+            model=profile.model,
+            send_messages=[],
+            tools_schema=None,
+            stream_responses=True,
+            runtime_context=ProviderRuntimeContext(
+                session_state=session_state,
+                agent_config={},
+                stream=True,
+                provider_profile=profile,
+            ),
+            session_state=session_state,
+            markdown_logger=_markdown_logger(),
+            turn_index=1,
+            route_id="openai/Qwen/Qwen3.5-35B-A3B",
+        )
+
+    runtime.invoke.assert_called_once()
+    retry_with_fallback.assert_not_called()
+
+
+def test_profile_bound_invocation_fails_closed_on_open_circuit():
+    runtime = _mk_runtime(_provider_result())
+    retry_with_fallback = Mock(return_value=_provider_result("must not run"))
+    invoker = _make_invoker(retry_with_fallback)
+    invoker.route_health.is_circuit_open.return_value = True
+    session_state = _session_state()
+    profile = OpenAICompletionsProviderProfile(
+        model="Qwen/Qwen3.5-35B-A3B",
+        scoped_credential="episode-secret",
+        base_url="http://127.0.0.1:8111/v1",
+        context_window=131_072,
+        max_output_tokens=32_000,
+    )
+
+    with pytest.raises(ProviderRuntimeError, match="route unavailable"):
+        invoker.invoke(
+            runtime=runtime,
+            client=object(),
+            model=profile.model,
+            send_messages=[],
+            tools_schema=None,
+            stream_responses=True,
+            runtime_context=ProviderRuntimeContext(
+                session_state=session_state,
+                agent_config={},
+                stream=True,
+                provider_profile=profile,
+            ),
+            session_state=session_state,
+            markdown_logger=_markdown_logger(),
+            turn_index=1,
+            route_id="openai/Qwen/Qwen3.5-35B-A3B",
+        )
+
+    runtime.invoke.assert_not_called()
+    retry_with_fallback.assert_not_called()
 
 def test_provider_invoker_counts_reasoning_only_result_as_output() -> None:
     runtime_result = ProviderResult(


### PR DESCRIPTION
## Contract
- adds immutable episode-scoped OpenAI Chat Completions profiles
- binds scoped credentials, endpoint/model/limits/sampling/headers/capabilities without env or global mutation
- emits the exact Qwen-compatible streamed request with zero retries and no fallback/store behavior
- keeps profile identity deterministic and secret-free
- accepts OpenAI SDK derived stream projection events while decoding only raw chunks

## Evidence
- `uv run --with pytest pytest -q tests/providers/test_openai_profile.py tests/providers/test_provider_runtime_openrouter.py -k 'profile or openrouter_chat_stream_omits_absent_tools'` — 7 passed
- real OpenAI Python 3.6 client against captured local HTTP endpoint — `fixture-ok`
- captured wire assertion — exact model, tools `strict:false`, `stream_options.include_usage`, `max_tokens=32000`, `n=1`, `enable_thinking=false`, no `store`/`provider`, retry count 0

No training-readiness claim. R3 remains immutable at 331/500.

Compat reviewed: non-breaking

The optional per-run provider profile path is additive; existing conductor and Agent callers retain prior behavior.