### PR TITLE
Export canonical headless workspace patches

### DIFF
--- a/breadboard/rl/harness/SANDBOX_CAPABILITY_MATRIX.json
+++ b/breadboard/rl/harness/SANDBOX_CAPABILITY_MATRIX.json
@@ -20,6 +20,7 @@
       },
       "required_host_capabilities": [
         "linux",
+        "git",
         "docker-engine",
         "runc-registration",
         "seccomp",
@@ -81,6 +82,7 @@
       },
       "required_host_capabilities": [
         "linux",
+        "git",
         "docker-engine",
         "runsc-registration",
         "pinned-runsc-binary",

--- a/breadboard/rl/harness/headless.py
+++ b/breadboard/rl/harness/headless.py
@@ -1030,18 +1030,39 @@ def _project_headless_run(
         run.evidence_manifest_ref,
     )
     workspace_diff = run.workspace_diff
+    if workspace_diff is None:
+        result["workspace_evidence"] = evidence_projection
+        return event_bytes, None
+    expected_keys = {
+        "returncode",
+        "stdout",
+        "stderr",
+        "base_commit",
+        "git_executable_digest",
+        "patch_digest",
+        "snapshot_root_digest",
+    }
     if (
         not isinstance(workspace_diff, Mapping)
-        or set(workspace_diff) != {"returncode", "stdout", "stderr"}
+        or set(workspace_diff) != expected_keys
         or workspace_diff.get("returncode") != 0
         or type(workspace_diff.get("stdout")) is not str
         or workspace_diff.get("stderr") != ""
+        or type(workspace_diff.get("base_commit")) is not str
+        or type(workspace_diff.get("git_executable_digest")) is not str
+        or type(workspace_diff.get("patch_digest")) is not str
+        or type(workspace_diff.get("snapshot_root_digest")) is not str
     ):
         raise ValueError("canonical workspace diff is unavailable")
     patch_bytes = workspace_diff["stdout"].encode("utf-8")
+    if workspace_diff["patch_digest"] != _digest_bytes(patch_bytes):
+        raise ValueError("canonical workspace patch digest mismatch")
     result["workspace_evidence"] = {
         **evidence_projection,
-        "patch_digest": _digest_bytes(patch_bytes),
+        "patch_digest": workspace_diff["patch_digest"],
+        "patch_base_commit": workspace_diff["base_commit"],
+        "patch_git_executable_digest": workspace_diff["git_executable_digest"],
+        "patch_snapshot_root_digest": workspace_diff["snapshot_root_digest"],
     }
     return event_bytes, patch_bytes
 

--- a/breadboard/rl/harness/headless.py
+++ b/breadboard/rl/harness/headless.py
@@ -1034,13 +1034,8 @@ def _project_headless_run(
         result["workspace_evidence"] = evidence_projection
         return event_bytes, None
     expected_keys = {
-        "returncode",
-        "stdout",
-        "stderr",
-        "base_commit",
-        "git_executable_digest",
-        "patch_digest",
-        "snapshot_root_digest",
+        "returncode", "stdout", "stderr", "base_commit",
+        "git_executable_digest", "patch_digest", "snapshot_root_digest",
     }
     if (
         not isinstance(workspace_diff, Mapping)

--- a/breadboard/rl/harness/headless.py
+++ b/breadboard/rl/harness/headless.py
@@ -38,8 +38,6 @@ _POLICY_PROVIDER_PATH = Path(__file__).with_name("policy_provider.py")
 _POLICY_PROVIDER_IDENTITY = measure_module_artifact(str(_POLICY_PROVIDER_PATH))
 
 
-
-
 class HeadlessWorkspaceInput(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -175,9 +173,7 @@ class HeadlessProviderRouteAuthority(BaseModel):
             "authority_model_id": self.authority_model_id,
             "base_url_sha256": _digest_bytes(self.base_url.encode("utf-8")),
             "caller_header_count": len(header_names),
-            "caller_header_names_sha256": _digest_bytes(
-                _canonical_bytes(header_names)
-            ),
+            "caller_header_names_sha256": _digest_bytes(_canonical_bytes(header_names)),
             "caller_headers_sha256": _digest_bytes(_canonical_bytes(header_items)),
             "policy_observation_digest": self.policy_observation_digest,
         }
@@ -203,21 +199,31 @@ class HeadlessRunRequest(BaseModel):
     provider: HeadlessProviderInput
     result_path: str
     event_log_path: str
+    patch_path: str | None = None
 
-    @field_validator(
-        "result_path",
-        "event_log_path",
-    )
+    @field_validator("result_path", "event_log_path")
     @classmethod
     def _path_is_absolute(cls, value: str) -> str:
         if not os.path.isabs(value) or os.path.normpath(value) != value:
             raise ValueError("headless paths must be normalized absolute paths")
         return value
 
+    @field_validator("patch_path")
+    @classmethod
+    def _optional_path_is_absolute(cls, value: str | None) -> str | None:
+        if value is not None and (
+            not os.path.isabs(value) or os.path.normpath(value) != value
+        ):
+            raise ValueError("headless paths must be normalized absolute paths")
+        return value
+
     @model_validator(mode="after")
     def _request_is_closed(self) -> HeadlessRunRequest:
-        if self.result_path == self.event_log_path:
-            raise ValueError("result_path and event_log_path must differ")
+        destinations = [self.result_path, self.event_log_path]
+        if self.patch_path is not None:
+            destinations.append(self.patch_path)
+        if len(destinations) != len(set(destinations)):
+            raise ValueError("headless output paths must differ")
         if not self.target_id or not self.target_overlay_id:
             raise ValueError("target and overlay identities are required")
         if any(
@@ -279,6 +285,7 @@ def load_headless_request(path: str) -> HeadlessRunRequest:
     payload = _read_regular_file(path, max_bytes=_MAX_REQUEST_BYTES)
     return HeadlessRunRequest.model_validate_json(payload, strict=True)
 
+
 def load_headless_provider_route_authority(
     path: str,
 ) -> HeadlessProviderRouteAuthority:
@@ -307,9 +314,7 @@ async def run_headless_request(
     composition: ProductionComposition | None = None
     try:
         if request.expected_sandbox.runtime_class is c.RuntimeClass.TRUSTED_PROCESS:
-            raise ValueError(
-                "headless execution requires an isolated sandbox runtime"
-            )
+            raise ValueError("headless execution requires an isolated sandbox runtime")
         composition_secrets = _secret_file_bindings(
             secret_files,
             field_name="composition secret files",
@@ -326,12 +331,9 @@ async def run_headless_request(
             raise ValueError(
                 "provider credential handles do not match the headless request"
             )
-        if (
-            set(provider_routes) != {request.provider.credential_handle}
-            or any(
-                type(value) is not HeadlessProviderRouteAuthority
-                for value in provider_routes.values()
-            )
+        if set(provider_routes) != {request.provider.credential_handle} or any(
+            type(value) is not HeadlessProviderRouteAuthority
+            for value in provider_routes.values()
         ):
             raise ValueError(
                 "provider route authorities do not match the headless request"
@@ -368,13 +370,9 @@ async def run_headless_request(
             return EpisodeOpenAICompletionsPolicyResolver(
                 authority,
                 profiles={episode_id: profile},
-                credential_handle_ids={
-                    episode_id: request.provider.credential_handle
-                },
+                credential_handle_ids={episode_id: request.provider.credential_handle},
                 target_projections={episode_id: target},
-                authority_model_ids={
-                    episode_id: request.provider.authority_model_id
-                },
+                authority_model_ids={episode_id: request.provider.authority_model_id},
                 authority_wire_models={episode_id: route.model},
                 expected_observation_digests={
                     episode_id: route.policy_observation_digest
@@ -430,9 +428,7 @@ async def run_headless_request(
             raise preflight_cancellation
         raise HeadlessRunFailed(result) from None
     loop = asyncio.get_running_loop()
-    episode_deadline = (
-        loop.time() + request.expected_resources.wall_time_ms / 1_000
-    )
+    episode_deadline = loop.time() + request.expected_resources.wall_time_ms / 1_000
     primary_failure: BaseException | None = None
     cleanup_failure: BaseException | None = None
     cancellation: asyncio.CancelledError | None = None
@@ -440,6 +436,7 @@ async def run_headless_request(
     run_started = False
     terminal_unsuccessful = False
     event_bytes: bytes | None = None
+    patch_bytes: bytes | None = None
     try:
         async with asyncio.timeout_at(episode_deadline):
             create_operation = await composition.service.create(request.resolve_request)
@@ -467,7 +464,11 @@ async def run_headless_request(
                 context=request.context,
             )
             run = run_operation.response
-            event_bytes = _project_headless_run(result, run, composition)
+            event_bytes, patch_bytes = _project_headless_run(
+                result,
+                run,
+                composition,
+            )
             close_operation = await composition.service.close_episode(episode_id)
             closed = await composition.service.get_closed_envelope(episode_id)
             _project_headless_cleanup(result, close_operation.response, closed)
@@ -491,14 +492,12 @@ async def run_headless_request(
                         context=request.context,
                     )
                     run = replay.response
-                    event_bytes = _project_headless_run(
+                    event_bytes, patch_bytes = _project_headless_run(
                         result,
                         run,
                         composition,
                     )
-                    terminal_unsuccessful = (
-                        run.primary_disposition.value != "succeeded"
-                    )
+                    terminal_unsuccessful = run.primary_disposition.value != "succeeded"
             except BaseException as exc:
                 cleanup_failure = exc
         try:
@@ -529,6 +528,7 @@ async def run_headless_request(
         primary_failure = TimeoutError("aggregate episode wall-time limit exceeded")
 
     result["event_log"] = _event_log_projection(event_bytes, request.event_log_path)
+    result["patch"] = _patch_projection(patch_bytes, request.patch_path)
     publication_failure: BaseException | None = None
     if event_bytes is not None:
         try:
@@ -537,6 +537,17 @@ async def run_headless_request(
             publication_failure = exc
             result["event_log"] = {
                 **result["event_log"],
+                "publication_failure": _safe_failure_projection(exc),
+            }
+    if request.patch_path is not None:
+        try:
+            if patch_bytes is None:
+                raise ValueError("headless run did not produce a workspace patch")
+            _atomic_write(request.patch_path, patch_bytes)
+        except Exception as exc:
+            publication_failure = publication_failure or exc
+            result["patch"] = {
+                **result["patch"],
                 "publication_failure": _safe_failure_projection(exc),
             }
     deadline_exceeded = loop.time() >= episode_deadline
@@ -635,7 +646,10 @@ def _validate_repository_base_commit_binding(
                 "repository base-commit bindings require a repository snapshot"
             )
         return
-    if set(bindings) != {expected_digest} or bindings[expected_digest] != expected_commit:
+    if (
+        set(bindings) != {expected_digest}
+        or bindings[expected_digest] != expected_commit
+    ):
         raise ValueError(
             "repository base commit is not bound to the admitted repository snapshot"
         )
@@ -704,10 +718,7 @@ def _project_effective_chat_tool(definition: Mapping[str, Any]) -> dict[str, Any
         "required": required,
     }
     openai_routing = routing.get("openai")
-    if (
-        isinstance(openai_routing, Mapping)
-        and "additionalProperties" in openai_routing
-    ):
+    if isinstance(openai_routing, Mapping) and "additionalProperties" in openai_routing:
         additional_properties = openai_routing["additionalProperties"]
         if type(additional_properties) is not bool:
             raise ValueError("effective target tool routing is malformed")
@@ -805,7 +816,7 @@ def _load_effective_plan(
 def _load_evidence_projection(
     composition: ProductionComposition,
     evidence_manifest_ref: Any,
-) -> tuple[dict[str, Any], bytes]:
+) -> tuple[dict[str, Any], bytes, bytes | None]:
     manifest_bytes = _cas_bytes(
         composition,
         evidence_manifest_ref,
@@ -826,10 +837,19 @@ def _load_evidence_projection(
             max_bytes=_MAX_EVIDENCE_BYTES,
         )
     )
+    patch_bytes = None
     patch_digest = None
     for item in artifact_manifest.get("objects", []):
         if item.get("role") in {"patch", "git_patch", "workspace_patch"}:
-            patch_digest = item["artifact_ref"]["sha256"]
+            patch_ref = item["artifact_ref"]
+            patch_digest = patch_ref["sha256"]
+            patch_bytes = _cas_bytes(
+                composition,
+                patch_ref,
+                max_bytes=_MAX_EVIDENCE_BYTES,
+            )
+            if _digest_bytes(patch_bytes) != patch_digest:
+                raise ValueError("workspace patch artifact digest mismatch")
             break
     return (
         {
@@ -841,6 +861,7 @@ def _load_evidence_projection(
             "artifact_manifest_ref": artifact_manifest_ref,
         },
         event_bytes,
+        patch_bytes,
     )
 
 
@@ -903,9 +924,7 @@ def _preflight_failure_result(
         "expected_limits": request.expected_limits.model_dump(mode="json"),
         "expected_sandbox": request.expected_sandbox.model_dump(mode="json"),
         "provider": request.provider.identity_dict(),
-        "provider_profile": (
-            None if profile is None else profile.identity_dict()
-        ),
+        "provider_profile": (None if profile is None else profile.identity_dict()),
         "provider_route": None if route is None else route.identity_dict(),
     }
     try:
@@ -930,9 +949,7 @@ def _preflight_failure_result(
             else profile.identity_dict()
         ),
         "provider_input_identity": request.provider.identity_dict(),
-        "provider_route_identity": (
-            None if route is None else route.identity_dict()
-        ),
+        "provider_route_identity": (None if route is None else route.identity_dict()),
         "target_identity": config_identity["target"],
         "workspace_input": request.workspace.model_dump(mode="json"),
         "terminal": {
@@ -1000,6 +1017,7 @@ def _base_result(
         "cleanup_inventory": None,
         "cleanup_inventory_digest": None,
         "event_log": None,
+        "patch": None,
     }
 
 
@@ -1007,7 +1025,7 @@ def _project_headless_run(
     result: dict[str, Any],
     run: Any,
     composition: ProductionComposition,
-) -> bytes | None:
+) -> tuple[bytes | None, bytes | None]:
     result["terminal"] = {
         "status": run.primary_disposition.value,
         "reason": run.termination,
@@ -1028,13 +1046,13 @@ def _project_headless_run(
         "reward_components": dict(run.reward_components),
     }
     if run.evidence_manifest_ref is None:
-        return None
-    evidence_projection, event_bytes = _load_evidence_projection(
+        return None, None
+    evidence_projection, event_bytes, patch_bytes = _load_evidence_projection(
         composition,
         run.evidence_manifest_ref,
     )
     result["workspace_evidence"] = evidence_projection
-    return event_bytes
+    return event_bytes, patch_bytes
 
 
 def _project_headless_cleanup(
@@ -1059,6 +1077,19 @@ def _event_log_projection(
     destination: str,
 ) -> dict[str, Any]:
     return {
+        "destination": destination,
+        "digest": None if payload is None else _digest_bytes(payload),
+        "size_bytes": None if payload is None else len(payload),
+        "available": payload is not None,
+    }
+
+
+def _patch_projection(
+    payload: bytes | None,
+    destination: str | None,
+) -> dict[str, Any]:
+    return {
+        "requested": destination is not None,
         "destination": destination,
         "digest": None if payload is None else _digest_bytes(payload),
         "size_bytes": None if payload is None else len(payload),

--- a/breadboard/rl/harness/headless.py
+++ b/breadboard/rl/harness/headless.py
@@ -816,7 +816,7 @@ def _load_effective_plan(
 def _load_evidence_projection(
     composition: ProductionComposition,
     evidence_manifest_ref: Any,
-) -> tuple[dict[str, Any], bytes, bytes | None]:
+) -> tuple[dict[str, Any], bytes]:
     manifest_bytes = _cas_bytes(
         composition,
         evidence_manifest_ref,
@@ -830,38 +830,15 @@ def _load_evidence_projection(
         max_bytes=_MAX_EVIDENCE_BYTES,
     )
     artifact_manifest_ref = manifest["artifact_manifest_ref"]
-    artifact_manifest = json.loads(
-        _cas_bytes(
-            composition,
-            artifact_manifest_ref,
-            max_bytes=_MAX_EVIDENCE_BYTES,
-        )
-    )
-    patch_bytes = None
-    patch_digest = None
-    for item in artifact_manifest.get("objects", []):
-        if item.get("role") in {"patch", "git_patch", "workspace_patch"}:
-            patch_ref = item["artifact_ref"]
-            patch_digest = patch_ref["sha256"]
-            patch_bytes = _cas_bytes(
-                composition,
-                patch_ref,
-                max_bytes=_MAX_EVIDENCE_BYTES,
-            )
-            if _digest_bytes(patch_bytes) != patch_digest:
-                raise ValueError("workspace patch artifact digest mismatch")
-            break
     return (
         {
             "materialization_digest": manifest.get("materialization_digest"),
             "final_workspace_snapshot_digest": manifest.get("verifier_snapshot_digest"),
-            "patch_digest": patch_digest,
             "runner_event_ledger_ref": runner_ref,
             "runner_event_ledger_digest": _digest_bytes(event_bytes),
             "artifact_manifest_ref": artifact_manifest_ref,
         },
         event_bytes,
-        patch_bytes,
     )
 
 
@@ -969,6 +946,7 @@ def _preflight_failure_result(
         "cleanup_inventory": None,
         "cleanup_inventory_digest": None,
         "event_log": _event_log_projection(None, request.event_log_path),
+        "patch": _patch_projection(None, request.patch_path),
     }
 
 
@@ -1047,11 +1025,24 @@ def _project_headless_run(
     }
     if run.evidence_manifest_ref is None:
         return None, None
-    evidence_projection, event_bytes, patch_bytes = _load_evidence_projection(
+    evidence_projection, event_bytes = _load_evidence_projection(
         composition,
         run.evidence_manifest_ref,
     )
-    result["workspace_evidence"] = evidence_projection
+    workspace_diff = run.workspace_diff
+    if (
+        not isinstance(workspace_diff, Mapping)
+        or set(workspace_diff) != {"returncode", "stdout", "stderr"}
+        or workspace_diff.get("returncode") != 0
+        or type(workspace_diff.get("stdout")) is not str
+        or workspace_diff.get("stderr") != ""
+    ):
+        raise ValueError("canonical workspace diff is unavailable")
+    patch_bytes = workspace_diff["stdout"].encode("utf-8")
+    result["workspace_evidence"] = {
+        **evidence_projection,
+        "patch_digest": _digest_bytes(patch_bytes),
+    }
     return event_bytes, patch_bytes
 
 

--- a/breadboard/rl/harness/headless.py
+++ b/breadboard/rl/harness/headless.py
@@ -468,6 +468,7 @@ async def run_headless_request(
                 result,
                 run,
                 composition,
+                expected_base_commit=request.workspace.base_commit,
             )
             close_operation = await composition.service.close_episode(episode_id)
             closed = await composition.service.get_closed_envelope(episode_id)
@@ -496,6 +497,7 @@ async def run_headless_request(
                         result,
                         run,
                         composition,
+                        expected_base_commit=request.workspace.base_commit,
                     )
                     terminal_unsuccessful = run.primary_disposition.value != "succeeded"
             except BaseException as exc:
@@ -1003,6 +1005,8 @@ def _project_headless_run(
     result: dict[str, Any],
     run: Any,
     composition: ProductionComposition,
+    *,
+    expected_base_commit: str | None,
 ) -> tuple[bytes | None, bytes | None]:
     result["terminal"] = {
         "status": run.primary_disposition.value,
@@ -1031,6 +1035,8 @@ def _project_headless_run(
     )
     workspace_diff = run.workspace_diff
     if workspace_diff is None:
+        if expected_base_commit is not None:
+            raise ValueError("canonical workspace diff is unavailable")
         result["workspace_evidence"] = evidence_projection
         return event_bytes, None
     expected_keys = {
@@ -1049,6 +1055,8 @@ def _project_headless_run(
         or type(workspace_diff.get("snapshot_root_digest")) is not str
     ):
         raise ValueError("canonical workspace diff is unavailable")
+    if workspace_diff["base_commit"] != expected_base_commit:
+        raise ValueError("canonical workspace patch base commit mismatch")
     patch_bytes = workspace_diff["stdout"].encode("utf-8")
     if workspace_diff["patch_digest"] != _digest_bytes(patch_bytes):
         raise ValueError("canonical workspace patch digest mismatch")

--- a/breadboard/rl/harness/headless.py
+++ b/breadboard/rl/harness/headless.py
@@ -1017,7 +1017,7 @@ def _project_headless_run(
         "reward_components": dict(run.reward_components),
     }
     if run.evidence_manifest_ref is None:
-        return None, None
+        raise ValueError("headless evidence manifest is unavailable")
     evidence_projection, event_bytes = _load_evidence_projection(
         composition,
         run.evidence_manifest_ref,

--- a/breadboard/rl/harness/headless.py
+++ b/breadboard/rl/harness/headless.py
@@ -44,16 +44,8 @@ class HeadlessWorkspaceInput(BaseModel):
     repository_snapshot_digest: str | None = Field(
         default=None, pattern=_DIGEST_PATTERN
     )
-    base_commit: str | None = Field(default=None, pattern=_GIT_COMMIT_PATTERN)
+    base_commit: str = Field(pattern=_GIT_COMMIT_PATTERN)
     task_image_digest: str = Field(pattern=_DIGEST_PATTERN)
-
-    @model_validator(mode="after")
-    def _repository_identity_is_complete(self) -> HeadlessWorkspaceInput:
-        if (self.repository_snapshot_digest is None) != (self.base_commit is None):
-            raise ValueError(
-                "repository snapshot digest and base commit must be provided together"
-            )
-        return self
 
 
 class HeadlessProviderInput(BaseModel):
@@ -640,20 +632,17 @@ def _validate_repository_base_commit_binding(
         for digest, commit in bindings.items()
     ):
         raise ValueError("repository base-commit bindings are invalid")
-    expected_digest = request.workspace.repository_snapshot_digest
+    expected_digest = (
+        request.workspace.repository_snapshot_digest
+        or request.workspace.task_image_digest
+    )
     expected_commit = request.workspace.base_commit
-    if expected_digest is None:
-        if bindings:
-            raise ValueError(
-                "repository base-commit bindings require a repository snapshot"
-            )
-        return
     if (
         set(bindings) != {expected_digest}
         or bindings[expected_digest] != expected_commit
     ):
         raise ValueError(
-            "repository base commit is not bound to the admitted repository snapshot"
+            "repository base commit is not bound to the admitted workspace authority"
         )
 
 
@@ -1006,7 +995,7 @@ def _project_headless_run(
     run: Any,
     composition: ProductionComposition,
     *,
-    expected_base_commit: str | None,
+    expected_base_commit: str,
 ) -> tuple[bytes | None, bytes | None]:
     result["terminal"] = {
         "status": run.primary_disposition.value,
@@ -1035,10 +1024,7 @@ def _project_headless_run(
     )
     workspace_diff = run.workspace_diff
     if workspace_diff is None:
-        if expected_base_commit is not None:
-            raise ValueError("canonical workspace diff is unavailable")
-        result["workspace_evidence"] = evidence_projection
-        return event_bytes, None
+        raise ValueError("canonical workspace diff is unavailable")
     expected_keys = {
         "returncode", "stdout", "stderr", "base_commit",
         "git_executable_digest", "patch_digest", "snapshot_root_digest",

--- a/breadboard/rl/harness/sandbox.py
+++ b/breadboard/rl/harness/sandbox.py
@@ -856,6 +856,9 @@ class RuntimeLaunchContext:
     workspace_fd: int | None = None
     workspace_identity: tuple[int, int] | None = None
     owner_token: str | None = None
+    record_process_identity: (
+        Callable[[str, Mapping[str, Any] | None], None] | None
+    ) = None
 
     def __post_init__(self) -> None:
         if (
@@ -866,6 +869,10 @@ class RuntimeLaunchContext:
             or self.epoch <= 0
             or type(self.storage) is not WorkspaceStorageIdentity
             or not callable(self.publish_prepared_identity)
+            or (
+                self.record_process_identity is not None
+                and not callable(self.record_process_identity)
+            )
             or (self.workspace_fd is None) != (self.workspace_identity is None)
             or (
                 self.workspace_fd is not None
@@ -1889,6 +1896,13 @@ class TrustedProcessBackend:
                 plan, workspace, lease_id, executable, git_executable,
                 context.workspace_fd, context.workspace_identity,
             )
+            if context.record_process_identity is None:
+                raise SandboxLaunchError(
+                    "trusted process identity recorder is unavailable",
+                    code="runtime_preflight_failed",
+                    lease_id=lease_id,
+                )
+            handle.bind_identity_recorder(context.record_process_identity)
             repository_base_commit = await handle.measure_repository_base_commit()
             requested = {
                 "runtime": plan.runtime.runtime_id,
@@ -2853,6 +2867,8 @@ class SandboxRuntimeManager:
             result_relative_path=None if role == "primary" else "result",
             publish_prepared_identity=lambda identity, lease_id=lease_id:
                 self._publish_runtime_identity(lease_id, identity),
+            record_process_identity=lambda resource_id, identity, lease_id=lease_id:
+                self._record_process_identity(lease_id, resource_id, identity),
             workspace_fd=workspace_fd,
             workspace_identity=workspace_identity,
             owner_token=owner_token,
@@ -3218,11 +3234,6 @@ class SandboxRuntimeManager:
                 runtime, measurement = await backend.launch(
                     plan, materialized.workspace_path, context=context
                 )
-                if isinstance(runtime, TrustedProcessHandle):
-                    runtime.bind_identity_recorder(
-                        lambda resource_id, identity, lease_id=lease_id:
-                            self._record_process_identity(lease_id, resource_id, identity)
-                    )
                 if measurement.mismatch:
                     raise SandboxAttestationError("runtime measurement mismatch", code="runtime_measurement_mismatch",
                                                   lease_id=lease_id)

--- a/breadboard/rl/harness/sandbox.py
+++ b/breadboard/rl/harness/sandbox.py
@@ -82,10 +82,11 @@ def _read_sandbox_capability_matrix_resource() -> bytes:
     limit = _MAX_SANDBOX_CAPABILITY_MATRIX_BYTES
     if isinstance(resource, Path):
         expected = os.stat(resource, follow_symlinks=False)
-        if not stat.S_ISREG(expected.st_mode) or expected.st_size > limit:
-            raise OSError(
-                "sandbox capability matrix resource is not regular and bounded"
-            )
+        if (
+            not stat.S_ISREG(expected.st_mode)
+            or expected.st_size > limit
+        ):
+            raise OSError("sandbox capability matrix resource is not regular and bounded")
         descriptor = os.open(
             resource,
             os.O_RDONLY
@@ -98,9 +99,12 @@ def _read_sandbox_capability_matrix_resource() -> bytes:
             if (
                 not stat.S_ISREG(opened.st_mode)
                 or opened.st_size > limit
-                or (opened.st_dev, opened.st_ino) != (expected.st_dev, expected.st_ino)
+                or (opened.st_dev, opened.st_ino)
+                != (expected.st_dev, expected.st_ino)
             ):
-                raise OSError("sandbox capability matrix resource identity changed")
+                raise OSError(
+                    "sandbox capability matrix resource identity changed"
+                )
             chunks: list[bytes] = []
             remaining = limit + 1
             while remaining:
@@ -131,10 +135,7 @@ def load_sandbox_capability_matrix() -> Mapping[str, Any]:
     """Load and validate the installed canonical sandbox capability matrix."""
     try:
         encoded_matrix = _read_sandbox_capability_matrix_resource()
-        if (
-            hashlib.sha256(encoded_matrix).hexdigest()
-            != SANDBOX_CAPABILITY_MATRIX_SHA256
-        ):
+        if hashlib.sha256(encoded_matrix).hexdigest() != SANDBOX_CAPABILITY_MATRIX_SHA256:
             raise SandboxRuntimeError(
                 "sandbox capability matrix digest is invalid",
                 code="capability_matrix_invalid",
@@ -184,12 +185,11 @@ def load_sandbox_capability_matrix() -> Mapping[str, Any]:
                 "unavailable_code",
                 "evidence_contracts",
             }
-            or adapter["status"] != _SANDBOX_ADAPTER_STATUSES.get(adapter["adapter_id"])
+            or adapter["status"]
+            != _SANDBOX_ADAPTER_STATUSES.get(adapter["adapter_id"])
             or type(adapter["capabilities"]) is not dict
             or set(adapter["capabilities"]) != _SANDBOX_CAPABILITY_KEYS
-            or any(
-                type(value) is not bool for value in adapter["capabilities"].values()
-            )
+            or any(type(value) is not bool for value in adapter["capabilities"].values())
             or type(adapter["required_host_capabilities"]) is not list
             or any(
                 type(value) is not str or not value
@@ -222,14 +222,12 @@ def load_sandbox_capability_matrix() -> Mapping[str, Any]:
 
 def _wp7_digest(value: Any) -> str:
     import hashlib
-
     return "sha256:" + hashlib.sha256(canonical_json_bytes(value)).hexdigest()
 
 
 def _seal_tree_at(parent_fd: int, name: str) -> None:
     directory_fd = os.open(
-        name,
-        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+        name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
         dir_fd=parent_fd,
     )
     try:
@@ -270,9 +268,7 @@ def _open_directory_at(parent_fd: int, name: str, *, create: bool) -> int:
         return os.open(name, flags, dir_fd=parent_fd)
 
 
-def _open_parent_descriptor(
-    root: Path, parts: tuple[str, ...], *, create: bool
-) -> tuple[int, str]:
+def _open_parent_descriptor(root: Path, parts: tuple[str, ...], *, create: bool) -> tuple[int, str]:
     descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
     try:
         for component in parts[:-1]:
@@ -285,9 +281,7 @@ def _open_parent_descriptor(
         raise
 
 
-def _open_parent_descriptor_fd(
-    root_fd: int, parts: tuple[str, ...], *, create: bool
-) -> tuple[int, str]:
+def _open_parent_descriptor_fd(root_fd: int, parts: tuple[str, ...], *, create: bool) -> tuple[int, str]:
     descriptor = os.dup(root_fd)
     try:
         for component in parts[:-1]:
@@ -300,9 +294,7 @@ def _open_parent_descriptor_fd(
         raise
 
 
-def _bounded_regular_read(
-    root: Path | int, logical_path: str, *, offset: int, limit: int
-) -> bytes:
+def _bounded_regular_read(root: Path | int, logical_path: str, *, offset: int, limit: int) -> bytes:
     parts = _workspace_parts(logical_path)
     parent_fd, name = (
         _open_parent_descriptor_fd(root, parts, create=False)
@@ -436,11 +428,11 @@ def _descriptor_list(
         before = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
         descriptor = _open_directory_at(parent_fd, name, create=False)
         after = os.fstat(descriptor)
-        if not file_type.S_ISDIR(before.st_mode) or (
-            before.st_dev,
-            before.st_ino,
-            before.st_mode,
-        ) != (after.st_dev, after.st_ino, after.st_mode):
+        if (
+            not file_type.S_ISDIR(before.st_mode)
+            or (before.st_dev, before.st_ino, before.st_mode)
+            != (after.st_dev, after.st_ino, after.st_mode)
+        ):
             raise OSError("workspace listing root identity changed")
         walk(descriptor, parts, 0)
         return values
@@ -525,8 +517,7 @@ class _PinnedExecutable:
 
 
 def _snapshot_installed_executable(
-    path: str,
-    expected_digest: str | None,
+    path: str, expected_digest: str | None
 ) -> _PinnedExecutable:
     required_fcntl = (
         "F_ADD_SEALS",
@@ -643,16 +634,15 @@ class InstalledRuntime:
             or not _exact_absolute_path(self.executable_path)
             or not _exact_sha256_digest(self.measured_binary_digest)
         ):
-            raise ValueError(
-                "runtime authority requires an exact class, path, and digest"
-            )
+            raise ValueError("runtime authority requires an exact class, path, and digest")
         hardened = self.runtime_class in {
             RuntimeClass.HARDENED_DOCKER,
             RuntimeClass.HARDENED_GVISOR,
         }
-        oci_identity_valid = _exact_absolute_path(
-            self.oci_runtime_binary_path
-        ) and _exact_sha256_digest(self.oci_runtime_binary_digest)
+        oci_identity_valid = (
+            _exact_absolute_path(self.oci_runtime_binary_path)
+            and _exact_sha256_digest(self.oci_runtime_binary_digest)
+        )
         if hardened and (not self.oci_runtime_name or not oci_identity_valid):
             raise ValueError("hardened runtime requires an exact OCI binary authority")
         if not hardened and (
@@ -664,19 +654,12 @@ class InstalledRuntime:
             self.runsc_binary_path != self.oci_runtime_binary_path
             or self.runsc_binary_digest != self.oci_runtime_binary_digest
         ):
-            raise ValueError(
-                "runsc registration authority must equal the pinned OCI binary"
-            )
+            raise ValueError("runsc registration authority must equal the pinned OCI binary")
         if self.fixed_environment != tuple(sorted(self.fixed_environment)):
             raise ValueError("fixed environment must be sorted")
-        if len({key for key, _ in self.fixed_environment}) != len(
-            self.fixed_environment
-        ):
+        if len({key for key, _ in self.fixed_environment}) != len(self.fixed_environment):
             raise ValueError("fixed environment keys must be unique")
-        if any(
-            not key or "=" in key or "\x00" in key + value
-            for key, value in self.fixed_environment
-        ):
+        if any(not key or "=" in key or "\x00" in key + value for key, value in self.fixed_environment):
             raise ValueError("invalid fixed environment")
 
 
@@ -687,10 +670,7 @@ class InstalledImage:
     immutable_reference: str
 
     def __post_init__(self) -> None:
-        if (
-            not self.image_digest.startswith("sha256:")
-            or "@sha256:" not in self.immutable_reference
-        ):
+        if not self.image_digest.startswith("sha256:") or "@sha256:" not in self.immutable_reference:
             raise ValueError("installed image must use an immutable digest reference")
 
 
@@ -716,49 +696,27 @@ class SandboxSecurityPolicy:
     snapshot_max_inodes: int
 
     def __post_init__(self) -> None:
-        if (
-            _wp7_digest(self.seccomp_bytes.decode("utf-8")) != self.seccomp_digest
-            and (
-                "sha256:" + __import__("hashlib").sha256(self.seccomp_bytes).hexdigest()
-            )
-            != self.seccomp_digest
-        ):
+        if _wp7_digest(self.seccomp_bytes.decode("utf-8")) != self.seccomp_digest and (
+            "sha256:" + __import__("hashlib").sha256(self.seccomp_bytes).hexdigest()
+        ) != self.seccomp_digest:
             raise ValueError("seccomp digest mismatch")
         if self.privileged or self.devices or not self.docker_socket_forbidden:
             raise ValueError("security policy admits forbidden container authority")
         if (self.apparmor_profile is None) == (self.selinux_label is None):
             raise ValueError("exactly one LSM authority is required")
-        if (
-            min(
-                self.uid,
-                self.gid,
-                self.snapshot_max_depth,
-                self.snapshot_max_files,
-                self.snapshot_max_inodes,
-            )
-            < 0
-        ):
+        if min(self.uid, self.gid, self.snapshot_max_depth, self.snapshot_max_files, self.snapshot_max_inodes) < 0:
             raise ValueError("invalid security policy numeric value")
 
     def projection(self) -> dict[str, Any]:
-        return {
-            "uid": self.uid,
-            "gid": self.gid,
-            "read_only_root": self.read_only_root,
-            "drop_all_capabilities": self.drop_all_capabilities,
-            "no_new_privileges": self.no_new_privileges,
-            "seccomp_digest": self.seccomp_digest,
-            "apparmor_profile": self.apparmor_profile,
-            "selinux_label": self.selinux_label,
-            "namespace_flags": list(self.namespace_flags),
-            "privileged": self.privileged,
-            "devices": list(self.devices),
-            "docker_socket_forbidden": self.docker_socket_forbidden,
-            "tmpfs_mounts": [list(item) for item in self.tmpfs_mounts],
-            "snapshot_max_depth": self.snapshot_max_depth,
-            "snapshot_max_files": self.snapshot_max_files,
-            "snapshot_max_inodes": self.snapshot_max_inodes,
-        }
+        return {"uid": self.uid, "gid": self.gid, "read_only_root": self.read_only_root,
+                "drop_all_capabilities": self.drop_all_capabilities,
+                "no_new_privileges": self.no_new_privileges, "seccomp_digest": self.seccomp_digest,
+                "apparmor_profile": self.apparmor_profile, "selinux_label": self.selinux_label,
+                "namespace_flags": list(self.namespace_flags), "privileged": self.privileged,
+                "devices": list(self.devices), "docker_socket_forbidden": self.docker_socket_forbidden,
+                "tmpfs_mounts": [list(item) for item in self.tmpfs_mounts],
+                "snapshot_max_depth": self.snapshot_max_depth, "snapshot_max_files": self.snapshot_max_files,
+                "snapshot_max_inodes": self.snapshot_max_inodes}
 
     @staticmethod
     def derive_digest(projection: Mapping[str, Any]) -> str:
@@ -774,12 +732,8 @@ class SandboxNetworkPolicy:
     default_deny: bool
 
     def projection(self) -> dict[str, Any]:
-        return {
-            "mode": self.mode,
-            "docker_network": self.docker_network,
-            "egress_route_ids": list(self.egress_route_ids),
-            "default_deny": self.default_deny,
-        }
+        return {"mode": self.mode, "docker_network": self.docker_network,
+                "egress_route_ids": list(self.egress_route_ids), "default_deny": self.default_deny}
 
     @staticmethod
     def derive_digest(projection: Mapping[str, Any]) -> str:
@@ -800,23 +754,11 @@ class InstalledVerifier:
     result_schema_digest: str
 
     def __post_init__(self) -> None:
-        if (
-            not self.argv
-            or Path(self.result_relative_path).is_absolute()
-            or ".." in Path(self.result_relative_path).parts
-        ):
+        if not self.argv or Path(self.result_relative_path).is_absolute() or ".." in Path(self.result_relative_path).parts:
             raise ValueError("invalid installed verifier")
-        if (
-            self.executable_digest,
-            self.code_digest,
-            self.input_schema_digest,
-            self.result_schema_digest,
-        ) != (
-            self.grant.executable_digest,
-            self.grant.code_digest,
-            self.grant.input_schema_digest,
-            self.grant.result_schema_digest,
-        ):
+        if (self.executable_digest, self.code_digest, self.input_schema_digest, self.result_schema_digest) != (
+            self.grant.executable_digest, self.grant.code_digest, self.grant.input_schema_digest,
+            self.grant.result_schema_digest):
             raise ValueError("verifier authority digest mismatch")
 
 
@@ -829,18 +771,14 @@ class InstalledSandboxAuthoritySet:
     verifiers: tuple[InstalledVerifier, ...]
 
     def __post_init__(self) -> None:
-        for values, key in (
-            (self.runtimes, lambda value: value.runtime_id),
-            (self.images, lambda value: value.image_digest),
-            (self.security_policies, lambda value: value.policy_digest),
-            (self.network_policies, lambda value: value.policy_digest),
-            (self.verifiers, lambda value: value.grant.verifier_id),
-        ):
+        for values, key in ((self.runtimes, lambda value: value.runtime_id),
+                            (self.images, lambda value: value.image_digest),
+                            (self.security_policies, lambda value: value.policy_digest),
+                            (self.network_policies, lambda value: value.policy_digest),
+                            (self.verifiers, lambda value: value.grant.verifier_id)):
             keys = tuple(key(value) for value in values)
             if keys != tuple(sorted(keys)) or len(keys) != len(set(keys)):
-                raise ValueError(
-                    "installed authority catalogs must be sorted and unique"
-                )
+                raise ValueError("installed authority catalogs must be sorted and unique")
 
 
 @dataclass(frozen=True, slots=True)
@@ -894,10 +832,8 @@ class RuntimePreparedIdentity:
         if (
             type(self.runtime_resource_id) is not str
             or not self.runtime_resource_id
-            or any(
-                type(key) is not str or not key or type(value) is not str
-                for key, value in self.labels.items()
-            )
+            or any(type(key) is not str or not key or type(value) is not str
+                   for key, value in self.labels.items())
         ):
             raise ValueError("invalid prepared runtime identity")
         object.__setattr__(
@@ -936,10 +872,7 @@ class RuntimeLaunchContext:
                     or self.workspace_fd < 0
                     or type(self.workspace_identity) is not tuple
                     or len(self.workspace_identity) != 2
-                    or any(
-                        type(value) is not int or value < 0
-                        for value in self.workspace_identity
-                    )
+                    or any(type(value) is not int or value < 0 for value in self.workspace_identity)
                 )
             )
             or (
@@ -981,16 +914,9 @@ class SandboxMeasurement:
 
 
 class SandboxRuntimeError(RuntimeError):
-    def __init__(
-        self,
-        message: str,
-        *,
-        code: str,
-        episode_id: str | None = None,
-        effective_plan_digest: str | None = None,
-        lease_id: str | None = None,
-        details: Mapping[str, Any] | None = None,
-    ) -> None:
+    def __init__(self, message: str, *, code: str, episode_id: str | None = None,
+                 effective_plan_digest: str | None = None, lease_id: str | None = None,
+                 details: Mapping[str, Any] | None = None) -> None:
         super().__init__(message)
         self.code = code
         self.episode_id = episode_id
@@ -999,48 +925,20 @@ class SandboxRuntimeError(RuntimeError):
         self.details = MappingProxyType(dict(details or {}))
 
 
-class SandboxPlanError(SandboxRuntimeError):
-    pass
-
-
-class MaterializationError(SandboxRuntimeError):
-    pass
-
-
-class CacheLeaseError(MaterializationError):
-    pass
-
-
-class SandboxLaunchError(SandboxRuntimeError):
-    pass
-
-
-class SandboxAttestationError(SandboxRuntimeError):
-    pass
-
-
-class WorkspaceStateError(SandboxRuntimeError):
-    pass
-
-
-class VerifierSnapshotError(SandboxRuntimeError):
-    pass
-
-
-class VerifierExecutionError(SandboxRuntimeError):
-    pass
+class SandboxPlanError(SandboxRuntimeError): pass
+class MaterializationError(SandboxRuntimeError): pass
+class CacheLeaseError(MaterializationError): pass
+class SandboxLaunchError(SandboxRuntimeError): pass
+class SandboxAttestationError(SandboxRuntimeError): pass
+class WorkspaceStateError(SandboxRuntimeError): pass
+class VerifierSnapshotError(SandboxRuntimeError): pass
+class VerifierExecutionError(SandboxRuntimeError): pass
 
 
 class SandboxFault(SandboxRuntimeError):
-    def __init__(
-        self,
-        primary: BaseException,
-        cleanup_receipt: SandboxCleanupReceipt,
-        cleanup_errors: tuple[str, ...],
-    ) -> None:
-        super().__init__(
-            "sandbox operation and cleanup both failed", code="cleanup_incomplete"
-        )
+    def __init__(self, primary: BaseException, cleanup_receipt: SandboxCleanupReceipt,
+                 cleanup_errors: tuple[str, ...]) -> None:
+        super().__init__("sandbox operation and cleanup both failed", code="cleanup_incomplete")
         self.primary = primary
         self.cleanup_receipt = cleanup_receipt
         self.cleanup_errors = cleanup_errors
@@ -1050,263 +948,121 @@ class SandboxFault(SandboxRuntimeError):
 def _exact_one(values: Sequence[Any], predicate: Any, *, missing_code: str) -> Any:
     found = [value for value in values if predicate(value)]
     if len(found) != 1:
-        raise SandboxPlanError(
-            "installed authority did not resolve exactly once", code=missing_code
-        )
+        raise SandboxPlanError("installed authority did not resolve exactly once", code=missing_code)
     return found[0]
 
 
-def build_sandbox_execution_plan(
-    request: WorkspaceOpenRequest,
-    registries: RegistrySnapshotSet,
-    installed_authorities: InstalledSandboxAuthoritySet,
-) -> SandboxExecutionPlan:
-    if (
-        type(request) is not WorkspaceOpenRequest
-        or type(request.effective_plan) is not EffectiveExecutionPlan
-    ):
-        raise SandboxPlanError(
-            "exact workspace request required", code="plan_type_invalid"
-        )
-    if (
-        type(registries) is not RegistrySnapshotSet
-        or type(installed_authorities) is not InstalledSandboxAuthoritySet
-    ):
-        raise SandboxPlanError(
-            "exact installed catalogs required", code="plan_type_invalid"
-        )
+def build_sandbox_execution_plan(request: WorkspaceOpenRequest, registries: RegistrySnapshotSet,
+                                 installed_authorities: InstalledSandboxAuthoritySet) -> SandboxExecutionPlan:
+    if type(request) is not WorkspaceOpenRequest or type(request.effective_plan) is not EffectiveExecutionPlan:
+        raise SandboxPlanError("exact workspace request required", code="plan_type_invalid")
+    if type(registries) is not RegistrySnapshotSet or type(installed_authorities) is not InstalledSandboxAuthoritySet:
+        raise SandboxPlanError("exact installed catalogs required", code="plan_type_invalid")
     plan = request.effective_plan
     if request.effective_plan_digest != plan.canonical_digest():
-        raise SandboxPlanError(
-            "effective plan digest mismatch", code="plan_digest_mismatch"
-        )
-    binding_record = _exact_one(
-        registries.sandbox_runtimes,
-        lambda item: item.binding.runtime_id == plan.sandbox.runtime_id,
-        missing_code="runtime_authority_missing",
-    )
-    expected_binding = SandboxBinding(
-        runtime_id=plan.sandbox.runtime_id,
+        raise SandboxPlanError("effective plan digest mismatch", code="plan_digest_mismatch")
+    binding_record = _exact_one(registries.sandbox_runtimes,
+                                lambda item: item.binding.runtime_id == plan.sandbox.runtime_id,
+                                missing_code="runtime_authority_missing")
+    expected_binding = SandboxBinding(runtime_id=plan.sandbox.runtime_id,
         runtime_class=plan.sandbox.runtime_class,
         driver_implementation_digest=plan.sandbox.driver_implementation_digest,
         runtime_binary_digest=plan.sandbox.runtime_binary_digest,
         security_policy_digest=plan.sandbox.security_policy_digest,
         image_digest=plan.sandbox.image_digest,
-        network_policy_digest=plan.sandbox.network_policy_digest,
-    )
+        network_policy_digest=plan.sandbox.network_policy_digest)
     if binding_record.binding != expected_binding:
-        raise SandboxPlanError(
-            "runtime registry binding mismatch", code="runtime_identity_mismatch"
-        )
-    runtime = _exact_one(
-        installed_authorities.runtimes,
-        lambda item: item.runtime_id == plan.sandbox.runtime_id,
-        missing_code="runtime_authority_missing",
-    )
-    if (
-        runtime.runtime_class,
-        runtime.driver_implementation_digest,
-        runtime.measured_binary_digest,
-    ) != (
-        plan.sandbox.runtime_class,
-        plan.sandbox.driver_implementation_digest,
-        plan.sandbox.runtime_binary_digest,
-    ):
-        raise SandboxPlanError(
-            "installed runtime mismatch", code="runtime_identity_mismatch"
-        )
-    if runtime.runtime_class not in {
-        RuntimeClass.TRUSTED_PROCESS,
-        RuntimeClass.HARDENED_DOCKER,
-        RuntimeClass.HARDENED_GVISOR,
-    }:
+        raise SandboxPlanError("runtime registry binding mismatch", code="runtime_identity_mismatch")
+    runtime = _exact_one(installed_authorities.runtimes,
+                         lambda item: item.runtime_id == plan.sandbox.runtime_id,
+                         missing_code="runtime_authority_missing")
+    if (runtime.runtime_class, runtime.driver_implementation_digest, runtime.measured_binary_digest) != (
+        plan.sandbox.runtime_class, plan.sandbox.driver_implementation_digest, plan.sandbox.runtime_binary_digest):
+        raise SandboxPlanError("installed runtime mismatch", code="runtime_identity_mismatch")
+    if runtime.runtime_class not in {RuntimeClass.TRUSTED_PROCESS, RuntimeClass.HARDENED_DOCKER, RuntimeClass.HARDENED_GVISOR}:
         raise SandboxPlanError("runtime class unsupported", code="runtime_unsupported")
-    if (
-        runtime.runtime_class is RuntimeClass.HARDENED_GVISOR
-        and runtime.oci_runtime_name != "runsc"
-    ):
-        raise SandboxPlanError(
-            "runsc authority is not exact", code="runtime_unsupported"
-        )
-    image = _exact_one(
-        installed_authorities.images,
-        lambda item: item.image_digest == plan.sandbox.image_digest,
-        missing_code="runtime_authority_missing",
-    )
+    if runtime.runtime_class is RuntimeClass.HARDENED_GVISOR and runtime.oci_runtime_name != "runsc":
+        raise SandboxPlanError("runsc authority is not exact", code="runtime_unsupported")
+    image = _exact_one(installed_authorities.images, lambda item: item.image_digest == plan.sandbox.image_digest,
+                       missing_code="runtime_authority_missing")
     if image.runtime_id != runtime.runtime_id:
-        raise SandboxPlanError(
-            "image runtime mismatch", code="runtime_identity_mismatch"
-        )
-    image_record = _exact_one(
-        registries.images,
-        lambda item: item.image_digest == image.image_digest,
-        missing_code="runtime_authority_missing",
-    )
+        raise SandboxPlanError("image runtime mismatch", code="runtime_identity_mismatch")
+    image_record = _exact_one(registries.images, lambda item: item.image_digest == image.image_digest,
+                              missing_code="runtime_authority_missing")
     if image_record.runtime_id != runtime.runtime_id:
-        raise SandboxPlanError(
-            "image registry mismatch", code="runtime_identity_mismatch"
-        )
-    security = _exact_one(
-        installed_authorities.security_policies,
-        lambda item: item.policy_digest == plan.sandbox.security_policy_digest,
-        missing_code="runtime_authority_missing",
-    )
-    if security.policy_digest != SandboxSecurityPolicy.derive_digest(
-        security.projection()
+        raise SandboxPlanError("image registry mismatch", code="runtime_identity_mismatch")
+    security = _exact_one(installed_authorities.security_policies,
+                          lambda item: item.policy_digest == plan.sandbox.security_policy_digest,
+                          missing_code="runtime_authority_missing")
+    if security.policy_digest != SandboxSecurityPolicy.derive_digest(security.projection()):
+        raise SandboxPlanError("security policy content mismatch", code="runtime_identity_mismatch")
+    if runtime.runtime_class in {RuntimeClass.HARDENED_DOCKER, RuntimeClass.HARDENED_GVISOR} and (
+        security.uid == 0 or security.gid == 0
     ):
-        raise SandboxPlanError(
-            "security policy content mismatch", code="runtime_identity_mismatch"
-        )
-    if runtime.runtime_class in {
-        RuntimeClass.HARDENED_DOCKER,
-        RuntimeClass.HARDENED_GVISOR,
-    } and (security.uid == 0 or security.gid == 0):
-        raise SandboxPlanError(
-            "hardened runtime cannot run as root", code="runtime_identity_mismatch"
-        )
-    network = _exact_one(
-        installed_authorities.network_policies,
-        lambda item: item.policy_digest == plan.sandbox.network_policy_digest,
-        missing_code="runtime_authority_missing",
-    )
-    if network.policy_digest != SandboxNetworkPolicy.derive_digest(
-        network.projection()
-    ):
-        raise SandboxPlanError(
-            "network policy content mismatch", code="runtime_identity_mismatch"
-        )
+        raise SandboxPlanError("hardened runtime cannot run as root", code="runtime_identity_mismatch")
+    network = _exact_one(installed_authorities.network_policies,
+                         lambda item: item.policy_digest == plan.sandbox.network_policy_digest,
+                         missing_code="runtime_authority_missing")
+    if network.policy_digest != SandboxNetworkPolicy.derive_digest(network.projection()):
+        raise SandboxPlanError("network policy content mismatch", code="runtime_identity_mismatch")
     if tuple(network.egress_route_ids) != tuple(plan.sandbox.egress_route_ids):
-        raise SandboxPlanError(
-            "network route authority mismatch", code="runtime_identity_mismatch"
-        )
+        raise SandboxPlanError("network route authority mismatch", code="runtime_identity_mismatch")
     if network.mode != "none" or not network.default_deny or network.egress_route_ids:
-        raise SandboxPlanError(
-            "installed network enforcement is unsupported", code="runtime_unsupported"
-        )
+        raise SandboxPlanError("installed network enforcement is unsupported", code="runtime_unsupported")
     setup_records: list[SetupRegistryRecord] = []
     for grant in plan.effective_capabilities.setup_plans:
-        record = _exact_one(
-            registries.setups,
-            lambda item, grant=grant: item.grant.setup_id == grant.setup_id,
-            missing_code="setup_plan_unresolvable",
-        )
-        if (
-            record.grant != grant
-            or record.derived_plan_digest() != grant.plan_digest
-            or record.route_ids
-            or record.secret_handle_ids
-        ):
-            raise SandboxPlanError(
-                "setup plan is not exactly resolvable", code="setup_plan_unresolvable"
-            )
+        record = _exact_one(registries.setups, lambda item, grant=grant: item.grant.setup_id == grant.setup_id,
+                            missing_code="setup_plan_unresolvable")
+        if record.grant != grant or record.derived_plan_digest() != grant.plan_digest or record.route_ids or record.secret_handle_ids:
+            raise SandboxPlanError("setup plan is not exactly resolvable", code="setup_plan_unresolvable")
         setup_records.append(record)
-    verifier = _exact_one(
-        installed_authorities.verifiers,
-        lambda item: item.grant.verifier_id == plan.verifier.verifier_id,
-        missing_code="verifier_authority_mismatch",
-    )
-    verifier_registry = _exact_one(
-        registries.verifiers,
-        lambda item: item.grant.verifier_id == plan.verifier.verifier_id,
-        missing_code="verifier_authority_mismatch",
-    )
-    if (
-        verifier.grant != plan.verifier
-        or verifier_registry.grant != plan.verifier
+    verifier = _exact_one(installed_authorities.verifiers,
+                          lambda item: item.grant.verifier_id == plan.verifier.verifier_id,
+                          missing_code="verifier_authority_mismatch")
+    verifier_registry = _exact_one(registries.verifiers,
+                                   lambda item: item.grant.verifier_id == plan.verifier.verifier_id,
+                                   missing_code="verifier_authority_mismatch")
+    if (verifier.grant != plan.verifier or verifier_registry.grant != plan.verifier
         or verifier_registry.runtime_id != verifier.runtime_id
         or verifier_registry.runtime_class is not verifier.runtime_class
         or verifier_registry.security_policy_digest != verifier.security_policy_digest
-        or plan.verifier.secret_handle_ids
-    ):
-        raise SandboxPlanError(
-            "verifier authority mismatch", code="verifier_authority_mismatch"
-        )
-    tools = tuple(
-        RunnerToolBinding(item.tool_id, item.implementation_digest, item.capability_ids)
-        for item in plan.effective_capabilities.tools
-    )
-    mounts_by_digest = {
-        mount.source_artifact_digest: mount for mount in plan.sandbox.mounts
-    }
+        or plan.verifier.secret_handle_ids):
+        raise SandboxPlanError("verifier authority mismatch", code="verifier_authority_mismatch")
+    tools = tuple(RunnerToolBinding(item.tool_id, item.implementation_digest, item.capability_ids)
+                  for item in plan.effective_capabilities.tools)
+    mounts_by_digest = {mount.source_artifact_digest: mount for mount in plan.sandbox.mounts}
     required: list[tuple[str, str]] = []
     if plan.task.repository_snapshot_digest is not None:
         required.append((plan.task.repository_snapshot_digest, "repository"))
     required += [(value, "dataset") for value in plan.task.dataset_digests]
     required += [(value, "input") for value in plan.task.input_artifact_digests]
-    required += [
-        (value, "setup_input")
-        for record in setup_records
-        for value in record.input_digests
-    ]
+    required += [(value, "setup_input") for record in setup_records for value in record.input_digests]
     if any(digest not in mounts_by_digest for digest, _ in required):
-        raise SandboxPlanError(
-            "task or setup input has no admitted target", code="task_input_unmapped"
-        )
+        raise SandboxPlanError("task or setup input has no admitted target", code="task_input_unmapped")
     role_by_digest = {digest: role for digest, role in required}
-    entries = tuple(
-        sorted(
-            (
-                MaterializationEntry(
-                    mount.source_artifact_digest,
-                    mount.target_logical_path,
-                    mount.access,
-                    mount.max_bytes,
-                    role_by_digest.get(mount.source_artifact_digest, "mount"),
-                )
-                for mount in plan.sandbox.mounts
-            ),
-            key=lambda item: (item.target_logical_path, item.source_digest, item.role),
-        )
-    )
+    entries = tuple(sorted((MaterializationEntry(mount.source_artifact_digest, mount.target_logical_path,
+                                                  mount.access, mount.max_bytes,
+                                                  role_by_digest.get(mount.source_artifact_digest, "mount"))
+                            for mount in plan.sandbox.mounts), key=lambda item: (item.target_logical_path, item.source_digest, item.role)))
     materialization = WorkspaceMaterializationPlan(
-        request.episode_id,
-        plan.subject_digest,
-        plan.final_receipt_digest,
-        request.effective_plan_digest,
-        plan.sandbox.model_dump(mode="json"),
-        plan.task.model_dump(mode="json"),
-        tuple(record.plan_projection() for record in setup_records),
-        entries,
-        tools,
+        request.episode_id, plan.subject_digest, plan.final_receipt_digest, request.effective_plan_digest,
+        plan.sandbox.model_dump(mode="json"), plan.task.model_dump(mode="json"),
+        tuple(record.plan_projection() for record in setup_records), entries, tools,
         plan.effective_capabilities.resources.model_dump(mode="json"),
-        plan.effective_capabilities.limits.model_dump(mode="json"),
-    )
-    disposition = (
-        IsolationDisposition.TRUSTED_PROCESS
-        if runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS
-        else IsolationDisposition.ISOLATED
-    )
-    return SandboxExecutionPlan(
-        request.episode_id,
-        request.effective_plan_digest,
-        plan.subject_digest,
-        plan.final_receipt_digest,
-        runtime,
-        image,
-        security,
-        network,
-        tuple(setup_records),
-        verifier,
-        plan.effective_capabilities.resources,
-        plan.effective_capabilities.limits,
-        materialization,
-        tools,
-        disposition,
-    )
+        plan.effective_capabilities.limits.model_dump(mode="json"))
+    disposition = IsolationDisposition.TRUSTED_PROCESS if runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS else IsolationDisposition.ISOLATED
+    return SandboxExecutionPlan(request.episode_id, request.effective_plan_digest, plan.subject_digest,
+                                plan.final_receipt_digest, runtime, image, security, network,
+                                tuple(setup_records), verifier, plan.effective_capabilities.resources,
+                                plan.effective_capabilities.limits, materialization, tools, disposition)
 
 
 class RuntimeHandle(Protocol):
     runtime_id: str
-
-    async def run_shell(
-        self, command: str, *, timeout_ms: int, output_limit: int
-    ) -> Mapping[str, Any]: ...
+    async def run_shell(self, command: str, *, timeout_ms: int, output_limit: int) -> Mapping[str, Any]: ...
     async def terminate(self) -> tuple[CleanupStepReceipt, ...]: ...
 
-    async def run_argv(
-        self, argv: Sequence[str], *, timeout_ms: int, output_limit: int
-    ) -> Mapping[str, Any]: ...
-
+    async def run_argv(self, argv: Sequence[str], *, timeout_ms: int, output_limit: int) -> Mapping[str, Any]: ...
 
 def _sealed_repository_diff(
     *,
@@ -1320,12 +1076,10 @@ def _sealed_repository_diff(
         or any(character not in "0123456789abcdef" for character in base_commit)
     ):
         raise VerifierSnapshotError(
-            "workspace base commit is invalid",
-            code="snapshot_tampered",
+            "workspace base commit is invalid", code="snapshot_tampered"
         )
     git_path = shutil.which(
-        "git",
-        path=dict(plan.runtime.fixed_environment).get("PATH", os.defpath),
+        "git", path=dict(plan.runtime.fixed_environment).get("PATH", os.defpath)
     )
     if git_path is None:
         raise VerifierSnapshotError(
@@ -1334,7 +1088,6 @@ def _sealed_repository_diff(
         )
     pinned = _snapshot_installed_executable(git_path, None)
     timeout_seconds = max(1, (plan.limits.action_timeout_ms + 999) // 1000)
-    output_limit = plan.limits.artifact_bytes_each
 
     def invoke(
         arguments: tuple[str, ...],
@@ -1357,12 +1110,14 @@ def _sealed_repository_diff(
                 )
             except (OSError, subprocess.TimeoutExpired) as exc:
                 raise VerifierSnapshotError(
-                    "sealed workspace diff command failed",
-                    code="snapshot_tampered",
+                    "sealed workspace diff command failed", code="snapshot_tampered"
                 ) from exc
             stdout_size = os.fstat(stdout.fileno()).st_size
             stderr_size = os.fstat(stderr.fileno()).st_size
-            if stdout_size > stdout_limit or stderr_size > 64 * 1024:
+            if (
+                stdout_size > stdout_limit
+                or stderr_size > 64 * 1024
+            ):
                 raise VerifierSnapshotError(
                     "sealed workspace diff exceeded its output limit",
                     code="output_limit_exceeded",
@@ -1372,8 +1127,8 @@ def _sealed_repository_diff(
             return completed.returncode, stdout.read(), stderr.read()
 
     try:
-        repository_identity = repository.stat(follow_symlinks=False)
-        if not stat.S_ISDIR(repository_identity.st_mode):
+        identity = repository.stat(follow_symlinks=False)
+        if not stat.S_ISDIR(identity.st_mode):
             raise VerifierSnapshotError(
                 "sealed workspace repository is not a directory",
                 code="snapshot_tampered",
@@ -1393,21 +1148,16 @@ def _sealed_repository_diff(
                 ),
             }
             common = (
-                "-c",
-                "core.attributesFile=/dev/null",
-                "-c",
-                "core.hooksPath=/dev/null",
-                "-c",
-                "diff.external=",
+                "-c", "core.attributesFile=/dev/null",
+                "-c", "core.hooksPath=/dev/null",
+                "-c", "diff.external=",
             )
             for command in (
                 (*common, "read-tree", base_commit),
                 (*common, "add", "--intent-to-add", "--force", "--", "."),
             ):
                 returncode, _, stderr = invoke(
-                    command,
-                    environment=environment,
-                    stdout_limit=64 * 1024,
+                    command, environment=environment, stdout_limit=64 * 1024
                 )
                 if returncode != 0:
                     raise VerifierSnapshotError(
@@ -1417,20 +1167,12 @@ def _sealed_repository_diff(
                     )
             returncode, stdout, stderr = invoke(
                 (
-                    *common,
-                    "diff",
-                    "--no-ext-diff",
-                    "--no-textconv",
-                    "--binary",
-                    "--full-index",
-                    "--no-renames",
-                    "--ignore-submodules=none",
-                    base_commit,
-                    "--",
-                    ".",
+                    *common, "diff", "--no-ext-diff", "--no-textconv", "--binary",
+                    "--full-index", "--no-renames", "--ignore-submodules=none",
+                    base_commit, "--", ".",
                 ),
                 environment=environment,
-                stdout_limit=output_limit,
+                stdout_limit=plan.limits.artifact_bytes_each,
             )
             if returncode != 0:
                 raise VerifierSnapshotError(
@@ -1449,21 +1191,15 @@ def _sealed_repository_diff(
             )
     except UnicodeDecodeError as exc:
         raise VerifierSnapshotError(
-            "sealed workspace diff is not UTF-8",
-            code="snapshot_tampered",
+            "sealed workspace diff is not UTF-8", code="snapshot_tampered"
         ) from exc
     finally:
         pinned.close()
 
 
 class RuntimeBackend(Protocol):
-    async def launch(
-        self,
-        plan: SandboxExecutionPlan,
-        workspace: Path,
-        *,
-        context: RuntimeLaunchContext,
-    ) -> tuple[RuntimeHandle, SandboxMeasurement]: ...
+    async def launch(self, plan: SandboxExecutionPlan, workspace: Path, *,
+                     context: RuntimeLaunchContext) -> tuple[RuntimeHandle, SandboxMeasurement]: ...
 
 
 class TrustedProcessHandle:
@@ -1493,17 +1229,13 @@ class TrustedProcessHandle:
         self.repository_relative_path: str | None = None
 
     def bind_identity_recorder(self, recorder: Any) -> None:
-        if getattr(self, "_identity_recorder", None) is not None or not callable(
-            recorder
-        ):
+        if getattr(self, "_identity_recorder", None) is not None or not callable(recorder):
             raise ValueError("trusted process identity recorder is not exact")
         self._identity_recorder = recorder
 
     @staticmethod
     def _proc_fields(pid: int) -> list[str]:
-        raw = _bounded_regular_read(
-            Path("/proc"), f"{pid}/stat", offset=0, limit=16_385
-        )
+        raw = _bounded_regular_read(Path("/proc"), f"{pid}/stat", offset=0, limit=16_385)
         if len(raw) > 16_384:
             raise OSError("process identity is oversized")
         return raw.decode("ascii", "strict").rsplit(")", 1)[1].split()
@@ -1514,9 +1246,7 @@ class TrustedProcessHandle:
 
     @staticmethod
     def _cgroup_identity(pid: int) -> str:
-        raw = _bounded_regular_read(
-            Path("/proc"), f"{pid}/cgroup", offset=0, limit=16_385
-        )
+        raw = _bounded_regular_read(Path("/proc"), f"{pid}/cgroup", offset=0, limit=16_385)
         if len(raw) > 16_384:
             raise OSError("process cgroup identity is oversized")
         return "sha256:" + __import__("hashlib").sha256(raw).hexdigest()
@@ -1571,7 +1301,8 @@ class TrustedProcessHandle:
                     if (
                         len(fields) <= 3
                         or int(fields[2]) != process_group
-                        or int(fields[3]) != identity.get("process_session_id")
+                        or int(fields[3])
+                        != identity.get("process_session_id")
                         or self._cgroup_identity(pid)
                         != identity.get("process_cgroup_identity")
                     ):
@@ -1610,6 +1341,8 @@ class TrustedProcessHandle:
         except (OSError, subprocess.SubprocessError, ValueError, IndexError):
             return False
 
+
+
     async def _drain_group(
         self,
         process_group: int,
@@ -1624,10 +1357,7 @@ class TrustedProcessHandle:
         except ProcessLookupError:
             return True
         deadline = asyncio.get_running_loop().time() + 0.25
-        while (
-            self._group_exists(process_group)
-            and asyncio.get_running_loop().time() < deadline
-        ):
+        while self._group_exists(process_group) and asyncio.get_running_loop().time() < deadline:
             await asyncio.sleep(0.01)
         if self._group_exists(process_group):
             if not self._group_identity_matches(process_group, identity):
@@ -1637,10 +1367,7 @@ class TrustedProcessHandle:
             except ProcessLookupError:
                 return True
         deadline = asyncio.get_running_loop().time() + 0.75
-        while (
-            self._group_exists(process_group)
-            and asyncio.get_running_loop().time() < deadline
-        ):
+        while self._group_exists(process_group) and asyncio.get_running_loop().time() < deadline:
             await asyncio.sleep(0.01)
         return not self._group_exists(process_group)
 
@@ -1745,7 +1472,10 @@ class TrustedProcessHandle:
                     )
                 read_fd, write_fd = os.pipe()
                 os.set_inheritable(write_fd, True)
-                bootstrap = f'printf B >&{write_fd}; kill -STOP $$; exec "$@"'
+                bootstrap = (
+                    f"printf B >&{write_fd}; "
+                    'kill -STOP $$; exec "$@"'
+                )
                 process = await asyncio.create_subprocess_exec(
                     self._executable.proc_fd_path,
                     "-c",
@@ -1977,19 +1707,12 @@ class TrustedProcessHandle:
 
 
 class TrustedProcessBackend:
-    async def launch(
-        self,
-        plan: SandboxExecutionPlan,
-        workspace: Path,
-        *,
-        context: RuntimeLaunchContext,
-    ) -> tuple[RuntimeHandle, SandboxMeasurement]:
+    async def launch(self, plan: SandboxExecutionPlan, workspace: Path, *,
+                     context: RuntimeLaunchContext) -> tuple[RuntimeHandle, SandboxMeasurement]:
         lease_id = context.lease_id
         workspace_id = context.workspace_id
         if plan.runtime.runtime_class is not RuntimeClass.TRUSTED_PROCESS:
-            raise SandboxLaunchError(
-                "trusted process backend class mismatch", code="runtime_unsupported"
-            )
+            raise SandboxLaunchError("trusted process backend class mismatch", code="runtime_unsupported")
         if context.workspace_fd is None or context.workspace_identity is None:
             raise SandboxLaunchError(
                 "pinned workspace descriptor required",
@@ -2014,13 +1737,8 @@ class TrustedProcessBackend:
                 plan.runtime.measured_binary_digest,
             )
             handle = TrustedProcessHandle(
-                plan,
-                workspace,
-                lease_id,
-                executable,
-                git_executable,
-                context.workspace_fd,
-                context.workspace_identity,
+                plan, workspace, lease_id, executable, git_executable,
+                context.workspace_fd, context.workspace_identity,
             )
             repository_base_commit = await handle.measure_repository_base_commit()
             requested = {
@@ -2113,24 +1831,15 @@ class TrustedProcessBackend:
 
 
 class LeaseBackedRunnerWorkspace:
-    def __init__(
-        self,
-        lease: SandboxWorkspaceLease,
-        effective_plan_digest: str,
-        tool_bindings: tuple[RunnerToolBinding, ...],
-    ) -> None:
-        if (
-            lease.plan.effective_plan_digest != effective_plan_digest
-            or lease.plan.tool_bindings != tool_bindings
-        ):
-            raise SandboxPlanError(
-                "runner workspace identity mismatch",
-                code="tool_binding_projection_mismatch",
-            )
+    def __init__(self, lease: SandboxWorkspaceLease, effective_plan_digest: str,
+                 tool_bindings: tuple[RunnerToolBinding, ...]) -> None:
+        if lease.plan.effective_plan_digest != effective_plan_digest or lease.plan.tool_bindings != tool_bindings:
+            raise SandboxPlanError("runner workspace identity mismatch", code="tool_binding_projection_mismatch")
         bindings = tuple(tool_bindings)
-        if any(type(binding) is not RunnerToolBinding for binding in bindings) or len(
-            {binding.tool_id for binding in bindings}
-        ) != len(bindings):
+        if (
+            any(type(binding) is not RunnerToolBinding for binding in bindings)
+            or len({binding.tool_id for binding in bindings}) != len(bindings)
+        ):
             raise SandboxPlanError(
                 "runner tool bindings are not exact and unique",
                 code="tool_binding_projection_mismatch",
@@ -2139,9 +1848,7 @@ class LeaseBackedRunnerWorkspace:
         self.__tool_bindings = bindings
 
     @property
-    def tool_bindings(self) -> tuple[RunnerToolBinding, ...]:
-        return self.__tool_bindings
-
+    def tool_bindings(self) -> tuple[RunnerToolBinding, ...]: return self.__tool_bindings
     async def invoke_tool(
         self,
         tool_id: str,
@@ -2173,8 +1880,7 @@ class LeaseBackedRunnerWorkspace:
         await lease._begin_operation()
         try:
             bindings = tuple(
-                binding
-                for binding in self.__tool_bindings
+                binding for binding in self.__tool_bindings
                 if binding.tool_id == tool_id
             )
             if tool_id != "terminal" or len(bindings) != 1:
@@ -2214,34 +1920,22 @@ class LeaseBackedRunnerWorkspace:
         finally:
             await lease._end_operation()
 
+
     async def run_shell(self, command: str, *, timeout: int) -> Mapping[str, Any]:
         lease = self.__lease
         await lease._begin_operation()
         try:
             if type(timeout) is not int or timeout <= 0:
-                raise WorkspaceStateError(
-                    "timeout exceeds admitted ceiling",
-                    code="runtime_preflight_failed",
-                    lease_id=lease.lease_id,
-                )
+                raise WorkspaceStateError("timeout exceeds admitted ceiling", code="runtime_preflight_failed", lease_id=lease.lease_id)
             timeout_ms = timeout * 1000
             if timeout_ms > lease.plan.limits.action_timeout_ms:
-                raise WorkspaceStateError(
-                    "timeout exceeds admitted ceiling",
-                    code="runtime_preflight_failed",
-                    lease_id=lease.lease_id,
-                )
-            return await lease._runtime.run_shell(
-                command,
-                timeout_ms=timeout_ms,
-                output_limit=lease.plan.limits.observation_bytes,
-            )
+                raise WorkspaceStateError("timeout exceeds admitted ceiling", code="runtime_preflight_failed", lease_id=lease.lease_id)
+            return await lease._runtime.run_shell(command, timeout_ms=timeout_ms,
+                                                  output_limit=lease.plan.limits.observation_bytes)
         finally:
             await lease._end_operation()
 
-    async def read_text(
-        self, path: str, *, offset: int = 0, limit: int | None = None
-    ) -> Mapping[str, Any]:
+    async def read_text(self, path: str, *, offset: int = 0, limit: int | None = None) -> Mapping[str, Any]:
         lease = self.__lease
         await lease._begin_operation()
         remote_read = getattr(lease._runtime, "read_text", None)
@@ -2255,11 +1949,7 @@ class LeaseBackedRunnerWorkspace:
                 lease._resolve(path)
                 ceiling = lease.plan.limits.observation_bytes
                 if offset < 0 or limit is not None and (limit < 0 or limit > ceiling):
-                    raise WorkspaceStateError(
-                        "read limit invalid",
-                        code="output_limit_exceeded",
-                        lease_id=lease.lease_id,
-                    )
+                    raise WorkspaceStateError("read limit invalid", code="output_limit_exceeded", lease_id=lease.lease_id)
                 read_limit = limit if limit is not None else ceiling + 1
                 try:
                     selected = await asyncio.to_thread(
@@ -2272,23 +1962,10 @@ class LeaseBackedRunnerWorkspace:
                 except FileNotFoundError:
                     raise
                 except OSError as exc:
-                    raise WorkspaceStateError(
-                        "workspace link authority denied",
-                        code="workspace_escape",
-                        lease_id=lease.lease_id,
-                    ) from exc
+                    raise WorkspaceStateError("workspace link authority denied", code="workspace_escape", lease_id=lease.lease_id) from exc
                 if len(selected) > ceiling:
-                    raise WorkspaceStateError(
-                        "read exceeds admitted ceiling",
-                        code="output_limit_exceeded",
-                        lease_id=lease.lease_id,
-                    )
-                return {
-                    "path": path,
-                    "content": selected.decode("utf-8"),
-                    "offset": offset,
-                    "bytes": len(selected),
-                }
+                    raise WorkspaceStateError("read exceeds admitted ceiling", code="output_limit_exceeded", lease_id=lease.lease_id)
+                return {"path": path, "content": selected.decode("utf-8"), "offset": offset, "bytes": len(selected)}
         finally:
             await lease._end_operation()
 
@@ -2306,24 +1983,13 @@ class LeaseBackedRunnerWorkspace:
             async with lease._io_lock:
                 lease._resolve(path, writable=True)
                 if len(payload) > lease.plan.limits.artifact_bytes_each:
-                    raise WorkspaceStateError(
-                        "write exceeds admitted ceiling",
-                        code="output_limit_exceeded",
-                        lease_id=lease.lease_id,
-                    )
+                    raise WorkspaceStateError("write exceeds admitted ceiling", code="output_limit_exceeded", lease_id=lease.lease_id)
                 try:
                     await asyncio.to_thread(
-                        _atomic_regular_write,
-                        lease._materialized.workspace_path,
-                        path,
-                        payload,
+                        _atomic_regular_write, lease._materialized.workspace_path, path, payload
                     )
                 except OSError as exc:
-                    raise WorkspaceStateError(
-                        "workspace link authority denied",
-                        code="workspace_escape",
-                        lease_id=lease.lease_id,
-                    ) from exc
+                    raise WorkspaceStateError("workspace link authority denied", code="workspace_escape", lease_id=lease.lease_id) from exc
                 return {"path": path, "bytes": len(payload)}
         finally:
             await lease._end_operation()
@@ -2340,11 +2006,7 @@ class LeaseBackedRunnerWorkspace:
         try:
             async with lease._io_lock:
                 if depth < 0 or depth > lease.plan.security_policy.snapshot_max_depth:
-                    raise WorkspaceStateError(
-                        "list depth invalid",
-                        code="output_limit_exceeded",
-                        lease_id=lease.lease_id,
-                    )
+                    raise WorkspaceStateError("list depth invalid", code="output_limit_exceeded", lease_id=lease.lease_id)
                 try:
                     values = await asyncio.to_thread(
                         _descriptor_list,
@@ -2372,26 +2034,12 @@ class LeaseBackedRunnerWorkspace:
 
 
 class SandboxWorkspaceLease:
-    def __init__(
-        self,
-        *,
-        manager: SandboxRuntimeManager,
-        lease_id: str,
-        plan: SandboxExecutionPlan,
-        materialized: MaterializedWorkspace,
-        runtime: RuntimeHandle,
-        measurement: SandboxMeasurement,
-        owner_token: str,
-        epoch: int,
-    ) -> None:
-        self.lease_id = lease_id
-        self.plan = plan
-        self.measurement = measurement
-        self._manager = manager
-        self._materialized = materialized
-        self._runtime = runtime
-        self._owner_token = owner_token
-        self._epoch = epoch
+    def __init__(self, *, manager: SandboxRuntimeManager, lease_id: str, plan: SandboxExecutionPlan,
+                 materialized: MaterializedWorkspace, runtime: RuntimeHandle,
+                 measurement: SandboxMeasurement, owner_token: str, epoch: int) -> None:
+        self.lease_id = lease_id; self.plan = plan; self.measurement = measurement
+        self._manager = manager; self._materialized = materialized; self._runtime = runtime
+        self._owner_token = owner_token; self._epoch = epoch
         self._state = WorkspaceLeaseState.ACTIVE
         self._lock = asyncio.Lock()
         self._operations_drained = asyncio.Condition(self._lock)
@@ -2402,12 +2050,9 @@ class SandboxWorkspaceLease:
         self._latest_cleanup = None
         self._close_task_lock = asyncio.Lock()
         self._close_task: asyncio.Task[SandboxCleanupReceipt] | None = None
-        self.runner_workspace = LeaseBackedRunnerWorkspace(
-            self, plan.effective_plan_digest, plan.tool_bindings
-        )
+        self.runner_workspace = LeaseBackedRunnerWorkspace(self, plan.effective_plan_digest, plan.tool_bindings)
         self._verifier_children: list[VerifierWorkspaceLease] = []
         self._sealed_workspace_diff: Mapping[str, Any] | None = None
-
     @property
     def identity(self) -> SandboxMeasurement:
         return self.measurement
@@ -2419,7 +2064,6 @@ class SandboxWorkspaceLease:
     @property
     def cleanup_receipt(self) -> SandboxCleanupReceipt | None:
         return self._latest_cleanup
-
     async def execute(
         self, argv: Sequence[str], *, timeout_ms: int | None = None
     ) -> Mapping[str, Any]:
@@ -2432,24 +2076,13 @@ class SandboxWorkspaceLease:
                 code="runtime_preflight_failed",
                 lease_id=self.lease_id,
             )
-        effective_timeout = (
-            self.plan.limits.action_timeout_ms if timeout_ms is None else timeout_ms
-        )
-        if (
-            type(effective_timeout) is not int
-            or effective_timeout <= 0
-            or effective_timeout > self.plan.limits.action_timeout_ms
-        ):
-            raise WorkspaceStateError(
-                "timeout exceeds admitted ceiling",
-                code="runtime_preflight_failed",
-                lease_id=self.lease_id,
-            )
+        effective_timeout = self.plan.limits.action_timeout_ms if timeout_ms is None else timeout_ms
+        if type(effective_timeout) is not int or effective_timeout <= 0 or effective_timeout > self.plan.limits.action_timeout_ms:
+            raise WorkspaceStateError("timeout exceeds admitted ceiling", code="runtime_preflight_failed", lease_id=self.lease_id)
         await self._begin_operation()
         try:
             return await self._runtime.run_argv(
-                tuple(argv),
-                timeout_ms=effective_timeout,
+                tuple(argv), timeout_ms=effective_timeout,
                 output_limit=self.plan.limits.observation_bytes,
             )
         finally:
@@ -2480,9 +2113,9 @@ class SandboxWorkspaceLease:
             )
         finally:
             await self._end_operation()
-
     def sealed_workspace_diff(self) -> Mapping[str, Any] | None:
         return self._sealed_workspace_diff
+
 
     async def cancel(self) -> SandboxCleanupReceipt:
         return await self._close_shared(preempt=True)
@@ -2543,18 +2176,13 @@ class SandboxWorkspaceLease:
         return await self.close()
 
     @property
-    def state(self) -> WorkspaceLeaseState:
-        return self._state
+    def state(self) -> WorkspaceLeaseState: return self._state
 
     def _assert_active(self) -> None:
         if self._state is not WorkspaceLeaseState.ACTIVE:
-            raise WorkspaceStateError(
-                "workspace lease is not active",
-                code="lease_not_active",
-                episode_id=self.plan.episode_id,
-                effective_plan_digest=self.plan.effective_plan_digest,
-                lease_id=self.lease_id,
-            )
+            raise WorkspaceStateError("workspace lease is not active", code="lease_not_active",
+                                      episode_id=self.plan.episode_id,
+                                      effective_plan_digest=self.plan.effective_plan_digest, lease_id=self.lease_id)
 
     async def _begin_operation(self) -> None:
         task = asyncio.current_task()
@@ -2591,17 +2219,8 @@ class SandboxWorkspaceLease:
 
     def _resolve(self, logical_path: str, *, writable: bool = False) -> Path:
         relative = Path(logical_path)
-        if (
-            not logical_path
-            or relative.is_absolute()
-            or ".." in relative.parts
-            or "\x00" in logical_path
-        ):
-            raise WorkspaceStateError(
-                "workspace path escapes",
-                code="workspace_escape",
-                lease_id=self.lease_id,
-            )
+        if not logical_path or relative.is_absolute() or ".." in relative.parts or "\x00" in logical_path:
+            raise WorkspaceStateError("workspace path escapes", code="workspace_escape", lease_id=self.lease_id)
         cursor = self._materialized.workspace_path
         for part in relative.parts:
             cursor = cursor / part
@@ -2609,38 +2228,16 @@ class SandboxWorkspaceLease:
                 metadata = cursor.lstat()
             except FileNotFoundError:
                 continue
-            if __import__("stat").S_ISLNK(metadata.st_mode) or (
-                __import__("stat").S_ISREG(metadata.st_mode) and metadata.st_nlink != 1
-            ):
-                raise WorkspaceStateError(
-                    "workspace link authority denied",
-                    code="workspace_escape",
-                    lease_id=self.lease_id,
-                )
+            if __import__("stat").S_ISLNK(metadata.st_mode) or (__import__("stat").S_ISREG(metadata.st_mode) and metadata.st_nlink != 1):
+                raise WorkspaceStateError("workspace link authority denied", code="workspace_escape", lease_id=self.lease_id)
         target = (self._materialized.workspace_path / relative).resolve(strict=False)
-        if (
-            self._materialized.workspace_path != target
-            and self._materialized.workspace_path not in target.parents
-        ):
-            raise WorkspaceStateError(
-                "workspace path escapes",
-                code="workspace_escape",
-                lease_id=self.lease_id,
-            )
+        if self._materialized.workspace_path != target and self._materialized.workspace_path not in target.parents:
+            raise WorkspaceStateError("workspace path escapes", code="workspace_escape", lease_id=self.lease_id)
         if writable:
-            writable_roots = [
-                (self._materialized.workspace_path / item.target_logical_path).resolve()
-                for item in self.plan.materialization_plan.entries
-                if item.access.value == "rw"
-            ]
-            if not any(
-                root == target or root in target.parents for root in writable_roots
-            ):
-                raise WorkspaceStateError(
-                    "path is outside writable authority",
-                    code="workspace_escape",
-                    lease_id=self.lease_id,
-                )
+            writable_roots = [(self._materialized.workspace_path / item.target_logical_path).resolve()
+                              for item in self.plan.materialization_plan.entries if item.access.value == "rw"]
+            if not any(root == target or root in target.parents for root in writable_roots):
+                raise WorkspaceStateError("path is outside writable authority", code="workspace_escape", lease_id=self.lease_id)
         return target
 
     async def seal_for_verifier(self) -> VerifierSnapshotReceipt:
@@ -2648,16 +2245,9 @@ class SandboxWorkspaceLease:
             self._assert_active()
             await self._fence_and_drain(WorkspaceLeaseState.QUIESCING)
             runtime_steps = await self._runtime.terminate()
-            if any(
-                step.state not in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
-                for step in runtime_steps
-            ):
+            if any(step.state not in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED} for step in runtime_steps):
                 self._state = WorkspaceLeaseState.QUARANTINED
-                raise VerifierSnapshotError(
-                    "runtime did not quiesce",
-                    code="snapshot_not_quiescent",
-                    lease_id=self.lease_id,
-                )
+                raise VerifierSnapshotError("runtime did not quiesce", code="snapshot_not_quiescent", lease_id=self.lease_id)
             base_commit = getattr(self._runtime, "repository_base_commit", None)
             relative_path = getattr(self._runtime, "repository_relative_path", None)
             if (base_commit is None) != (relative_path is None):
@@ -2730,35 +2320,18 @@ class SandboxWorkspaceLease:
                 return receipt
             except Exception as exc:
                 self._state = WorkspaceLeaseState.QUARANTINED
-                raise VerifierSnapshotError(
-                    "verifier snapshot failed", code=str(exc), lease_id=self.lease_id
-                ) from exc
+                raise VerifierSnapshotError("verifier snapshot failed", code=str(exc), lease_id=self.lease_id) from exc
 
     async def close(self) -> SandboxCleanupReceipt:
         return await self._close_shared()
 
-
 class VerifierWorkspaceLease:
-    def __init__(
-        self,
-        *,
-        manager: SandboxRuntimeManager,
-        primary: SandboxWorkspaceLease,
-        lease_id: str,
-        plan: SandboxExecutionPlan,
-        snapshot: VerifierSnapshotReceipt,
-        workspace: Path,
-        runtime: RuntimeHandle,
-        measurement: SandboxMeasurement,
-    ) -> None:
-        self._manager = manager
-        self._primary = primary
-        self.lease_id = lease_id
-        self.plan = plan
-        self.snapshot = snapshot
-        self.workspace = workspace
-        self._runtime = runtime
-        self.measurement = measurement
+    def __init__(self, *, manager: SandboxRuntimeManager, primary: SandboxWorkspaceLease,
+                 lease_id: str, plan: SandboxExecutionPlan, snapshot: VerifierSnapshotReceipt,
+                 workspace: Path, runtime: RuntimeHandle, measurement: SandboxMeasurement) -> None:
+        self._manager = manager; self._primary = primary; self.lease_id = lease_id
+        self.plan = plan; self.snapshot = snapshot; self.workspace = workspace
+        self._runtime = runtime; self.measurement = measurement
         self._closed = False
         self._closing = False
         self._fenced = False
@@ -2769,7 +2342,6 @@ class VerifierWorkspaceLease:
         self._cleanup: SandboxCleanupReceipt | None = None
 
         self._close_task: asyncio.Task[SandboxCleanupReceipt] | None = None
-
     async def execute(self) -> Mapping[str, Any]:
         task = asyncio.current_task()
         if task is None:
@@ -2904,54 +2476,28 @@ class VerifierWorkspaceLease:
             )
             if runtime_released:
                 try:
-                    for root, dirs, files in os.walk(
-                        self.workspace, topdown=True, followlinks=False
-                    ):
+                    for root, dirs, files in os.walk(self.workspace, topdown=True, followlinks=False):
                         root_path = Path(root)
                         os.chmod(root_path, 0o700, follow_symlinks=False)
                         for name in dirs + files:
                             candidate = root_path / name
                             if candidate.is_symlink():
                                 continue
-                            os.chmod(
-                                candidate,
-                                0o700 if candidate.is_dir() else 0o600,
-                                follow_symlinks=False,
-                            )
-                    await asyncio.to_thread(
-                        self._manager.materialization_store.storage_backend.release,
-                        self.workspace,
-                    )
-                    absent = self._manager.materialization_store.storage_backend.verify_absent(
-                        self.workspace
-                    )
-                    steps.append(
-                        CleanupStepReceipt(
-                            "workspace",
-                            CleanupState.RELEASED if absent else CleanupState.FAILED,
-                        )
-                    )
+                            os.chmod(candidate, 0o700 if candidate.is_dir() else 0o600,
+                                     follow_symlinks=False)
+                    await asyncio.to_thread(self._manager.materialization_store.storage_backend.release, self.workspace)
+                    absent = self._manager.materialization_store.storage_backend.verify_absent(self.workspace)
+                    steps.append(CleanupStepReceipt("workspace", CleanupState.RELEASED if absent else CleanupState.FAILED))
                 except FileNotFoundError:
-                    steps.append(
-                        CleanupStepReceipt("workspace", CleanupState.ALREADY_RELEASED)
-                    )
+                    steps.append(CleanupStepReceipt("workspace", CleanupState.ALREADY_RELEASED))
                 except Exception as exc:
-                    steps.append(
-                        CleanupStepReceipt(
-                            "workspace", CleanupState.FAILED, type(exc).__name__
-                        )
-                    )
+                    steps.append(CleanupStepReceipt("workspace", CleanupState.FAILED, type(exc).__name__))
             else:
-                steps.append(
-                    CleanupStepReceipt(
-                        "workspace",
-                        CleanupState.QUARANTINED,
-                        "dependent runtime cleanup incomplete",
-                    )
-                )
+                steps.append(CleanupStepReceipt(
+                    "workspace", CleanupState.QUARANTINED, "dependent runtime cleanup incomplete"
+                ))
             dependencies_released = all(
-                step.state
-                in {
+                step.state in {
                     CleanupState.RELEASED,
                     CleanupState.ALREADY_RELEASED,
                 }
@@ -2977,30 +2523,18 @@ class VerifierWorkspaceLease:
                 if prior_ok:
                     self._manager._unlink_lease_record(self.lease_id)
                     absent = not self._manager._lease_record_exists(self.lease_id)
-                    steps.append(
-                        CleanupStepReceipt(
-                            "lease_record",
-                            CleanupState.RELEASED if absent else CleanupState.FAILED,
-                        )
-                    )
+                    steps.append(CleanupStepReceipt(
+                        "lease_record", CleanupState.RELEASED if absent else CleanupState.FAILED
+                    ))
                 else:
-                    steps.append(
-                        CleanupStepReceipt(
-                            "lease_record",
-                            CleanupState.QUARANTINED,
-                            "dependent cleanup incomplete",
-                        )
-                    )
+                    steps.append(CleanupStepReceipt(
+                        "lease_record", CleanupState.QUARANTINED, "dependent cleanup incomplete"
+                    ))
             except Exception as exc:
-                steps.append(
-                    CleanupStepReceipt(
-                        "lease_record", CleanupState.FAILED, type(exc).__name__
-                    )
-                )
+                steps.append(CleanupStepReceipt("lease_record", CleanupState.FAILED, type(exc).__name__))
             receipt = SandboxCleanupReceipt.from_steps(self.lease_id, tuple(steps))
             if receipt.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}:
-                self._closed = True
-                self._cleanup = receipt
+                self._closed = True; self._cleanup = receipt
             return receipt
 
 
@@ -3013,51 +2547,40 @@ class _PendingLaunchCleanup:
 
 
 class SandboxRuntimeManager:
-    def __init__(
-        self,
-        *,
-        registries: RegistrySnapshotSet,
-        installed_authorities: InstalledSandboxAuthoritySet,
-        materialization_store: FilesystemMaterializationStore,
-        lease_root: str | Path,
-        process_backend: RuntimeBackend,
-        docker_backend: RuntimeBackend | None,
-        random_bytes: Any,
-        lease_root_fd: int | None = None,
-    ) -> None:
-        self.registries = registries
-        self.installed_authorities = installed_authorities
+    def __init__(self, *, registries: RegistrySnapshotSet,
+                 installed_authorities: InstalledSandboxAuthoritySet,
+                 materialization_store: FilesystemMaterializationStore,
+                 lease_root: str | Path, process_backend: RuntimeBackend,
+                 docker_backend: RuntimeBackend | None, random_bytes: Any,
+                 lease_root_fd: int | None = None) -> None:
+        self.registries = registries; self.installed_authorities = installed_authorities
         self.materialization_store = materialization_store
         supplied_lease_root = Path(lease_root).resolve(strict=True)
         self._lease_root_fd = (
             os.dup(lease_root_fd)
             if lease_root_fd is not None
-            else os.open(
-                supplied_lease_root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-            )
+            else os.open(supplied_lease_root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
         )
         try:
             opened_root = os.fstat(self._lease_root_fd)
             supplied_root = os.stat(supplied_lease_root, follow_symlinks=False)
-            if not stat.S_ISDIR(opened_root.st_mode) or (
-                opened_root.st_dev,
-                opened_root.st_ino,
-            ) != (supplied_root.st_dev, supplied_root.st_ino):
+            if (
+                not stat.S_ISDIR(opened_root.st_mode)
+                or (opened_root.st_dev, opened_root.st_ino)
+                != (supplied_root.st_dev, supplied_root.st_ino)
+            ):
                 raise ValueError("lease root descriptor identity mismatch")
         except BaseException:
             os.close(self._lease_root_fd)
             self._lease_root_fd = None
             raise
         self.lease_root = supplied_lease_root
-        self.process_backend = process_backend
-        self.docker_backend = docker_backend
-        self._random_bytes = random_bytes
-        self._leases: dict[str, SandboxWorkspaceLease] = {}
+        self.process_backend = process_backend; self.docker_backend = docker_backend
+        self._random_bytes = random_bytes; self._leases: dict[str, SandboxWorkspaceLease] = {}
         self._snapshots: dict[str, tuple[VerifierSnapshotReceipt, Path]] = {}
         self._pending_launch_cleanups: dict[str, _PendingLaunchCleanup] = {}
         self._lease_owner_locks: dict[str, int] = {}
-        self._lock = asyncio.Lock()
-        self._closed = False
+        self._lock = asyncio.Lock(); self._closed = False
         self._reconcile_lock = asyncio.Lock()
         self._close_task: asyncio.Future[list[SandboxCleanupReceipt]] | None = None
         self._last_close_receipts: tuple[SandboxCleanupReceipt, ...] | None = None
@@ -3078,15 +2601,12 @@ class SandboxRuntimeManager:
 
     def _nonce(self) -> str:
         value = self._random_bytes(16)
-        if type(value) is not bytes or len(value) < 16:
-            raise ValueError("random source returned insufficient bytes")
+        if type(value) is not bytes or len(value) < 16: raise ValueError("random source returned insufficient bytes")
         return value.hex()
 
     @staticmethod
     def _make_workspace_releasable(workspace: Path) -> None:
-        for root, dirs, filenames in os.walk(
-            workspace, topdown=True, followlinks=False
-        ):
+        for root, dirs, filenames in os.walk(workspace, topdown=True, followlinks=False):
             root_path = Path(root)
             os.chmod(root_path, 0o700, follow_symlinks=False)
             for name in dirs + filenames:
@@ -3143,12 +2663,10 @@ class SandboxRuntimeManager:
                 authority
                 if type(authority) is str and authority
                 else f"{type(self.materialization_store.storage_backend).__module__}."
-                f"{type(self.materialization_store.storage_backend).__qualname__}"
+                     f"{type(self.materialization_store.storage_backend).__qualname__}"
             ),
             quota_enforced=quota_enforced is True,
-            quota_bytes=measured_quota
-            if type(measured_quota) is int and measured_quota > 0
-            else quota_bytes,
+            quota_bytes=measured_quota if type(measured_quota) is int and measured_quota > 0 else quota_bytes,
             owner_uid=owner_uid,
             owner_gid=owner_gid,
         )
@@ -3160,9 +2678,8 @@ class SandboxRuntimeManager:
             storage=storage,
             snapshot_relative_path=None if role == "primary" else "snapshot",
             result_relative_path=None if role == "primary" else "result",
-            publish_prepared_identity=lambda identity, lease_id=lease_id: (
-                self._publish_runtime_identity(lease_id, identity)
-            ),
+            publish_prepared_identity=lambda identity, lease_id=lease_id:
+                self._publish_runtime_identity(lease_id, identity),
             workspace_fd=workspace_fd,
             workspace_identity=workspace_identity,
             owner_token=owner_token,
@@ -3225,9 +2742,9 @@ class SandboxRuntimeManager:
         finally:
             os.close(descriptor)
 
+
     def _lease_record_path(self, lease_id: str) -> Path:
         return self.lease_root / (lease_id + ".json")
-
     def _lease_record_exists(self, lease_id: str) -> bool:
         if self._lease_root_fd is None:
             return False
@@ -3251,6 +2768,7 @@ class SandboxRuntimeManager:
         self._release_lease_owner_lock(lease_id, unlink=True)
         os.fsync(self._lease_root_fd)
 
+
     def _write_lease_record(self, lease_id: str, payload: Mapping[str, Any]) -> None:
         if payload.get("lease_id") != lease_id:
             raise WorkspaceStateError(
@@ -3258,9 +2776,7 @@ class SandboxRuntimeManager:
                 code="stale_identity_uncertain",
                 lease_id=lease_id,
             )
-        record = canonical_json_bytes(
-            {"payload": dict(payload), "checksum": _wp7_digest(dict(payload))}
-        )
+        record = canonical_json_bytes({"payload": dict(payload), "checksum": _wp7_digest(dict(payload))})
         path = self._lease_record_path(lease_id)
         temporary = path.name + ".tmp-" + self._nonce()
         if self._lease_root_fd is None:
@@ -3318,9 +2834,7 @@ class SandboxRuntimeManager:
                 raise ValueError
             return MappingProxyType(payload)
         except Exception as exc:
-            raise WorkspaceStateError(
-                "workspace lease record is corrupt", code="stale_identity_uncertain"
-            ) from exc
+            raise WorkspaceStateError("workspace lease record is corrupt", code="stale_identity_uncertain") from exc
 
     async def _publish_runtime_identity(
         self, lease_id: str, identity: RuntimePreparedIdentity
@@ -3348,6 +2862,7 @@ class SandboxRuntimeManager:
         record["runtime_labels"] = dict(identity.labels)
         self._write_lease_record(lease_id, record)
 
+
     def _record_process_identity(
         self, lease_id: str, resource_id: str, identity: Mapping[str, Any] | None
     ) -> None:
@@ -3360,9 +2875,7 @@ class SandboxRuntimeManager:
             or not resource_id
         ):
             raise WorkspaceStateError(
-                "process lease identity changed",
-                code="stale_identity_uncertain",
-                lease_id=lease_id,
+                "process lease identity changed", code="stale_identity_uncertain", lease_id=lease_id
             )
         identities = {
             item["resource_id"]: dict(item)
@@ -3381,27 +2894,21 @@ class SandboxRuntimeManager:
                 or resource_id != f"process-group-{identity.get('process_group_id')}"
             ):
                 raise WorkspaceStateError(
-                    "process identity is incomplete",
-                    code="stale_identity_uncertain",
-                    lease_id=lease_id,
+                    "process identity is incomplete", code="stale_identity_uncertain", lease_id=lease_id
                 )
             if resource_id in identities and identities[resource_id] != {
-                "resource_id": resource_id,
-                **identity,
+                "resource_id": resource_id, **identity
             }:
                 raise WorkspaceStateError(
-                    "process identity changed",
-                    code="stale_identity_uncertain",
-                    lease_id=lease_id,
+                    "process identity changed", code="stale_identity_uncertain", lease_id=lease_id
                 )
             identities[resource_id] = {"resource_id": resource_id, **identity}
-        record["process_identities"] = [identities[key] for key in sorted(identities)]
+        record["process_identities"] = [
+            identities[key] for key in sorted(identities)
+        ]
         for key in (
-            "process_pid",
-            "process_group_id",
-            "process_session_id",
-            "process_start_identity",
-            "process_cgroup_identity",
+            "process_pid", "process_group_id", "process_session_id",
+            "process_start_identity", "process_cgroup_identity",
         ):
             record.pop(key, None)
         self._write_lease_record(lease_id, record)
@@ -3469,18 +2976,13 @@ class SandboxRuntimeManager:
             ",".join(released),
         )
 
+
     async def open(self, request: WorkspaceOpenRequest) -> SandboxWorkspaceLease:
-        plan = build_sandbox_execution_plan(
-            request, self.registries, self.installed_authorities
-        )
+        plan = build_sandbox_execution_plan(request, self.registries, self.installed_authorities)
         async with self._lock:
-            if self._closed:
-                raise WorkspaceStateError(
-                    "lease manager closed", code="lease_manager_closed"
-                )
+            if self._closed: raise WorkspaceStateError("lease manager closed", code="lease_manager_closed")
             lease_id = "lease-" + self._nonce()
-            owner_token = self._nonce()
-            epoch = 1
+            owner_token = self._nonce(); epoch = 1
             materialized: MaterializedWorkspace | None = None
             runtime: RuntimeHandle | None = None
             backend: RuntimeBackend | None = None
@@ -3515,40 +3017,19 @@ class SandboxRuntimeManager:
                     "cache_key_digest": materialized.cache_token.cache_key.digest,
                     "cache_manifest_digest": materialized.cache_receipt.immutable_object_manifest_digest,
                     "cache_source_digests": [
-                        entry.source_digest
-                        for entry in plan.materialization_plan.entries
+                        entry.source_digest for entry in plan.materialization_plan.entries
                     ],
                 }
-                self._write_lease_record(
-                    lease_id,
-                    {
-                        "schema_version": "bb.rl.workspace-lease.v1",
-                        "lease_id": lease_id,
-                        "workspace_id": materialized.receipt.workspace_id,
-                        "workspace_path": str(materialized.workspace_path),
-                        "cache_lease_id": materialized.receipt.cache_lease_id,
-                        "effective_plan_digest": plan.effective_plan_digest,
-                        "owner_token": owner_token,
-                        "epoch": epoch,
-                        "expires_at": (
-                            issued + self.materialization_store.lease_ttl
-                        ).isoformat(),
-                        "role": "primary",
-                        **cache_identity,
-                        "runtime_id": plan.runtime.runtime_id,
-                        "state": "allocating",
-                    },
-                )
+                self._write_lease_record(lease_id, {"schema_version": "bb.rl.workspace-lease.v1",
+                    "lease_id": lease_id, "workspace_id": materialized.receipt.workspace_id,
+                    "workspace_path": str(materialized.workspace_path), "cache_lease_id": materialized.receipt.cache_lease_id,
+                    "effective_plan_digest": plan.effective_plan_digest, "owner_token": owner_token, "epoch": epoch,
+                    "expires_at": (issued + self.materialization_store.lease_ttl).isoformat(), "role": "primary",
+                    **cache_identity,
+                    "runtime_id": plan.runtime.runtime_id, "state": "allocating"})
                 record_written = True
-                backend = (
-                    self.process_backend
-                    if plan.runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS
-                    else self.docker_backend
-                )
-                if backend is None:
-                    raise SandboxLaunchError(
-                        "runtime backend unavailable", code="runtime_unsupported"
-                    )
+                backend = self.process_backend if plan.runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS else self.docker_backend
+                if backend is None: raise SandboxLaunchError("runtime backend unavailable", code="runtime_unsupported")
                 context = self._launch_context(
                     plan=plan,
                     workspace=materialized.workspace_path,
@@ -3566,43 +3047,22 @@ class SandboxRuntimeManager:
                 )
                 if isinstance(runtime, TrustedProcessHandle):
                     runtime.bind_identity_recorder(
-                        lambda resource_id, identity, lease_id=lease_id: (
-                            self._record_process_identity(
-                                lease_id, resource_id, identity
-                            )
-                        )
+                        lambda resource_id, identity, lease_id=lease_id:
+                            self._record_process_identity(lease_id, resource_id, identity)
                     )
                 if measurement.mismatch:
-                    raise SandboxAttestationError(
-                        "runtime measurement mismatch",
-                        code="runtime_measurement_mismatch",
-                        lease_id=lease_id,
-                    )
+                    raise SandboxAttestationError("runtime measurement mismatch", code="runtime_measurement_mismatch",
+                                                  lease_id=lease_id)
                 for setup in plan.setups:
-                    result = await runtime.run_argv(
-                        setup.argv,
-                        timeout_ms=min(setup.timeout_ms, plan.limits.setup_timeout_ms),
-                        output_limit=plan.limits.observation_bytes,
-                    )
+                    result = await runtime.run_argv(setup.argv,
+                                                    timeout_ms=min(setup.timeout_ms, plan.limits.setup_timeout_ms),
+                                                    output_limit=plan.limits.observation_bytes)
                     if result.get("returncode") != 0:
-                        raise SandboxLaunchError(
-                            "setup failed",
-                            code="runtime_launch_failed",
-                            lease_id=lease_id,
-                        )
-                lease = SandboxWorkspaceLease(
-                    manager=self,
-                    lease_id=lease_id,
-                    plan=plan,
-                    materialized=materialized,
-                    runtime=runtime,
-                    measurement=measurement,
-                    owner_token=owner_token,
-                    epoch=epoch,
-                )
-                active_record = dict(
-                    self._read_lease_record(self._lease_record_path(lease_id))
-                )
+                        raise SandboxLaunchError("setup failed", code="runtime_launch_failed", lease_id=lease_id)
+                lease = SandboxWorkspaceLease(manager=self, lease_id=lease_id, plan=plan,
+                    materialized=materialized, runtime=runtime, measurement=measurement,
+                    owner_token=owner_token, epoch=epoch)
+                active_record = dict(self._read_lease_record(self._lease_record_path(lease_id)))
                 prepared_resource_id = active_record.get("runtime_resource_id")
                 if (
                     prepared_resource_id is not None
@@ -3613,19 +3073,16 @@ class SandboxRuntimeManager:
                         code="stale_identity_uncertain",
                         lease_id=lease_id,
                     )
-                active_record.update(
-                    {
-                        "runtime_authority_id": plan.runtime.runtime_id,
-                        "runtime_resource_id": runtime.runtime_id,
-                        "storage_authority_id": context.storage.authority_id,
-                        "storage_quota_bytes": context.storage.quota_bytes,
-                        "runtime_executable_path": plan.runtime.executable_path,
-                        "runtime_binary_digest": plan.runtime.measured_binary_digest,
-                        "action_timeout_ms": plan.limits.action_timeout_ms,
-                        "observation_bytes": plan.limits.observation_bytes,
-                        "state": "active",
-                    }
-                )
+                active_record.update({
+                    "runtime_authority_id": plan.runtime.runtime_id,
+                    "runtime_resource_id": runtime.runtime_id,
+                    "storage_authority_id": context.storage.authority_id,
+                    "storage_quota_bytes": context.storage.quota_bytes,
+                    "runtime_executable_path": plan.runtime.executable_path,
+                    "runtime_binary_digest": plan.runtime.measured_binary_digest,
+                    "action_timeout_ms": plan.limits.action_timeout_ms,
+                    "observation_bytes": plan.limits.observation_bytes,
+                    "state": "active"})
                 self._write_lease_record(lease_id, active_record)
                 self._leases[lease_id] = lease
                 return lease
@@ -3637,31 +3094,25 @@ class SandboxRuntimeManager:
                         cleanup_steps.extend(await runtime.terminate())
                     except BaseException as cleanup_exc:
                         cleanup_errors.append(f"runtime:{type(cleanup_exc).__name__}")
-                        cleanup_steps.append(
-                            CleanupStepReceipt(
-                                "runtime",
-                                CleanupState.FAILED,
-                                type(cleanup_exc).__name__,
-                            )
-                        )
+                        cleanup_steps.append(CleanupStepReceipt("runtime", CleanupState.FAILED,
+                                                                type(cleanup_exc).__name__))
                 backend_cleanup_pending = (
                     runtime is None
                     and backend is self.docker_backend
                     and bool(getattr(backend, "cleanup_pending", False))
                 )
                 runtime_cleanup_pending = (
-                    runtime is not None and not _runtime_cleanup_released(cleanup_steps)
+                    runtime is not None
+                    and not _runtime_cleanup_released(cleanup_steps)
                 )
                 if backend_cleanup_pending:
-                    cleanup_steps.append(
-                        CleanupStepReceipt(
-                            "runtime",
-                            CleanupState.QUARANTINED,
-                            "backend retained launch cleanup authority",
-                        )
-                    )
-                if materialized is not None and (
-                    backend_cleanup_pending or runtime_cleanup_pending
+                    cleanup_steps.append(CleanupStepReceipt(
+                        "runtime", CleanupState.QUARANTINED,
+                        "backend retained launch cleanup authority",
+                    ))
+                if (
+                    materialized is not None
+                    and (backend_cleanup_pending or runtime_cleanup_pending)
                 ):
                     self._pending_launch_cleanups[lease_id] = _PendingLaunchCleanup(
                         workspace=materialized.workspace_path,
@@ -3675,36 +3126,19 @@ class SandboxRuntimeManager:
                 if materialized is not None and runtime_released:
                     try:
                         await asyncio.to_thread(materialized.close)
-                        cleanup_steps.append(
-                            CleanupStepReceipt("workspace", CleanupState.RELEASED)
-                        )
-                        cleanup_steps.append(
-                            CleanupStepReceipt("cache_holder", CleanupState.RELEASED)
-                        )
+                        cleanup_steps.append(CleanupStepReceipt("workspace", CleanupState.RELEASED))
+                        cleanup_steps.append(CleanupStepReceipt("cache_holder", CleanupState.RELEASED))
                     except BaseException as cleanup_exc:
                         cleanup_errors.append(f"workspace:{type(cleanup_exc).__name__}")
-                        cleanup_steps.append(
-                            CleanupStepReceipt(
-                                "workspace",
-                                CleanupState.FAILED,
-                                type(cleanup_exc).__name__,
-                            )
-                        )
+                        cleanup_steps.append(CleanupStepReceipt("workspace", CleanupState.FAILED,
+                                                                type(cleanup_exc).__name__))
                 elif materialized is not None:
-                    cleanup_steps.append(
-                        CleanupStepReceipt(
-                            "workspace",
-                            CleanupState.QUARANTINED,
-                            "dependent runtime cleanup incomplete",
-                        )
-                    )
-                    cleanup_steps.append(
-                        CleanupStepReceipt(
-                            "cache_holder",
-                            CleanupState.QUARANTINED,
-                            "dependent runtime cleanup incomplete",
-                        )
-                    )
+                    cleanup_steps.append(CleanupStepReceipt(
+                        "workspace", CleanupState.QUARANTINED, "dependent runtime cleanup incomplete"
+                    ))
+                    cleanup_steps.append(CleanupStepReceipt(
+                        "cache_holder", CleanupState.QUARANTINED, "dependent runtime cleanup incomplete"
+                    ))
                 dependencies_released = all(
                     step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
                     for step in cleanup_steps
@@ -3712,48 +3146,26 @@ class SandboxRuntimeManager:
                 try:
                     if record_written and dependencies_released:
                         self._unlink_lease_record(lease_id)
-                        cleanup_steps.append(
-                            CleanupStepReceipt("lease_record", CleanupState.RELEASED)
-                        )
+                        cleanup_steps.append(CleanupStepReceipt("lease_record", CleanupState.RELEASED))
                     elif record_written:
-                        cleanup_steps.append(
-                            CleanupStepReceipt(
-                                "lease_record",
-                                CleanupState.QUARANTINED,
-                                "dependent cleanup incomplete",
-                            )
-                        )
+                        cleanup_steps.append(CleanupStepReceipt(
+                            "lease_record", CleanupState.QUARANTINED,
+                            "dependent cleanup incomplete"
+                        ))
                     else:
                         self._release_lease_owner_lock(lease_id, unlink=True)
-                        cleanup_steps.append(
-                            CleanupStepReceipt(
-                                "lease_record", CleanupState.ALREADY_RELEASED
-                            )
-                        )
+                        cleanup_steps.append(CleanupStepReceipt("lease_record", CleanupState.ALREADY_RELEASED))
                 except BaseException as cleanup_exc:
                     cleanup_errors.append(f"lease_record:{type(cleanup_exc).__name__}")
-                    cleanup_steps.append(
-                        CleanupStepReceipt(
-                            "lease_record",
-                            CleanupState.FAILED,
-                            type(cleanup_exc).__name__,
-                        )
-                    )
-                receipt = SandboxCleanupReceipt.from_steps(
-                    lease_id, tuple(cleanup_steps)
-                )
-                if cleanup_errors or receipt.state not in {
-                    CleanupState.RELEASED,
-                    CleanupState.ALREADY_RELEASED,
-                }:
-                    raise SandboxFault(
-                        primary, receipt, tuple(cleanup_errors)
-                    ) from primary
+                    cleanup_steps.append(CleanupStepReceipt("lease_record", CleanupState.FAILED,
+                                                            type(cleanup_exc).__name__))
+                receipt = SandboxCleanupReceipt.from_steps(lease_id, tuple(cleanup_steps))
+                if cleanup_errors or receipt.state not in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}:
+                    raise SandboxFault(primary, receipt, tuple(cleanup_errors)) from primary
                 raise
 
-    async def open_verifier(
-        self, primary: SandboxWorkspaceLease, snapshot: VerifierSnapshotReceipt
-    ) -> VerifierWorkspaceLease:
+    async def open_verifier(self, primary: SandboxWorkspaceLease,
+                            snapshot: VerifierSnapshotReceipt) -> VerifierWorkspaceLease:
         if (
             type(primary) is not SandboxWorkspaceLease
             or primary._manager is not self
@@ -3765,11 +3177,11 @@ class SandboxRuntimeManager:
             )
         async with primary._lock:
             if primary.state is not WorkspaceLeaseState.QUIESCING:
-                raise VerifierSnapshotError(
-                    "snapshot does not bind quiesced primary",
-                    code="snapshot_not_quiescent",
-                )
-            if primary.plan.episode_id != primary.plan.materialization_plan.episode_id:
+                raise VerifierSnapshotError("snapshot does not bind quiesced primary", code="snapshot_not_quiescent")
+            if (
+                primary.plan.episode_id
+                != primary.plan.materialization_plan.episode_id
+            ):
                 raise VerifierSnapshotError(
                     "primary episode identity mismatch", code="snapshot_not_quiescent"
                 )
@@ -3785,9 +3197,8 @@ class SandboxRuntimeManager:
                 )
             verifier = _exact_one(
                 self.installed_authorities.verifiers,
-                lambda item: (
-                    item.grant.verifier_id == primary.plan.verifier.grant.verifier_id
-                ),
+                lambda item: item.grant.verifier_id
+                == primary.plan.verifier.grant.verifier_id,
                 missing_code="verifier_authority_mismatch",
             )
             if verifier != primary.plan.verifier:
@@ -3800,73 +3211,47 @@ class SandboxRuntimeManager:
                 lambda item: item.runtime_id == verifier.runtime_id,
                 missing_code="verifier_authority_mismatch",
             )
-            if primary.measurement.reward_eligible and runtime.runtime_class not in {
-                RuntimeClass.HARDENED_DOCKER,
-                RuntimeClass.HARDENED_GVISOR,
-            }:
+            if (
+                primary.measurement.reward_eligible
+                and runtime.runtime_class not in {
+                    RuntimeClass.HARDENED_DOCKER,
+                    RuntimeClass.HARDENED_GVISOR,
+                }
+            ):
                 raise VerifierExecutionError(
                     "reward-eligible primary requires an isolated verifier",
                     code="verifier_authority_mismatch",
                 )
             canonical = self._snapshots.get(snapshot.snapshot_id)
             if canonical is None or canonical[0] != snapshot:
-                raise VerifierSnapshotError(
-                    "snapshot receipt is not canonical", code="snapshot_tampered"
-                )
+                raise VerifierSnapshotError("snapshot receipt is not canonical", code="snapshot_tampered")
             canonical_receipt, snapshot_path = canonical
             if snapshot.source_lease_id != primary.lease_id or (
                 snapshot.effective_plan_digest != primary.plan.effective_plan_digest
             ):
-                raise VerifierSnapshotError(
-                    "snapshot identity mismatch", code="snapshot_tampered"
-                )
+                raise VerifierSnapshotError("snapshot identity mismatch", code="snapshot_tampered")
             if not snapshot_path.is_dir():
-                raise VerifierSnapshotError(
-                    "sealed snapshot storage missing", code="snapshot_tampered"
-                )
-            image = _exact_one(
-                self.installed_authorities.images,
-                lambda item: item.image_digest == verifier.grant.image_digest,
-                missing_code="verifier_authority_mismatch",
-            )
-            security = _exact_one(
-                self.installed_authorities.security_policies,
-                lambda item: item.policy_digest == verifier.security_policy_digest,
-                missing_code="verifier_authority_mismatch",
-            )
-            network = _exact_one(
-                self.installed_authorities.network_policies,
-                lambda item: item.policy_digest == verifier.grant.network_policy_digest,
-                missing_code="verifier_authority_mismatch",
-            )
-            if (
-                runtime.runtime_class is not verifier.runtime_class
-                or image.runtime_id != runtime.runtime_id
-            ):
-                raise VerifierExecutionError(
-                    "verifier runtime authority mismatch",
-                    code="verifier_authority_mismatch",
-                )
-            verifier_plan = replace(
-                primary.plan,
-                runtime=runtime,
-                image=image,
-                security_policy=security,
-                network_policy=network,
-                isolation_disposition=(
-                    IsolationDisposition.TRUSTED_PROCESS
-                    if runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS
-                    else IsolationDisposition.ISOLATED
-                ),
-            )
+                raise VerifierSnapshotError("sealed snapshot storage missing", code="snapshot_tampered")
+            image = _exact_one(self.installed_authorities.images,
+                               lambda item: item.image_digest == verifier.grant.image_digest,
+                               missing_code="verifier_authority_mismatch")
+            security = _exact_one(self.installed_authorities.security_policies,
+                                  lambda item: item.policy_digest == verifier.security_policy_digest,
+                                  missing_code="verifier_authority_mismatch")
+            network = _exact_one(self.installed_authorities.network_policies,
+                                 lambda item: item.policy_digest == verifier.grant.network_policy_digest,
+                                 missing_code="verifier_authority_mismatch")
+            if runtime.runtime_class is not verifier.runtime_class or image.runtime_id != runtime.runtime_id:
+                raise VerifierExecutionError("verifier runtime authority mismatch", code="verifier_authority_mismatch")
+            verifier_plan = replace(primary.plan, runtime=runtime, image=image, security_policy=security,
+                                    network_policy=network,
+                                    isolation_disposition=(IsolationDisposition.TRUSTED_PROCESS
+                                        if runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS else IsolationDisposition.ISOLATED))
             workspace_id = "verifier-workspace-" + self._nonce()
             lease_id = "verifier-lease-" + self._nonce()
             owner_token = self._nonce()
             issued = self.materialization_store.clock.current()
-            quota_bytes = min(
-                primary.plan.resources.storage_bytes,
-                primary.plan.limits.artifact_bytes_total,
-            )
+            quota_bytes = min(primary.plan.resources.storage_bytes, primary.plan.limits.artifact_bytes_total)
             workspace = self.materialization_store.workspace_root / workspace_id
             try:
                 if not self._claim_lease_owner_lock(lease_id):
@@ -3904,21 +3289,13 @@ class SandboxRuntimeManager:
             backend: RuntimeBackend | None = None
             try:
                 workspace = self.materialization_store.storage_backend.allocate(
-                    workspace_id=workspace_id,
-                    root=self.materialization_store.workspace_root,
-                    max_bytes=quota_bytes,
-                )
-                workspace_fd = self.materialization_store._workspace.open_dir(
-                    workspace_id
-                )
+                    workspace_id=workspace_id, root=self.materialization_store.workspace_root,
+                    max_bytes=quota_bytes)
+                workspace_fd = self.materialization_store._workspace.open_dir(workspace_id)
                 workspace_metadata = os.fstat(workspace_fd)
-                copy_snapshot = getattr(
-                    self.materialization_store, "copy_snapshot", None
-                )
+                copy_snapshot = getattr(self.materialization_store, "copy_snapshot", None)
                 if not callable(copy_snapshot):
-                    raise VerifierSnapshotError(
-                        "snapshot copier unavailable", code="snapshot_tampered"
-                    )
+                    raise VerifierSnapshotError("snapshot copier unavailable", code="snapshot_tampered")
                 try:
                     copy_task = asyncio.create_task(
                         asyncio.to_thread(
@@ -3942,45 +3319,30 @@ class SandboxRuntimeManager:
                         raise
                 except Exception as exc:
                     raise VerifierSnapshotError(
-                        "sealed snapshot authentication failed",
-                        code="snapshot_tampered",
+                        "sealed snapshot authentication failed", code="snapshot_tampered"
                     ) from exc
                 _seal_tree_at(workspace_fd, "snapshot")
                 os.mkdir("result", mode=0o700, dir_fd=workspace_fd)
-                backend = (
-                    self.process_backend
-                    if runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS
-                    else self.docker_backend
-                )
+                backend = self.process_backend if runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS else self.docker_backend
                 if backend is None:
-                    raise VerifierExecutionError(
-                        "verifier runtime backend unavailable",
-                        code="runtime_unsupported",
-                    )
-                request_bytes = canonical_json_bytes(
-                    {
-                        "schema_version": VERIFIER_REQUEST_SCHEMA_VERSION,
-                        "episode_id": verifier_plan.episode_id,
-                        "effective_plan_digest": verifier_plan.effective_plan_digest,
-                        "task_digest": snapshot.task_digest,
-                        "snapshot_digest": snapshot.root_digest,
-                        "verifier_digest": verifier_plan.verifier.grant.implementation_digest,
-                    }
-                )
+                    raise VerifierExecutionError("verifier runtime backend unavailable", code="runtime_unsupported")
+                request_bytes = canonical_json_bytes({
+                    "schema_version": VERIFIER_REQUEST_SCHEMA_VERSION,
+                    "episode_id": verifier_plan.episode_id,
+                    "effective_plan_digest": verifier_plan.effective_plan_digest,
+                    "task_digest": snapshot.task_digest,
+                    "snapshot_digest": snapshot.root_digest,
+                    "verifier_digest": verifier_plan.verifier.grant.implementation_digest,
+                })
                 os.mkdir("input", mode=0o700, dir_fd=workspace_fd)
                 input_dir_fd = os.open(
-                    "input",
-                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+                    "input", os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
                     dir_fd=workspace_fd,
                 )
                 try:
                     request_fd = os.open(
                         "verifier-request.json",
-                        os.O_WRONLY
-                        | os.O_CREAT
-                        | os.O_EXCL
-                        | os.O_NOFOLLOW
-                        | os.O_CLOEXEC,
+                        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
                         0o400,
                         dir_fd=input_dir_fd,
                     )
@@ -4036,10 +3398,7 @@ class SandboxRuntimeManager:
                     epoch=1,
                     quota_bytes=quota_bytes,
                     workspace_fd=workspace_fd,
-                    workspace_identity=(
-                        workspace_metadata.st_dev,
-                        workspace_metadata.st_ino,
-                    ),
+                    workspace_identity=(workspace_metadata.st_dev, workspace_metadata.st_ino),
                     owner_token=owner_token,
                 )
                 workspace_fd = -1
@@ -4048,21 +3407,14 @@ class SandboxRuntimeManager:
                 )
                 if isinstance(launched, TrustedProcessHandle):
                     launched.bind_identity_recorder(
-                        lambda resource_id, identity, lease_id=lease_id: (
-                            self._record_process_identity(
-                                lease_id, resource_id, identity
-                            )
-                        )
+                        lambda resource_id, identity, lease_id=lease_id:
+                            self._record_process_identity(lease_id, resource_id, identity)
                     )
                 if measurement.mismatch:
-                    raise SandboxAttestationError(
-                        "verifier runtime measurement mismatch",
-                        code="runtime_measurement_mismatch",
-                        lease_id=lease_id,
-                    )
+                    raise SandboxAttestationError("verifier runtime measurement mismatch", code="runtime_measurement_mismatch",
+                                                  lease_id=lease_id)
                 if primary.measurement.reward_eligible and (
-                    measurement.isolation_disposition
-                    is not IsolationDisposition.ISOLATED
+                    measurement.isolation_disposition is not IsolationDisposition.ISOLATED
                     or not measurement.isolated
                     or not measurement.reward_eligible
                 ):
@@ -4071,19 +3423,10 @@ class SandboxRuntimeManager:
                         code="runtime_measurement_mismatch",
                         lease_id=lease_id,
                     )
-                lease = VerifierWorkspaceLease(
-                    manager=self,
-                    primary=primary,
-                    lease_id=lease_id,
-                    plan=verifier_plan,
-                    snapshot=snapshot,
-                    workspace=workspace,
-                    runtime=launched,
-                    measurement=measurement,
-                )
-                active_record = dict(
-                    self._read_lease_record(self._lease_record_path(lease_id))
-                )
+                lease = VerifierWorkspaceLease(manager=self, primary=primary, lease_id=lease_id,
+                    plan=verifier_plan, snapshot=snapshot, workspace=workspace, runtime=launched,
+                    measurement=measurement)
+                active_record = dict(self._read_lease_record(self._lease_record_path(lease_id)))
                 prepared_resource_id = active_record.get("runtime_resource_id")
                 if (
                     prepared_resource_id is not None
@@ -4094,19 +3437,17 @@ class SandboxRuntimeManager:
                         code="stale_identity_uncertain",
                         lease_id=lease_id,
                     )
-                active_record.update(
-                    {
-                        "runtime_authority_id": runtime.runtime_id,
-                        "runtime_resource_id": launched.runtime_id,
-                        "storage_authority_id": context.storage.authority_id,
-                        "storage_quota_bytes": context.storage.quota_bytes,
-                        "runtime_executable_path": runtime.executable_path,
-                        "runtime_binary_digest": runtime.measured_binary_digest,
-                        "action_timeout_ms": verifier_plan.limits.verifier_timeout_ms,
-                        "observation_bytes": verifier_plan.limits.observation_bytes,
-                        "state": "active",
-                    }
-                )
+                active_record.update({
+                    "runtime_authority_id": runtime.runtime_id,
+                    "runtime_resource_id": launched.runtime_id,
+                    "storage_authority_id": context.storage.authority_id,
+                    "storage_quota_bytes": context.storage.quota_bytes,
+                    "runtime_executable_path": runtime.executable_path,
+                    "runtime_binary_digest": runtime.measured_binary_digest,
+                    "action_timeout_ms": verifier_plan.limits.verifier_timeout_ms,
+                    "observation_bytes": verifier_plan.limits.observation_bytes,
+                    "state": "active",
+                })
                 self._write_lease_record(lease_id, active_record)
                 primary._verifier_children.append(lease)
                 return lease
@@ -4121,13 +3462,9 @@ class SandboxRuntimeManager:
                         cleanup_steps.extend(await launched.terminate())
                     except BaseException as cleanup_error:
                         cleanup_errors.append(f"runtime:{type(cleanup_error).__name__}")
-                        cleanup_steps.append(
-                            CleanupStepReceipt(
-                                "runtime",
-                                CleanupState.FAILED,
-                                type(cleanup_error).__name__,
-                            )
-                        )
+                        cleanup_steps.append(CleanupStepReceipt(
+                            "runtime", CleanupState.FAILED, type(cleanup_error).__name__
+                        ))
                 backend_cleanup_pending = (
                     launched is None
                     and backend is self.docker_backend
@@ -4138,13 +3475,10 @@ class SandboxRuntimeManager:
                     and not _runtime_cleanup_released(cleanup_steps)
                 )
                 if backend_cleanup_pending:
-                    cleanup_steps.append(
-                        CleanupStepReceipt(
-                            "runtime",
-                            CleanupState.QUARANTINED,
-                            "backend retained launch cleanup authority",
-                        )
-                    )
+                    cleanup_steps.append(CleanupStepReceipt(
+                        "runtime", CleanupState.QUARANTINED,
+                        "backend retained launch cleanup authority",
+                    ))
                 if backend_cleanup_pending or runtime_cleanup_pending:
                     self._pending_launch_cleanups[lease_id] = _PendingLaunchCleanup(
                         workspace=workspace,
@@ -4161,70 +3495,40 @@ class SandboxRuntimeManager:
                             self._make_workspace_releasable, workspace
                         )
                         await asyncio.to_thread(
-                            self.materialization_store.storage_backend.release,
-                            workspace,
+                            self.materialization_store.storage_backend.release, workspace
                         )
-                        absent = (
-                            self.materialization_store.storage_backend.verify_absent(
-                                workspace
-                            )
-                        )
-                        cleanup_steps.append(
-                            CleanupStepReceipt(
-                                "workspace",
-                                CleanupState.RELEASED
-                                if absent
-                                else CleanupState.FAILED,
-                            )
-                        )
+                        absent = self.materialization_store.storage_backend.verify_absent(workspace)
+                        cleanup_steps.append(CleanupStepReceipt(
+                            "workspace", CleanupState.RELEASED if absent else CleanupState.FAILED
+                        ))
                     except FileNotFoundError:
-                        cleanup_steps.append(
-                            CleanupStepReceipt(
-                                "workspace", CleanupState.ALREADY_RELEASED
-                            )
-                        )
+                        cleanup_steps.append(CleanupStepReceipt("workspace", CleanupState.ALREADY_RELEASED))
                     except BaseException as cleanup_error:
-                        cleanup_errors.append(
-                            f"workspace:{type(cleanup_error).__name__}"
-                        )
-                        cleanup_steps.append(
-                            CleanupStepReceipt(
-                                "workspace",
-                                CleanupState.FAILED,
-                                type(cleanup_error).__name__,
-                            )
-                        )
+                        cleanup_errors.append(f"workspace:{type(cleanup_error).__name__}")
+                        cleanup_steps.append(CleanupStepReceipt(
+                            "workspace", CleanupState.FAILED, type(cleanup_error).__name__
+                        ))
                 else:
-                    cleanup_steps.append(
-                        CleanupStepReceipt(
-                            "workspace",
-                            CleanupState.QUARANTINED,
-                            "dependent runtime cleanup incomplete",
-                        )
-                    )
+                    cleanup_steps.append(CleanupStepReceipt(
+                        "workspace", CleanupState.QUARANTINED,
+                        "dependent runtime cleanup incomplete",
+                    ))
                 dependencies_released = all(
                     step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
                     for step in cleanup_steps
                 )
                 if dependencies_released:
                     self._unlink_lease_record(lease_id)
-                    cleanup_steps.append(
-                        CleanupStepReceipt("lease_record", CleanupState.RELEASED)
-                    )
+                    cleanup_steps.append(CleanupStepReceipt("lease_record", CleanupState.RELEASED))
                 else:
-                    cleanup_steps.append(
-                        CleanupStepReceipt(
-                            "lease_record",
-                            CleanupState.FAILED,
-                            "dependent cleanup incomplete",
-                        )
-                    )
+                    cleanup_steps.append(CleanupStepReceipt(
+                        "lease_record", CleanupState.FAILED, "dependent cleanup incomplete"
+                    ))
                 cleanup_receipt = SandboxCleanupReceipt.from_steps(
                     lease_id, tuple(cleanup_steps)
                 )
                 if cleanup_errors or cleanup_receipt.state not in {
-                    CleanupState.RELEASED,
-                    CleanupState.ALREADY_RELEASED,
+                    CleanupState.RELEASED, CleanupState.ALREADY_RELEASED
                 }:
                     raise SandboxFault(
                         primary_error, cleanup_receipt, tuple(cleanup_errors)
@@ -4233,8 +3537,7 @@ class SandboxRuntimeManager:
 
     async def _close_lease(self, lease: SandboxWorkspaceLease) -> SandboxCleanupReceipt:
         async with lease._lock:
-            if lease._cleanup is not None:
-                return lease._cleanup
+            if lease._cleanup is not None: return lease._cleanup
             await lease._fence_and_drain(WorkspaceLeaseState.RELEASING)
             steps: list[CleanupStepReceipt] = []
             child_states: list[CleanupState] = []
@@ -4263,7 +3566,9 @@ class SandboxRuntimeManager:
                 )
             )
             lease._verifier_children[:] = [
-                child for child in lease._verifier_children if not child._closed
+                child
+                for child in lease._verifier_children
+                if not child._closed
             ]
             if not incomplete_child_ids:
                 snapshot_ids = tuple(
@@ -4282,74 +3587,39 @@ class SandboxRuntimeManager:
                 try:
                     cache = await asyncio.to_thread(lease._materialized.close)
                     steps.append(CleanupStepReceipt("workspace", CleanupState.RELEASED))
-                    steps.append(
-                        CleanupStepReceipt(
-                            "cache_holder",
-                            CleanupState.RELEASED
-                            if cache.release_state.value == "released"
-                            else CleanupState.FAILED,
-                        )
-                    )
-                except Exception as exc:
-                    steps.append(
-                        CleanupStepReceipt(
-                            "workspace", CleanupState.FAILED, type(exc).__name__
-                        )
-                    )
-                    steps.append(
-                        CleanupStepReceipt(
-                            "cache_holder", CleanupState.FAILED, type(exc).__name__
-                        )
-                    )
-            else:
-                steps.append(
-                    CleanupStepReceipt(
-                        "workspace",
-                        CleanupState.QUARANTINED,
-                        "dependent runtime cleanup incomplete",
-                    )
-                )
-                steps.append(
-                    CleanupStepReceipt(
+                    steps.append(CleanupStepReceipt(
                         "cache_holder",
-                        CleanupState.QUARANTINED,
-                        "dependent runtime cleanup incomplete",
-                    )
-                )
-            prior_ok = all(
-                step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
-                for step in steps
-            )
+                        CleanupState.RELEASED
+                        if cache.release_state.value == "released"
+                        else CleanupState.FAILED,
+                    ))
+                except Exception as exc:
+                    steps.append(CleanupStepReceipt("workspace", CleanupState.FAILED, type(exc).__name__))
+                    steps.append(CleanupStepReceipt("cache_holder", CleanupState.FAILED, type(exc).__name__))
+            else:
+                steps.append(CleanupStepReceipt(
+                    "workspace", CleanupState.QUARANTINED, "dependent runtime cleanup incomplete"
+                ))
+                steps.append(CleanupStepReceipt(
+                    "cache_holder", CleanupState.QUARANTINED, "dependent runtime cleanup incomplete"
+                ))
+            prior_ok = all(step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED} for step in steps)
             try:
                 if prior_ok:
                     self._unlink_lease_record(lease.lease_id)
                     absent = not self._lease_record_exists(lease.lease_id)
-                    steps.append(
-                        CleanupStepReceipt(
-                            "lease_record",
-                            CleanupState.RELEASED if absent else CleanupState.FAILED,
-                        )
-                    )
+                    steps.append(CleanupStepReceipt("lease_record", CleanupState.RELEASED if absent else CleanupState.FAILED))
                 else:
-                    steps.append(
-                        CleanupStepReceipt(
-                            "lease_record",
-                            CleanupState.QUARANTINED,
-                            "dependent cleanup incomplete",
-                        )
-                    )
+                    steps.append(CleanupStepReceipt(
+                        "lease_record", CleanupState.QUARANTINED, "dependent cleanup incomplete"
+                    ))
             except Exception as exc:
-                steps.append(
-                    CleanupStepReceipt(
-                        "lease_record", CleanupState.FAILED, type(exc).__name__
-                    )
-                )
+                steps.append(CleanupStepReceipt("lease_record", CleanupState.FAILED, type(exc).__name__))
             receipt = SandboxCleanupReceipt.from_steps(lease.lease_id, tuple(steps))
             lease._latest_cleanup = receipt
             lease._state = (
                 WorkspaceLeaseState.RELEASED
-                if receipt.state
-                in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
+                if receipt.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
                 else WorkspaceLeaseState.QUARANTINED
                 if receipt.state is CleanupState.QUARANTINED
                 else WorkspaceLeaseState.FAILED
@@ -4369,7 +3639,9 @@ class SandboxRuntimeManager:
         if any(retained.backend_cleanup_pending for _, retained in pending):
             reconcile = getattr(self.docker_backend, "reconcile_quarantined", None)
             if not callable(reconcile):
-                backend_failure = RuntimeError("backend cleanup authority unavailable")
+                backend_failure = RuntimeError(
+                    "backend cleanup authority unavailable"
+                )
             else:
                 try:
                     await reconcile()
@@ -4382,69 +3654,52 @@ class SandboxRuntimeManager:
                 try:
                     steps.extend(await retained.runtime.terminate())
                 except BaseException as exc:
-                    steps.append(
-                        CleanupStepReceipt(
-                            "runtime", CleanupState.FAILED, type(exc).__name__
-                        )
-                    )
+                    steps.append(CleanupStepReceipt(
+                        "runtime", CleanupState.FAILED, type(exc).__name__
+                    ))
                 runtime_released = _runtime_cleanup_released(steps)
             elif retained.backend_cleanup_pending and backend_failure is not None:
-                steps.append(
-                    CleanupStepReceipt(
-                        "runtime",
-                        CleanupState.QUARANTINED,
-                        type(backend_failure).__name__,
-                    )
-                )
+                steps.append(CleanupStepReceipt(
+                    "runtime", CleanupState.QUARANTINED,
+                    type(backend_failure).__name__,
+                ))
                 runtime_released = False
             elif retained.backend_cleanup_pending:
-                steps.append(CleanupStepReceipt("runtime", CleanupState.RELEASED))
+                steps.append(CleanupStepReceipt(
+                    "runtime", CleanupState.RELEASED
+                ))
                 runtime_released = True
             else:
-                steps.append(
-                    CleanupStepReceipt(
-                        "runtime",
-                        CleanupState.FAILED,
-                        "retained cleanup authority is incomplete",
-                    )
-                )
+                steps.append(CleanupStepReceipt(
+                    "runtime", CleanupState.FAILED,
+                    "retained cleanup authority is incomplete",
+                ))
                 runtime_released = False
             if not runtime_released:
-                steps.append(
-                    CleanupStepReceipt(
-                        "workspace",
-                        CleanupState.QUARANTINED,
-                        "dependent runtime cleanup incomplete",
-                    )
-                )
+                steps.append(CleanupStepReceipt(
+                    "workspace", CleanupState.QUARANTINED,
+                    "dependent runtime cleanup incomplete",
+                ))
                 if retained.materialized is not None:
-                    steps.append(
-                        CleanupStepReceipt(
-                            "cache_holder",
-                            CleanupState.QUARANTINED,
-                            "dependent runtime cleanup incomplete",
-                        )
-                    )
-                steps.append(
-                    CleanupStepReceipt(
-                        "lease_record",
-                        CleanupState.QUARANTINED,
-                        "dependent cleanup incomplete",
-                    )
-                )
-                receipts.append(
-                    SandboxCleanupReceipt.from_steps(lease_id, tuple(steps))
-                )
+                    steps.append(CleanupStepReceipt(
+                        "cache_holder", CleanupState.QUARANTINED,
+                        "dependent runtime cleanup incomplete",
+                    ))
+                steps.append(CleanupStepReceipt(
+                    "lease_record", CleanupState.QUARANTINED,
+                    "dependent cleanup incomplete",
+                ))
+                receipts.append(SandboxCleanupReceipt.from_steps(
+                    lease_id, tuple(steps)
+                ))
                 continue
             try:
                 if retained.materialized is not None:
                     await asyncio.to_thread(retained.materialized.close)
-                    steps.extend(
-                        (
-                            CleanupStepReceipt("workspace", CleanupState.RELEASED),
-                            CleanupStepReceipt("cache_holder", CleanupState.RELEASED),
-                        )
-                    )
+                    steps.extend((
+                        CleanupStepReceipt("workspace", CleanupState.RELEASED),
+                        CleanupStepReceipt("cache_holder", CleanupState.RELEASED),
+                    ))
                 else:
                     await asyncio.to_thread(
                         self._make_workspace_releasable, retained.workspace
@@ -4456,34 +3711,24 @@ class SandboxRuntimeManager:
                     absent = self.materialization_store.storage_backend.verify_absent(
                         retained.workspace
                     )
-                    steps.extend(
-                        (
-                            CleanupStepReceipt(
-                                "workspace",
-                                CleanupState.RELEASED
-                                if absent
-                                else CleanupState.FAILED,
-                            ),
-                            CleanupStepReceipt(
-                                "cache_holder", CleanupState.ALREADY_RELEASED
-                            ),
-                        )
-                    )
-            except FileNotFoundError:
-                steps.extend(
-                    (
-                        CleanupStepReceipt("workspace", CleanupState.ALREADY_RELEASED),
+                    steps.extend((
+                        CleanupStepReceipt(
+                            "workspace",
+                            CleanupState.RELEASED if absent else CleanupState.FAILED,
+                        ),
                         CleanupStepReceipt(
                             "cache_holder", CleanupState.ALREADY_RELEASED
                         ),
-                    )
-                )
+                    ))
+            except FileNotFoundError:
+                steps.extend((
+                    CleanupStepReceipt("workspace", CleanupState.ALREADY_RELEASED),
+                    CleanupStepReceipt("cache_holder", CleanupState.ALREADY_RELEASED),
+                ))
             except BaseException as exc:
-                steps.append(
-                    CleanupStepReceipt(
-                        "workspace", CleanupState.FAILED, type(exc).__name__
-                    )
-                )
+                steps.append(CleanupStepReceipt(
+                    "workspace", CleanupState.FAILED, type(exc).__name__
+                ))
             dependencies_released = all(
                 step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
                 for step in steps
@@ -4491,32 +3736,31 @@ class SandboxRuntimeManager:
             if dependencies_released:
                 try:
                     self._unlink_lease_record(lease_id)
-                    steps.append(
-                        CleanupStepReceipt("lease_record", CleanupState.RELEASED)
-                    )
+                    steps.append(CleanupStepReceipt(
+                        "lease_record", CleanupState.RELEASED
+                    ))
                     self._pending_launch_cleanups.pop(lease_id, None)
                 except BaseException as exc:
-                    steps.append(
-                        CleanupStepReceipt(
-                            "lease_record", CleanupState.FAILED, type(exc).__name__
-                        )
-                    )
+                    steps.append(CleanupStepReceipt(
+                        "lease_record", CleanupState.FAILED, type(exc).__name__
+                    ))
             else:
-                steps.append(
-                    CleanupStepReceipt(
-                        "lease_record",
-                        CleanupState.QUARANTINED,
-                        "dependent cleanup incomplete",
-                    )
-                )
-            receipts.append(SandboxCleanupReceipt.from_steps(lease_id, tuple(steps)))
+                steps.append(CleanupStepReceipt(
+                    "lease_record", CleanupState.QUARANTINED,
+                    "dependent cleanup incomplete",
+                ))
+            receipts.append(SandboxCleanupReceipt.from_steps(
+                lease_id, tuple(steps)
+            ))
         return tuple(receipts)
+
 
     async def reconcile_stale(self) -> tuple[SandboxCleanupReceipt, ...]:
         async with self._reconcile_lock:
             if self._lease_root_fd is None:
                 return ()
             return await self._reconcile_stale_owner()
+
 
     async def _reconcile_stale_owner(
         self,
@@ -4527,12 +3771,15 @@ class SandboxRuntimeManager:
         if self._lease_root_fd is None:
             return ()
         names = tuple(
-            name
-            for name in os.listdir(self._lease_root_fd)
+            name for name in os.listdir(self._lease_root_fd)
             if "/" not in name and name not in {".", ".."}
         )
-        record_names = frozenset(name for name in names if name.endswith(".json"))
-        for lock_name in sorted(name for name in names if name.endswith(".owner.lock")):
+        record_names = frozenset(
+            name for name in names if name.endswith(".json")
+        )
+        for lock_name in sorted(
+            name for name in names if name.endswith(".owner.lock")
+        ):
             lease_id = lock_name.removesuffix(".owner.lock")
             if (
                 lease_id + ".json" in record_names
@@ -4627,16 +3874,8 @@ class SandboxRuntimeManager:
             try:
                 record = self._read_lease_record(path)
             except WorkspaceStateError as exc:
-                receipts.append(
-                    SandboxCleanupReceipt.from_steps(
-                        path.stem,
-                        (
-                            CleanupStepReceipt(
-                                "lease_record", CleanupState.QUARANTINED, exc.code
-                            ),
-                        ),
-                    )
-                )
+                receipts.append(SandboxCleanupReceipt.from_steps(path.stem, (
+                    CleanupStepReceipt("lease_record", CleanupState.QUARANTINED, exc.code),)))
                 continue
             try:
                 expires_at = record["expires_at"]
@@ -4722,8 +3961,10 @@ class SandboxRuntimeManager:
                     CleanupState.RELEASED,
                     CleanupState.ALREADY_RELEASED,
                 }:
-                    snapshot_step = await self._release_durable_snapshots_for_lease(
-                        path.stem
+                    snapshot_step = (
+                        await self._release_durable_snapshots_for_lease(
+                            path.stem
+                        )
                     )
                 else:
                     snapshot_step = CleanupStepReceipt(
@@ -4732,24 +3973,19 @@ class SandboxRuntimeManager:
                         "dependent verifier cleanup incomplete",
                     )
             reconciliation_prefix = tuple(
-                step for step in (child_step, snapshot_step) if step is not None
+                step
+                for step in (child_step, snapshot_step)
+                if step is not None
             )
             runtime_authority_id = str(
                 record.get("runtime_authority_id", record.get("runtime_id", ""))
             )
             trusted_runtime_ids = {
-                item.runtime_id
-                for item in self.installed_authorities.runtimes
+                item.runtime_id for item in self.installed_authorities.runtimes
                 if item.runtime_class is RuntimeClass.TRUSTED_PROCESS
             }
-            backend = (
-                self.process_backend
-                if runtime_authority_id in trusted_runtime_ids
-                else self.docker_backend
-            )
-            reconcile = (
-                getattr(backend, "reconcile", None) if backend is not None else None
-            )
+            backend = self.process_backend if runtime_authority_id in trusted_runtime_ids else self.docker_backend
+            reconcile = getattr(backend, "reconcile", None) if backend is not None else None
             if not callable(reconcile):
                 unavailable_steps = (
                     CleanupStepReceipt(
@@ -4781,51 +4017,61 @@ class SandboxRuntimeManager:
                 )
                 continue
             raw_steps = reconciliation_prefix + tuple(await reconcile(record))
-            if {step.resource for step in raw_steps} == (
-                {
-                    "child_verifier",
-                    *(("snapshot",) if snapshot_step is not None else ()),
-                    "runtime",
-                    "workspace",
-                    "cache_holder",
-                    "lease_record",
-                }
-                if role == "primary"
-                else {
-                    "runtime",
-                    "workspace",
-                    "cache_holder",
-                    "lease_record",
-                }
-            ) and all(
-                step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
-                for step in raw_steps
+            if (
+                {step.resource for step in raw_steps}
+                == (
+                    {
+                        "child_verifier",
+                        *(("snapshot",) if snapshot_step is not None else ()),
+                        "runtime",
+                        "workspace",
+                        "cache_holder",
+                        "lease_record",
+                    }
+                    if role == "primary"
+                    else {
+                        "runtime",
+                        "workspace",
+                        "cache_holder",
+                        "lease_record",
+                    }
+                )
+                and all(
+                    step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
+                    for step in raw_steps
+                )
             ):
                 self._unlink_lease_record(path.stem)
-                receipts.append(
-                    SandboxCleanupReceipt.from_steps(str(record["lease_id"]), raw_steps)
-                )
+                receipts.append(SandboxCleanupReceipt.from_steps(
+                    str(record["lease_id"]), raw_steps
+                ))
                 continue
             runtime_steps = tuple(
                 step for step in raw_steps if step.resource == "runtime"
             )
             runtime_released = bool(runtime_steps) and all(
-                step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
+                step.state
+                in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
                 for step in runtime_steps
             )
             steps = list(raw_steps)
-            if runtime_released and (
-                child_step is None
-                or child_step.state
-                in {
-                    CleanupState.RELEASED,
-                    CleanupState.ALREADY_RELEASED,
-                }
+            if (
+                runtime_released
+                and (
+                    child_step is None
+                    or child_step.state
+                    in {
+                        CleanupState.RELEASED,
+                        CleanupState.ALREADY_RELEASED,
+                    }
+                )
             ):
                 workspace_id = record.get("workspace_id")
                 workspace_path = record.get("workspace_path")
                 workspace_prefix = (
-                    "verifier-workspace-" if role == "verifier" else "workspace-"
+                    "verifier-workspace-"
+                    if role == "verifier"
+                    else "workspace-"
                 )
                 valid_workspace_id = (
                     type(workspace_id) is str
@@ -4833,7 +4079,7 @@ class SandboxRuntimeManager:
                     and len(workspace_id) == len(workspace_prefix) + 32
                     and all(
                         character in "0123456789abcdef"
-                        for character in workspace_id[len(workspace_prefix) :]
+                        for character in workspace_id[len(workspace_prefix):]
                     )
                 )
                 expected_workspace = (
@@ -4854,55 +4100,35 @@ class SandboxRuntimeManager:
                             self.materialization_store.storage_backend.release,
                             expected_workspace,
                         )
-                        absent = (
-                            self.materialization_store.storage_backend.verify_absent(
-                                expected_workspace
-                            )
+                        absent = self.materialization_store.storage_backend.verify_absent(
+                            expected_workspace
                         )
-                        steps.append(
-                            CleanupStepReceipt(
-                                "workspace",
-                                CleanupState.RELEASED
-                                if absent
-                                else CleanupState.FAILED,
-                            )
-                        )
-                    except FileNotFoundError:
-                        steps.append(
-                            CleanupStepReceipt(
-                                "workspace", CleanupState.ALREADY_RELEASED
-                            )
-                        )
-                    except Exception as exc:
-                        steps.append(
-                            CleanupStepReceipt(
-                                "workspace", CleanupState.FAILED, type(exc).__name__
-                            )
-                        )
-                else:
-                    steps.append(
-                        CleanupStepReceipt(
+                        steps.append(CleanupStepReceipt(
                             "workspace",
-                            CleanupState.QUARANTINED,
-                            "stale_identity_uncertain",
-                        )
-                    )
+                            CleanupState.RELEASED if absent else CleanupState.FAILED,
+                        ))
+                    except FileNotFoundError:
+                        steps.append(CleanupStepReceipt(
+                            "workspace", CleanupState.ALREADY_RELEASED
+                        ))
+                    except Exception as exc:
+                        steps.append(CleanupStepReceipt(
+                            "workspace", CleanupState.FAILED, type(exc).__name__
+                        ))
+                else:
+                    steps.append(CleanupStepReceipt(
+                        "workspace", CleanupState.QUARANTINED, "stale_identity_uncertain"
+                    ))
             else:
-                steps.append(
-                    CleanupStepReceipt(
-                        "workspace",
-                        CleanupState.QUARANTINED,
-                        "stale_identity_uncertain",
-                    )
-                )
+                steps.append(CleanupStepReceipt(
+                    "workspace", CleanupState.QUARANTINED, "stale_identity_uncertain"
+                ))
             dependencies_released = all(
                 step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
                 for step in steps
             )
             if role == "verifier" and dependencies_released:
-                steps.append(
-                    CleanupStepReceipt("cache_holder", CleanupState.ALREADY_RELEASED)
-                )
+                steps.append(CleanupStepReceipt("cache_holder", CleanupState.ALREADY_RELEASED))
                 self._unlink_lease_record(path.stem)
                 steps.append(CleanupStepReceipt("lease_record", CleanupState.RELEASED))
             elif role == "primary" and dependencies_released:
@@ -4913,53 +4139,30 @@ class SandboxRuntimeManager:
                     cache_step = await asyncio.to_thread(recover_cache, record)
                 else:
                     cache_step = CleanupStepReceipt(
-                        "cache_holder",
-                        CleanupState.QUARANTINED,
-                        "stale_identity_uncertain",
+                        "cache_holder", CleanupState.QUARANTINED, "stale_identity_uncertain"
                     )
                 steps.append(cache_step)
                 if cache_step.state in {
-                    CleanupState.RELEASED,
-                    CleanupState.ALREADY_RELEASED,
+                    CleanupState.RELEASED, CleanupState.ALREADY_RELEASED
                 }:
                     self._unlink_lease_record(path.stem)
-                    steps.append(
-                        CleanupStepReceipt("lease_record", CleanupState.RELEASED)
-                    )
+                    steps.append(CleanupStepReceipt("lease_record", CleanupState.RELEASED))
                 else:
-                    steps.append(
-                        CleanupStepReceipt(
-                            "lease_record",
-                            CleanupState.QUARANTINED,
-                            "stale_identity_uncertain",
-                        )
-                    )
+                    steps.append(CleanupStepReceipt(
+                        "lease_record", CleanupState.QUARANTINED, "stale_identity_uncertain"
+                    ))
             else:
-                steps.append(
-                    CleanupStepReceipt(
-                        "cache_holder",
-                        CleanupState.QUARANTINED,
-                        "stale_identity_uncertain",
-                    )
-                )
-                steps.append(
-                    CleanupStepReceipt(
-                        "lease_record",
-                        CleanupState.QUARANTINED,
-                        "stale_identity_uncertain",
-                    )
-                )
-            receipts.append(
-                SandboxCleanupReceipt.from_steps(str(record["lease_id"]), tuple(steps))
-            )
-        receipts.extend(
-            [
-                await self._close_lease(lease)
-                for lease in tuple(self._leases.values())
-                if lease.state
-                in {WorkspaceLeaseState.FAILED, WorkspaceLeaseState.QUARANTINED}
-            ]
-        )
+                steps.append(CleanupStepReceipt(
+                    "cache_holder", CleanupState.QUARANTINED, "stale_identity_uncertain"
+                ))
+                steps.append(CleanupStepReceipt(
+                    "lease_record", CleanupState.QUARANTINED, "stale_identity_uncertain"
+                ))
+            receipts.append(SandboxCleanupReceipt.from_steps(
+                str(record["lease_id"]), tuple(steps)
+            ))
+        receipts.extend([await self._close_lease(lease) for lease in tuple(self._leases.values())
+                         if lease.state in {WorkspaceLeaseState.FAILED, WorkspaceLeaseState.QUARANTINED}])
         return tuple(receipts)
 
     async def _close_all(
@@ -4969,7 +4172,9 @@ class SandboxRuntimeManager:
         receipts.extend(await self._reconcile_pending_launch_cleanups())
         for snapshot_id in tuple(self._snapshots):
             step = await self._release_snapshot(snapshot_id)
-            receipts.append(SandboxCleanupReceipt.from_steps(snapshot_id, (step,)))
+            receipts.append(
+                SandboxCleanupReceipt.from_steps(snapshot_id, (step,))
+            )
         return receipts
 
     async def _close_all_serialized(
@@ -4994,7 +4199,9 @@ class SandboxRuntimeManager:
                     return self._last_close_receipts or ()
                 self._closed = True
                 leases = tuple(self._leases.values())
-                close_task = asyncio.create_task(self._close_all_serialized(leases))
+                close_task = asyncio.create_task(
+                    self._close_all_serialized(leases)
+                )
                 self._close_task = close_task
         try:
             result = tuple(await asyncio.shield(close_task))
@@ -5004,10 +4211,10 @@ class SandboxRuntimeManager:
                     if self._close_task is close_task:
                         self._close_task = None
         pending = tuple(
-            receipt
-            for receipt in result
-            if receipt.state
-            not in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
+            receipt for receipt in result
+            if receipt.state not in {
+                CleanupState.RELEASED, CleanupState.ALREADY_RELEASED
+            }
         )
         if not pending:
             self._last_close_receipts = result
@@ -5026,41 +4233,17 @@ class SandboxRuntimeManager:
 
 
 __all__ = [
-    "CacheLeaseError",
-    "InstalledImage",
-    "InstalledRuntime",
-    "InstalledSandboxAuthoritySet",
-    "InstalledVerifier",
-    "LeaseBackedRunnerWorkspace",
-    "MaterializationError",
-    "RuntimeBackend",
-    "RuntimeHandle",
-    "RuntimeLaunchContext",
-    "RuntimePreparedIdentity",
-    "SandboxAttestationError",
-    "SandboxCleanupReceipt",
-    "SandboxExecutionPlan",
-    "SandboxFault",
-    "SandboxLaunchError",
-    "SandboxMeasurement",
-    "SandboxNetworkPolicy",
-    "SandboxPlanError",
-    "SandboxRuntimeError",
-    "SandboxRuntimeManager",
-    "SandboxSecurityPolicy",
-    "SandboxWorkspaceLease",
-    "TrustedProcessBackend",
-    "TrustedProcessHandle",
-    "SANDBOX_CAPABILITY_MATRIX_RESOURCE",
-    "SANDBOX_CAPABILITY_MATRIX_SCHEMA_VERSION",
+    "CacheLeaseError", "InstalledImage", "InstalledRuntime", "InstalledSandboxAuthoritySet",
+    "InstalledVerifier", "LeaseBackedRunnerWorkspace", "MaterializationError", "RuntimeBackend",
+    "RuntimeHandle", "RuntimeLaunchContext", "RuntimePreparedIdentity", "SandboxAttestationError",
+    "SandboxCleanupReceipt", "SandboxExecutionPlan", "SandboxFault", "SandboxLaunchError",
+    "SandboxMeasurement", "SandboxNetworkPolicy",
+    "SandboxPlanError", "SandboxRuntimeError", "SandboxRuntimeManager", "SandboxSecurityPolicy",
+    "SandboxWorkspaceLease", "TrustedProcessBackend", "TrustedProcessHandle",
+    "SANDBOX_CAPABILITY_MATRIX_RESOURCE", "SANDBOX_CAPABILITY_MATRIX_SCHEMA_VERSION",
     "SANDBOX_CAPABILITY_MATRIX_SHA256",
-    "VERIFIER_REQUEST_RELATIVE_PATH",
-    "VERIFIER_REQUEST_SCHEMA_VERSION",
-    "VerifierExecutionError",
-    "VerifierSnapshotError",
-    "VerifierWorkspaceLease",
-    "WorkspaceStateError",
-    "WorkspaceStorageIdentity",
-    "build_sandbox_execution_plan",
+    "VERIFIER_REQUEST_RELATIVE_PATH", "VERIFIER_REQUEST_SCHEMA_VERSION",
+    "VerifierExecutionError", "VerifierSnapshotError", "VerifierWorkspaceLease",
+    "WorkspaceStateError", "WorkspaceStorageIdentity", "build_sandbox_execution_plan",
     "load_sandbox_capability_matrix",
 ]

--- a/breadboard/rl/harness/sandbox.py
+++ b/breadboard/rl/harness/sandbox.py
@@ -10,6 +10,7 @@ import signal
 import stat
 import subprocess
 import sys
+import tempfile
 import uuid
 from dataclasses import dataclass, replace
 from datetime import datetime
@@ -81,11 +82,10 @@ def _read_sandbox_capability_matrix_resource() -> bytes:
     limit = _MAX_SANDBOX_CAPABILITY_MATRIX_BYTES
     if isinstance(resource, Path):
         expected = os.stat(resource, follow_symlinks=False)
-        if (
-            not stat.S_ISREG(expected.st_mode)
-            or expected.st_size > limit
-        ):
-            raise OSError("sandbox capability matrix resource is not regular and bounded")
+        if not stat.S_ISREG(expected.st_mode) or expected.st_size > limit:
+            raise OSError(
+                "sandbox capability matrix resource is not regular and bounded"
+            )
         descriptor = os.open(
             resource,
             os.O_RDONLY
@@ -98,12 +98,9 @@ def _read_sandbox_capability_matrix_resource() -> bytes:
             if (
                 not stat.S_ISREG(opened.st_mode)
                 or opened.st_size > limit
-                or (opened.st_dev, opened.st_ino)
-                != (expected.st_dev, expected.st_ino)
+                or (opened.st_dev, opened.st_ino) != (expected.st_dev, expected.st_ino)
             ):
-                raise OSError(
-                    "sandbox capability matrix resource identity changed"
-                )
+                raise OSError("sandbox capability matrix resource identity changed")
             chunks: list[bytes] = []
             remaining = limit + 1
             while remaining:
@@ -134,7 +131,10 @@ def load_sandbox_capability_matrix() -> Mapping[str, Any]:
     """Load and validate the installed canonical sandbox capability matrix."""
     try:
         encoded_matrix = _read_sandbox_capability_matrix_resource()
-        if hashlib.sha256(encoded_matrix).hexdigest() != SANDBOX_CAPABILITY_MATRIX_SHA256:
+        if (
+            hashlib.sha256(encoded_matrix).hexdigest()
+            != SANDBOX_CAPABILITY_MATRIX_SHA256
+        ):
             raise SandboxRuntimeError(
                 "sandbox capability matrix digest is invalid",
                 code="capability_matrix_invalid",
@@ -184,11 +184,12 @@ def load_sandbox_capability_matrix() -> Mapping[str, Any]:
                 "unavailable_code",
                 "evidence_contracts",
             }
-            or adapter["status"]
-            != _SANDBOX_ADAPTER_STATUSES.get(adapter["adapter_id"])
+            or adapter["status"] != _SANDBOX_ADAPTER_STATUSES.get(adapter["adapter_id"])
             or type(adapter["capabilities"]) is not dict
             or set(adapter["capabilities"]) != _SANDBOX_CAPABILITY_KEYS
-            or any(type(value) is not bool for value in adapter["capabilities"].values())
+            or any(
+                type(value) is not bool for value in adapter["capabilities"].values()
+            )
             or type(adapter["required_host_capabilities"]) is not list
             or any(
                 type(value) is not str or not value
@@ -221,12 +222,14 @@ def load_sandbox_capability_matrix() -> Mapping[str, Any]:
 
 def _wp7_digest(value: Any) -> str:
     import hashlib
+
     return "sha256:" + hashlib.sha256(canonical_json_bytes(value)).hexdigest()
 
 
 def _seal_tree_at(parent_fd: int, name: str) -> None:
     directory_fd = os.open(
-        name, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+        name,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
         dir_fd=parent_fd,
     )
     try:
@@ -267,7 +270,9 @@ def _open_directory_at(parent_fd: int, name: str, *, create: bool) -> int:
         return os.open(name, flags, dir_fd=parent_fd)
 
 
-def _open_parent_descriptor(root: Path, parts: tuple[str, ...], *, create: bool) -> tuple[int, str]:
+def _open_parent_descriptor(
+    root: Path, parts: tuple[str, ...], *, create: bool
+) -> tuple[int, str]:
     descriptor = os.open(root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
     try:
         for component in parts[:-1]:
@@ -280,7 +285,9 @@ def _open_parent_descriptor(root: Path, parts: tuple[str, ...], *, create: bool)
         raise
 
 
-def _open_parent_descriptor_fd(root_fd: int, parts: tuple[str, ...], *, create: bool) -> tuple[int, str]:
+def _open_parent_descriptor_fd(
+    root_fd: int, parts: tuple[str, ...], *, create: bool
+) -> tuple[int, str]:
     descriptor = os.dup(root_fd)
     try:
         for component in parts[:-1]:
@@ -293,7 +300,9 @@ def _open_parent_descriptor_fd(root_fd: int, parts: tuple[str, ...], *, create: 
         raise
 
 
-def _bounded_regular_read(root: Path | int, logical_path: str, *, offset: int, limit: int) -> bytes:
+def _bounded_regular_read(
+    root: Path | int, logical_path: str, *, offset: int, limit: int
+) -> bytes:
     parts = _workspace_parts(logical_path)
     parent_fd, name = (
         _open_parent_descriptor_fd(root, parts, create=False)
@@ -427,11 +436,11 @@ def _descriptor_list(
         before = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
         descriptor = _open_directory_at(parent_fd, name, create=False)
         after = os.fstat(descriptor)
-        if (
-            not file_type.S_ISDIR(before.st_mode)
-            or (before.st_dev, before.st_ino, before.st_mode)
-            != (after.st_dev, after.st_ino, after.st_mode)
-        ):
+        if not file_type.S_ISDIR(before.st_mode) or (
+            before.st_dev,
+            before.st_ino,
+            before.st_mode,
+        ) != (after.st_dev, after.st_ino, after.st_mode):
             raise OSError("workspace listing root identity changed")
         walk(descriptor, parts, 0)
         return values
@@ -515,7 +524,10 @@ class _PinnedExecutable:
             self.closed = True
 
 
-def _snapshot_installed_executable(path: str, expected_digest: str) -> _PinnedExecutable:
+def _snapshot_installed_executable(
+    path: str,
+    expected_digest: str | None,
+) -> _PinnedExecutable:
     required_fcntl = (
         "F_ADD_SEALS",
         "F_GET_SEALS",
@@ -558,7 +570,7 @@ def _snapshot_installed_executable(path: str, expected_digest: str) -> _PinnedEx
                     raise OSError("short executable snapshot write")
                 view = view[written:]
         digest = "sha256:" + hasher.hexdigest()
-        if digest != expected_digest:
+        if expected_digest is not None and digest != expected_digest:
             raise SandboxLaunchError(
                 "trusted process executable identity mismatch",
                 code="runtime_preflight_failed",
@@ -631,15 +643,16 @@ class InstalledRuntime:
             or not _exact_absolute_path(self.executable_path)
             or not _exact_sha256_digest(self.measured_binary_digest)
         ):
-            raise ValueError("runtime authority requires an exact class, path, and digest")
+            raise ValueError(
+                "runtime authority requires an exact class, path, and digest"
+            )
         hardened = self.runtime_class in {
             RuntimeClass.HARDENED_DOCKER,
             RuntimeClass.HARDENED_GVISOR,
         }
-        oci_identity_valid = (
-            _exact_absolute_path(self.oci_runtime_binary_path)
-            and _exact_sha256_digest(self.oci_runtime_binary_digest)
-        )
+        oci_identity_valid = _exact_absolute_path(
+            self.oci_runtime_binary_path
+        ) and _exact_sha256_digest(self.oci_runtime_binary_digest)
         if hardened and (not self.oci_runtime_name or not oci_identity_valid):
             raise ValueError("hardened runtime requires an exact OCI binary authority")
         if not hardened and (
@@ -651,12 +664,19 @@ class InstalledRuntime:
             self.runsc_binary_path != self.oci_runtime_binary_path
             or self.runsc_binary_digest != self.oci_runtime_binary_digest
         ):
-            raise ValueError("runsc registration authority must equal the pinned OCI binary")
+            raise ValueError(
+                "runsc registration authority must equal the pinned OCI binary"
+            )
         if self.fixed_environment != tuple(sorted(self.fixed_environment)):
             raise ValueError("fixed environment must be sorted")
-        if len({key for key, _ in self.fixed_environment}) != len(self.fixed_environment):
+        if len({key for key, _ in self.fixed_environment}) != len(
+            self.fixed_environment
+        ):
             raise ValueError("fixed environment keys must be unique")
-        if any(not key or "=" in key or "\x00" in key + value for key, value in self.fixed_environment):
+        if any(
+            not key or "=" in key or "\x00" in key + value
+            for key, value in self.fixed_environment
+        ):
             raise ValueError("invalid fixed environment")
 
 
@@ -667,7 +687,10 @@ class InstalledImage:
     immutable_reference: str
 
     def __post_init__(self) -> None:
-        if not self.image_digest.startswith("sha256:") or "@sha256:" not in self.immutable_reference:
+        if (
+            not self.image_digest.startswith("sha256:")
+            or "@sha256:" not in self.immutable_reference
+        ):
             raise ValueError("installed image must use an immutable digest reference")
 
 
@@ -693,27 +716,49 @@ class SandboxSecurityPolicy:
     snapshot_max_inodes: int
 
     def __post_init__(self) -> None:
-        if _wp7_digest(self.seccomp_bytes.decode("utf-8")) != self.seccomp_digest and (
-            "sha256:" + __import__("hashlib").sha256(self.seccomp_bytes).hexdigest()
-        ) != self.seccomp_digest:
+        if (
+            _wp7_digest(self.seccomp_bytes.decode("utf-8")) != self.seccomp_digest
+            and (
+                "sha256:" + __import__("hashlib").sha256(self.seccomp_bytes).hexdigest()
+            )
+            != self.seccomp_digest
+        ):
             raise ValueError("seccomp digest mismatch")
         if self.privileged or self.devices or not self.docker_socket_forbidden:
             raise ValueError("security policy admits forbidden container authority")
         if (self.apparmor_profile is None) == (self.selinux_label is None):
             raise ValueError("exactly one LSM authority is required")
-        if min(self.uid, self.gid, self.snapshot_max_depth, self.snapshot_max_files, self.snapshot_max_inodes) < 0:
+        if (
+            min(
+                self.uid,
+                self.gid,
+                self.snapshot_max_depth,
+                self.snapshot_max_files,
+                self.snapshot_max_inodes,
+            )
+            < 0
+        ):
             raise ValueError("invalid security policy numeric value")
 
     def projection(self) -> dict[str, Any]:
-        return {"uid": self.uid, "gid": self.gid, "read_only_root": self.read_only_root,
-                "drop_all_capabilities": self.drop_all_capabilities,
-                "no_new_privileges": self.no_new_privileges, "seccomp_digest": self.seccomp_digest,
-                "apparmor_profile": self.apparmor_profile, "selinux_label": self.selinux_label,
-                "namespace_flags": list(self.namespace_flags), "privileged": self.privileged,
-                "devices": list(self.devices), "docker_socket_forbidden": self.docker_socket_forbidden,
-                "tmpfs_mounts": [list(item) for item in self.tmpfs_mounts],
-                "snapshot_max_depth": self.snapshot_max_depth, "snapshot_max_files": self.snapshot_max_files,
-                "snapshot_max_inodes": self.snapshot_max_inodes}
+        return {
+            "uid": self.uid,
+            "gid": self.gid,
+            "read_only_root": self.read_only_root,
+            "drop_all_capabilities": self.drop_all_capabilities,
+            "no_new_privileges": self.no_new_privileges,
+            "seccomp_digest": self.seccomp_digest,
+            "apparmor_profile": self.apparmor_profile,
+            "selinux_label": self.selinux_label,
+            "namespace_flags": list(self.namespace_flags),
+            "privileged": self.privileged,
+            "devices": list(self.devices),
+            "docker_socket_forbidden": self.docker_socket_forbidden,
+            "tmpfs_mounts": [list(item) for item in self.tmpfs_mounts],
+            "snapshot_max_depth": self.snapshot_max_depth,
+            "snapshot_max_files": self.snapshot_max_files,
+            "snapshot_max_inodes": self.snapshot_max_inodes,
+        }
 
     @staticmethod
     def derive_digest(projection: Mapping[str, Any]) -> str:
@@ -729,8 +774,12 @@ class SandboxNetworkPolicy:
     default_deny: bool
 
     def projection(self) -> dict[str, Any]:
-        return {"mode": self.mode, "docker_network": self.docker_network,
-                "egress_route_ids": list(self.egress_route_ids), "default_deny": self.default_deny}
+        return {
+            "mode": self.mode,
+            "docker_network": self.docker_network,
+            "egress_route_ids": list(self.egress_route_ids),
+            "default_deny": self.default_deny,
+        }
 
     @staticmethod
     def derive_digest(projection: Mapping[str, Any]) -> str:
@@ -751,11 +800,23 @@ class InstalledVerifier:
     result_schema_digest: str
 
     def __post_init__(self) -> None:
-        if not self.argv or Path(self.result_relative_path).is_absolute() or ".." in Path(self.result_relative_path).parts:
+        if (
+            not self.argv
+            or Path(self.result_relative_path).is_absolute()
+            or ".." in Path(self.result_relative_path).parts
+        ):
             raise ValueError("invalid installed verifier")
-        if (self.executable_digest, self.code_digest, self.input_schema_digest, self.result_schema_digest) != (
-            self.grant.executable_digest, self.grant.code_digest, self.grant.input_schema_digest,
-            self.grant.result_schema_digest):
+        if (
+            self.executable_digest,
+            self.code_digest,
+            self.input_schema_digest,
+            self.result_schema_digest,
+        ) != (
+            self.grant.executable_digest,
+            self.grant.code_digest,
+            self.grant.input_schema_digest,
+            self.grant.result_schema_digest,
+        ):
             raise ValueError("verifier authority digest mismatch")
 
 
@@ -768,14 +829,18 @@ class InstalledSandboxAuthoritySet:
     verifiers: tuple[InstalledVerifier, ...]
 
     def __post_init__(self) -> None:
-        for values, key in ((self.runtimes, lambda value: value.runtime_id),
-                            (self.images, lambda value: value.image_digest),
-                            (self.security_policies, lambda value: value.policy_digest),
-                            (self.network_policies, lambda value: value.policy_digest),
-                            (self.verifiers, lambda value: value.grant.verifier_id)):
+        for values, key in (
+            (self.runtimes, lambda value: value.runtime_id),
+            (self.images, lambda value: value.image_digest),
+            (self.security_policies, lambda value: value.policy_digest),
+            (self.network_policies, lambda value: value.policy_digest),
+            (self.verifiers, lambda value: value.grant.verifier_id),
+        ):
             keys = tuple(key(value) for value in values)
             if keys != tuple(sorted(keys)) or len(keys) != len(set(keys)):
-                raise ValueError("installed authority catalogs must be sorted and unique")
+                raise ValueError(
+                    "installed authority catalogs must be sorted and unique"
+                )
 
 
 @dataclass(frozen=True, slots=True)
@@ -829,8 +894,10 @@ class RuntimePreparedIdentity:
         if (
             type(self.runtime_resource_id) is not str
             or not self.runtime_resource_id
-            or any(type(key) is not str or not key or type(value) is not str
-                   for key, value in self.labels.items())
+            or any(
+                type(key) is not str or not key or type(value) is not str
+                for key, value in self.labels.items()
+            )
         ):
             raise ValueError("invalid prepared runtime identity")
         object.__setattr__(
@@ -869,7 +936,10 @@ class RuntimeLaunchContext:
                     or self.workspace_fd < 0
                     or type(self.workspace_identity) is not tuple
                     or len(self.workspace_identity) != 2
-                    or any(type(value) is not int or value < 0 for value in self.workspace_identity)
+                    or any(
+                        type(value) is not int or value < 0
+                        for value in self.workspace_identity
+                    )
                 )
             )
             or (
@@ -911,9 +981,16 @@ class SandboxMeasurement:
 
 
 class SandboxRuntimeError(RuntimeError):
-    def __init__(self, message: str, *, code: str, episode_id: str | None = None,
-                 effective_plan_digest: str | None = None, lease_id: str | None = None,
-                 details: Mapping[str, Any] | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        episode_id: str | None = None,
+        effective_plan_digest: str | None = None,
+        lease_id: str | None = None,
+        details: Mapping[str, Any] | None = None,
+    ) -> None:
         super().__init__(message)
         self.code = code
         self.episode_id = episode_id
@@ -922,20 +999,48 @@ class SandboxRuntimeError(RuntimeError):
         self.details = MappingProxyType(dict(details or {}))
 
 
-class SandboxPlanError(SandboxRuntimeError): pass
-class MaterializationError(SandboxRuntimeError): pass
-class CacheLeaseError(MaterializationError): pass
-class SandboxLaunchError(SandboxRuntimeError): pass
-class SandboxAttestationError(SandboxRuntimeError): pass
-class WorkspaceStateError(SandboxRuntimeError): pass
-class VerifierSnapshotError(SandboxRuntimeError): pass
-class VerifierExecutionError(SandboxRuntimeError): pass
+class SandboxPlanError(SandboxRuntimeError):
+    pass
+
+
+class MaterializationError(SandboxRuntimeError):
+    pass
+
+
+class CacheLeaseError(MaterializationError):
+    pass
+
+
+class SandboxLaunchError(SandboxRuntimeError):
+    pass
+
+
+class SandboxAttestationError(SandboxRuntimeError):
+    pass
+
+
+class WorkspaceStateError(SandboxRuntimeError):
+    pass
+
+
+class VerifierSnapshotError(SandboxRuntimeError):
+    pass
+
+
+class VerifierExecutionError(SandboxRuntimeError):
+    pass
 
 
 class SandboxFault(SandboxRuntimeError):
-    def __init__(self, primary: BaseException, cleanup_receipt: SandboxCleanupReceipt,
-                 cleanup_errors: tuple[str, ...]) -> None:
-        super().__init__("sandbox operation and cleanup both failed", code="cleanup_incomplete")
+    def __init__(
+        self,
+        primary: BaseException,
+        cleanup_receipt: SandboxCleanupReceipt,
+        cleanup_errors: tuple[str, ...],
+    ) -> None:
+        super().__init__(
+            "sandbox operation and cleanup both failed", code="cleanup_incomplete"
+        )
         self.primary = primary
         self.cleanup_receipt = cleanup_receipt
         self.cleanup_errors = cleanup_errors
@@ -945,125 +1050,420 @@ class SandboxFault(SandboxRuntimeError):
 def _exact_one(values: Sequence[Any], predicate: Any, *, missing_code: str) -> Any:
     found = [value for value in values if predicate(value)]
     if len(found) != 1:
-        raise SandboxPlanError("installed authority did not resolve exactly once", code=missing_code)
+        raise SandboxPlanError(
+            "installed authority did not resolve exactly once", code=missing_code
+        )
     return found[0]
 
 
-def build_sandbox_execution_plan(request: WorkspaceOpenRequest, registries: RegistrySnapshotSet,
-                                 installed_authorities: InstalledSandboxAuthoritySet) -> SandboxExecutionPlan:
-    if type(request) is not WorkspaceOpenRequest or type(request.effective_plan) is not EffectiveExecutionPlan:
-        raise SandboxPlanError("exact workspace request required", code="plan_type_invalid")
-    if type(registries) is not RegistrySnapshotSet or type(installed_authorities) is not InstalledSandboxAuthoritySet:
-        raise SandboxPlanError("exact installed catalogs required", code="plan_type_invalid")
+def build_sandbox_execution_plan(
+    request: WorkspaceOpenRequest,
+    registries: RegistrySnapshotSet,
+    installed_authorities: InstalledSandboxAuthoritySet,
+) -> SandboxExecutionPlan:
+    if (
+        type(request) is not WorkspaceOpenRequest
+        or type(request.effective_plan) is not EffectiveExecutionPlan
+    ):
+        raise SandboxPlanError(
+            "exact workspace request required", code="plan_type_invalid"
+        )
+    if (
+        type(registries) is not RegistrySnapshotSet
+        or type(installed_authorities) is not InstalledSandboxAuthoritySet
+    ):
+        raise SandboxPlanError(
+            "exact installed catalogs required", code="plan_type_invalid"
+        )
     plan = request.effective_plan
     if request.effective_plan_digest != plan.canonical_digest():
-        raise SandboxPlanError("effective plan digest mismatch", code="plan_digest_mismatch")
-    binding_record = _exact_one(registries.sandbox_runtimes,
-                                lambda item: item.binding.runtime_id == plan.sandbox.runtime_id,
-                                missing_code="runtime_authority_missing")
-    expected_binding = SandboxBinding(runtime_id=plan.sandbox.runtime_id,
+        raise SandboxPlanError(
+            "effective plan digest mismatch", code="plan_digest_mismatch"
+        )
+    binding_record = _exact_one(
+        registries.sandbox_runtimes,
+        lambda item: item.binding.runtime_id == plan.sandbox.runtime_id,
+        missing_code="runtime_authority_missing",
+    )
+    expected_binding = SandboxBinding(
+        runtime_id=plan.sandbox.runtime_id,
         runtime_class=plan.sandbox.runtime_class,
         driver_implementation_digest=plan.sandbox.driver_implementation_digest,
         runtime_binary_digest=plan.sandbox.runtime_binary_digest,
         security_policy_digest=plan.sandbox.security_policy_digest,
         image_digest=plan.sandbox.image_digest,
-        network_policy_digest=plan.sandbox.network_policy_digest)
+        network_policy_digest=plan.sandbox.network_policy_digest,
+    )
     if binding_record.binding != expected_binding:
-        raise SandboxPlanError("runtime registry binding mismatch", code="runtime_identity_mismatch")
-    runtime = _exact_one(installed_authorities.runtimes,
-                         lambda item: item.runtime_id == plan.sandbox.runtime_id,
-                         missing_code="runtime_authority_missing")
-    if (runtime.runtime_class, runtime.driver_implementation_digest, runtime.measured_binary_digest) != (
-        plan.sandbox.runtime_class, plan.sandbox.driver_implementation_digest, plan.sandbox.runtime_binary_digest):
-        raise SandboxPlanError("installed runtime mismatch", code="runtime_identity_mismatch")
-    if runtime.runtime_class not in {RuntimeClass.TRUSTED_PROCESS, RuntimeClass.HARDENED_DOCKER, RuntimeClass.HARDENED_GVISOR}:
-        raise SandboxPlanError("runtime class unsupported", code="runtime_unsupported")
-    if runtime.runtime_class is RuntimeClass.HARDENED_GVISOR and runtime.oci_runtime_name != "runsc":
-        raise SandboxPlanError("runsc authority is not exact", code="runtime_unsupported")
-    image = _exact_one(installed_authorities.images, lambda item: item.image_digest == plan.sandbox.image_digest,
-                       missing_code="runtime_authority_missing")
-    if image.runtime_id != runtime.runtime_id:
-        raise SandboxPlanError("image runtime mismatch", code="runtime_identity_mismatch")
-    image_record = _exact_one(registries.images, lambda item: item.image_digest == image.image_digest,
-                              missing_code="runtime_authority_missing")
-    if image_record.runtime_id != runtime.runtime_id:
-        raise SandboxPlanError("image registry mismatch", code="runtime_identity_mismatch")
-    security = _exact_one(installed_authorities.security_policies,
-                          lambda item: item.policy_digest == plan.sandbox.security_policy_digest,
-                          missing_code="runtime_authority_missing")
-    if security.policy_digest != SandboxSecurityPolicy.derive_digest(security.projection()):
-        raise SandboxPlanError("security policy content mismatch", code="runtime_identity_mismatch")
-    if runtime.runtime_class in {RuntimeClass.HARDENED_DOCKER, RuntimeClass.HARDENED_GVISOR} and (
-        security.uid == 0 or security.gid == 0
+        raise SandboxPlanError(
+            "runtime registry binding mismatch", code="runtime_identity_mismatch"
+        )
+    runtime = _exact_one(
+        installed_authorities.runtimes,
+        lambda item: item.runtime_id == plan.sandbox.runtime_id,
+        missing_code="runtime_authority_missing",
+    )
+    if (
+        runtime.runtime_class,
+        runtime.driver_implementation_digest,
+        runtime.measured_binary_digest,
+    ) != (
+        plan.sandbox.runtime_class,
+        plan.sandbox.driver_implementation_digest,
+        plan.sandbox.runtime_binary_digest,
     ):
-        raise SandboxPlanError("hardened runtime cannot run as root", code="runtime_identity_mismatch")
-    network = _exact_one(installed_authorities.network_policies,
-                         lambda item: item.policy_digest == plan.sandbox.network_policy_digest,
-                         missing_code="runtime_authority_missing")
-    if network.policy_digest != SandboxNetworkPolicy.derive_digest(network.projection()):
-        raise SandboxPlanError("network policy content mismatch", code="runtime_identity_mismatch")
+        raise SandboxPlanError(
+            "installed runtime mismatch", code="runtime_identity_mismatch"
+        )
+    if runtime.runtime_class not in {
+        RuntimeClass.TRUSTED_PROCESS,
+        RuntimeClass.HARDENED_DOCKER,
+        RuntimeClass.HARDENED_GVISOR,
+    }:
+        raise SandboxPlanError("runtime class unsupported", code="runtime_unsupported")
+    if (
+        runtime.runtime_class is RuntimeClass.HARDENED_GVISOR
+        and runtime.oci_runtime_name != "runsc"
+    ):
+        raise SandboxPlanError(
+            "runsc authority is not exact", code="runtime_unsupported"
+        )
+    image = _exact_one(
+        installed_authorities.images,
+        lambda item: item.image_digest == plan.sandbox.image_digest,
+        missing_code="runtime_authority_missing",
+    )
+    if image.runtime_id != runtime.runtime_id:
+        raise SandboxPlanError(
+            "image runtime mismatch", code="runtime_identity_mismatch"
+        )
+    image_record = _exact_one(
+        registries.images,
+        lambda item: item.image_digest == image.image_digest,
+        missing_code="runtime_authority_missing",
+    )
+    if image_record.runtime_id != runtime.runtime_id:
+        raise SandboxPlanError(
+            "image registry mismatch", code="runtime_identity_mismatch"
+        )
+    security = _exact_one(
+        installed_authorities.security_policies,
+        lambda item: item.policy_digest == plan.sandbox.security_policy_digest,
+        missing_code="runtime_authority_missing",
+    )
+    if security.policy_digest != SandboxSecurityPolicy.derive_digest(
+        security.projection()
+    ):
+        raise SandboxPlanError(
+            "security policy content mismatch", code="runtime_identity_mismatch"
+        )
+    if runtime.runtime_class in {
+        RuntimeClass.HARDENED_DOCKER,
+        RuntimeClass.HARDENED_GVISOR,
+    } and (security.uid == 0 or security.gid == 0):
+        raise SandboxPlanError(
+            "hardened runtime cannot run as root", code="runtime_identity_mismatch"
+        )
+    network = _exact_one(
+        installed_authorities.network_policies,
+        lambda item: item.policy_digest == plan.sandbox.network_policy_digest,
+        missing_code="runtime_authority_missing",
+    )
+    if network.policy_digest != SandboxNetworkPolicy.derive_digest(
+        network.projection()
+    ):
+        raise SandboxPlanError(
+            "network policy content mismatch", code="runtime_identity_mismatch"
+        )
     if tuple(network.egress_route_ids) != tuple(plan.sandbox.egress_route_ids):
-        raise SandboxPlanError("network route authority mismatch", code="runtime_identity_mismatch")
+        raise SandboxPlanError(
+            "network route authority mismatch", code="runtime_identity_mismatch"
+        )
     if network.mode != "none" or not network.default_deny or network.egress_route_ids:
-        raise SandboxPlanError("installed network enforcement is unsupported", code="runtime_unsupported")
+        raise SandboxPlanError(
+            "installed network enforcement is unsupported", code="runtime_unsupported"
+        )
     setup_records: list[SetupRegistryRecord] = []
     for grant in plan.effective_capabilities.setup_plans:
-        record = _exact_one(registries.setups, lambda item, grant=grant: item.grant.setup_id == grant.setup_id,
-                            missing_code="setup_plan_unresolvable")
-        if record.grant != grant or record.derived_plan_digest() != grant.plan_digest or record.route_ids or record.secret_handle_ids:
-            raise SandboxPlanError("setup plan is not exactly resolvable", code="setup_plan_unresolvable")
+        record = _exact_one(
+            registries.setups,
+            lambda item, grant=grant: item.grant.setup_id == grant.setup_id,
+            missing_code="setup_plan_unresolvable",
+        )
+        if (
+            record.grant != grant
+            or record.derived_plan_digest() != grant.plan_digest
+            or record.route_ids
+            or record.secret_handle_ids
+        ):
+            raise SandboxPlanError(
+                "setup plan is not exactly resolvable", code="setup_plan_unresolvable"
+            )
         setup_records.append(record)
-    verifier = _exact_one(installed_authorities.verifiers,
-                          lambda item: item.grant.verifier_id == plan.verifier.verifier_id,
-                          missing_code="verifier_authority_mismatch")
-    verifier_registry = _exact_one(registries.verifiers,
-                                   lambda item: item.grant.verifier_id == plan.verifier.verifier_id,
-                                   missing_code="verifier_authority_mismatch")
-    if (verifier.grant != plan.verifier or verifier_registry.grant != plan.verifier
+    verifier = _exact_one(
+        installed_authorities.verifiers,
+        lambda item: item.grant.verifier_id == plan.verifier.verifier_id,
+        missing_code="verifier_authority_mismatch",
+    )
+    verifier_registry = _exact_one(
+        registries.verifiers,
+        lambda item: item.grant.verifier_id == plan.verifier.verifier_id,
+        missing_code="verifier_authority_mismatch",
+    )
+    if (
+        verifier.grant != plan.verifier
+        or verifier_registry.grant != plan.verifier
         or verifier_registry.runtime_id != verifier.runtime_id
         or verifier_registry.runtime_class is not verifier.runtime_class
         or verifier_registry.security_policy_digest != verifier.security_policy_digest
-        or plan.verifier.secret_handle_ids):
-        raise SandboxPlanError("verifier authority mismatch", code="verifier_authority_mismatch")
-    tools = tuple(RunnerToolBinding(item.tool_id, item.implementation_digest, item.capability_ids)
-                  for item in plan.effective_capabilities.tools)
-    mounts_by_digest = {mount.source_artifact_digest: mount for mount in plan.sandbox.mounts}
+        or plan.verifier.secret_handle_ids
+    ):
+        raise SandboxPlanError(
+            "verifier authority mismatch", code="verifier_authority_mismatch"
+        )
+    tools = tuple(
+        RunnerToolBinding(item.tool_id, item.implementation_digest, item.capability_ids)
+        for item in plan.effective_capabilities.tools
+    )
+    mounts_by_digest = {
+        mount.source_artifact_digest: mount for mount in plan.sandbox.mounts
+    }
     required: list[tuple[str, str]] = []
     if plan.task.repository_snapshot_digest is not None:
         required.append((plan.task.repository_snapshot_digest, "repository"))
     required += [(value, "dataset") for value in plan.task.dataset_digests]
     required += [(value, "input") for value in plan.task.input_artifact_digests]
-    required += [(value, "setup_input") for record in setup_records for value in record.input_digests]
+    required += [
+        (value, "setup_input")
+        for record in setup_records
+        for value in record.input_digests
+    ]
     if any(digest not in mounts_by_digest for digest, _ in required):
-        raise SandboxPlanError("task or setup input has no admitted target", code="task_input_unmapped")
+        raise SandboxPlanError(
+            "task or setup input has no admitted target", code="task_input_unmapped"
+        )
     role_by_digest = {digest: role for digest, role in required}
-    entries = tuple(sorted((MaterializationEntry(mount.source_artifact_digest, mount.target_logical_path,
-                                                  mount.access, mount.max_bytes,
-                                                  role_by_digest.get(mount.source_artifact_digest, "mount"))
-                            for mount in plan.sandbox.mounts), key=lambda item: (item.target_logical_path, item.source_digest, item.role)))
+    entries = tuple(
+        sorted(
+            (
+                MaterializationEntry(
+                    mount.source_artifact_digest,
+                    mount.target_logical_path,
+                    mount.access,
+                    mount.max_bytes,
+                    role_by_digest.get(mount.source_artifact_digest, "mount"),
+                )
+                for mount in plan.sandbox.mounts
+            ),
+            key=lambda item: (item.target_logical_path, item.source_digest, item.role),
+        )
+    )
     materialization = WorkspaceMaterializationPlan(
-        request.episode_id, plan.subject_digest, plan.final_receipt_digest, request.effective_plan_digest,
-        plan.sandbox.model_dump(mode="json"), plan.task.model_dump(mode="json"),
-        tuple(record.plan_projection() for record in setup_records), entries, tools,
+        request.episode_id,
+        plan.subject_digest,
+        plan.final_receipt_digest,
+        request.effective_plan_digest,
+        plan.sandbox.model_dump(mode="json"),
+        plan.task.model_dump(mode="json"),
+        tuple(record.plan_projection() for record in setup_records),
+        entries,
+        tools,
         plan.effective_capabilities.resources.model_dump(mode="json"),
-        plan.effective_capabilities.limits.model_dump(mode="json"))
-    disposition = IsolationDisposition.TRUSTED_PROCESS if runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS else IsolationDisposition.ISOLATED
-    return SandboxExecutionPlan(request.episode_id, request.effective_plan_digest, plan.subject_digest,
-                                plan.final_receipt_digest, runtime, image, security, network,
-                                tuple(setup_records), verifier, plan.effective_capabilities.resources,
-                                plan.effective_capabilities.limits, materialization, tools, disposition)
+        plan.effective_capabilities.limits.model_dump(mode="json"),
+    )
+    disposition = (
+        IsolationDisposition.TRUSTED_PROCESS
+        if runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS
+        else IsolationDisposition.ISOLATED
+    )
+    return SandboxExecutionPlan(
+        request.episode_id,
+        request.effective_plan_digest,
+        plan.subject_digest,
+        plan.final_receipt_digest,
+        runtime,
+        image,
+        security,
+        network,
+        tuple(setup_records),
+        verifier,
+        plan.effective_capabilities.resources,
+        plan.effective_capabilities.limits,
+        materialization,
+        tools,
+        disposition,
+    )
 
 
 class RuntimeHandle(Protocol):
     runtime_id: str
-    async def run_shell(self, command: str, *, timeout_ms: int, output_limit: int) -> Mapping[str, Any]: ...
+
+    async def run_shell(
+        self, command: str, *, timeout_ms: int, output_limit: int
+    ) -> Mapping[str, Any]: ...
     async def terminate(self) -> tuple[CleanupStepReceipt, ...]: ...
 
-    async def run_argv(self, argv: Sequence[str], *, timeout_ms: int, output_limit: int) -> Mapping[str, Any]: ...
+    async def run_argv(
+        self, argv: Sequence[str], *, timeout_ms: int, output_limit: int
+    ) -> Mapping[str, Any]: ...
+
+
+def _sealed_repository_diff(
+    *,
+    repository: Path,
+    base_commit: str,
+    plan: SandboxExecutionPlan,
+) -> Mapping[str, Any]:
+    if (
+        len(base_commit) != 40
+        or base_commit != base_commit.lower()
+        or any(character not in "0123456789abcdef" for character in base_commit)
+    ):
+        raise VerifierSnapshotError(
+            "workspace base commit is invalid",
+            code="snapshot_tampered",
+        )
+    git_path = shutil.which(
+        "git",
+        path=dict(plan.runtime.fixed_environment).get("PATH", os.defpath),
+    )
+    if git_path is None:
+        raise VerifierSnapshotError(
+            "sealed workspace diff requires installed host git",
+            code="runtime_unsupported",
+        )
+    pinned = _snapshot_installed_executable(git_path, None)
+    timeout_seconds = max(1, (plan.limits.action_timeout_ms + 999) // 1000)
+    output_limit = plan.limits.artifact_bytes_each
+
+    def invoke(
+        arguments: tuple[str, ...],
+        *,
+        environment: Mapping[str, str],
+        stdout_limit: int,
+    ) -> tuple[int, bytes, bytes]:
+        with tempfile.TemporaryFile() as stdout, tempfile.TemporaryFile() as stderr:
+            try:
+                completed = subprocess.run(
+                    (pinned.proc_fd_path, *arguments),
+                    cwd=repository,
+                    env=dict(environment),
+                    stdin=subprocess.DEVNULL,
+                    stdout=stdout,
+                    stderr=stderr,
+                    timeout=timeout_seconds,
+                    check=False,
+                    pass_fds=(pinned.fd,),
+                )
+            except (OSError, subprocess.TimeoutExpired) as exc:
+                raise VerifierSnapshotError(
+                    "sealed workspace diff command failed",
+                    code="snapshot_tampered",
+                ) from exc
+            stdout_size = os.fstat(stdout.fileno()).st_size
+            stderr_size = os.fstat(stderr.fileno()).st_size
+            if stdout_size > stdout_limit or stderr_size > 64 * 1024:
+                raise VerifierSnapshotError(
+                    "sealed workspace diff exceeded its output limit",
+                    code="output_limit_exceeded",
+                )
+            stdout.seek(0)
+            stderr.seek(0)
+            return completed.returncode, stdout.read(), stderr.read()
+
+    try:
+        repository_identity = repository.stat(follow_symlinks=False)
+        if not stat.S_ISDIR(repository_identity.st_mode):
+            raise VerifierSnapshotError(
+                "sealed workspace repository is not a directory",
+                code="snapshot_tampered",
+            )
+        with tempfile.TemporaryDirectory(prefix="breadboard-sealed-diff-") as temporary:
+            environment = {
+                "GIT_CONFIG_GLOBAL": os.devnull,
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "GIT_INDEX_FILE": os.path.join(temporary, "index"),
+                "GIT_OPTIONAL_LOCKS": "0",
+                "GIT_TERMINAL_PROMPT": "0",
+                "HOME": temporary,
+                "LANG": "C",
+                "LC_ALL": "C",
+                "PATH": os.pathsep.join(
+                    (os.path.dirname(git_path), "/usr/local/bin", "/usr/bin", "/bin")
+                ),
+            }
+            common = (
+                "-c",
+                "core.attributesFile=/dev/null",
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-c",
+                "diff.external=",
+            )
+            for command in (
+                (*common, "read-tree", base_commit),
+                (*common, "add", "--intent-to-add", "--force", "--", "."),
+            ):
+                returncode, _, stderr = invoke(
+                    command,
+                    environment=environment,
+                    stdout_limit=64 * 1024,
+                )
+                if returncode != 0:
+                    raise VerifierSnapshotError(
+                        "sealed workspace diff preparation failed",
+                        code="snapshot_tampered",
+                        details={"stderr": stderr.decode("utf-8", "replace")[:4096]},
+                    )
+            returncode, stdout, stderr = invoke(
+                (
+                    *common,
+                    "diff",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    "--binary",
+                    "--full-index",
+                    "--no-renames",
+                    "--ignore-submodules=none",
+                    base_commit,
+                    "--",
+                    ".",
+                ),
+                environment=environment,
+                stdout_limit=output_limit,
+            )
+            if returncode != 0:
+                raise VerifierSnapshotError(
+                    "sealed workspace diff failed",
+                    code="snapshot_tampered",
+                    details={"stderr": stderr.decode("utf-8", "replace")[:4096]},
+                )
+            return MappingProxyType(
+                {
+                    "returncode": 0,
+                    "stdout": stdout.decode("utf-8", "strict"),
+                    "stderr": stderr.decode("utf-8", "replace"),
+                    "base_commit": base_commit,
+                    "git_executable_digest": pinned.digest,
+                }
+            )
+    except UnicodeDecodeError as exc:
+        raise VerifierSnapshotError(
+            "sealed workspace diff is not UTF-8",
+            code="snapshot_tampered",
+        ) from exc
+    finally:
+        pinned.close()
+
 
 class RuntimeBackend(Protocol):
-    async def launch(self, plan: SandboxExecutionPlan, workspace: Path, *,
-                     context: RuntimeLaunchContext) -> tuple[RuntimeHandle, SandboxMeasurement]: ...
+    async def launch(
+        self,
+        plan: SandboxExecutionPlan,
+        workspace: Path,
+        *,
+        context: RuntimeLaunchContext,
+    ) -> tuple[RuntimeHandle, SandboxMeasurement]: ...
 
 
 class TrustedProcessHandle:
@@ -1089,15 +1489,21 @@ class TrustedProcessHandle:
         self._launch_lock = asyncio.Lock()
         self._closing = False
         self._closed = False
+        self.repository_base_commit: str | None = None
+        self.repository_relative_path: str | None = None
 
     def bind_identity_recorder(self, recorder: Any) -> None:
-        if getattr(self, "_identity_recorder", None) is not None or not callable(recorder):
+        if getattr(self, "_identity_recorder", None) is not None or not callable(
+            recorder
+        ):
             raise ValueError("trusted process identity recorder is not exact")
         self._identity_recorder = recorder
 
     @staticmethod
     def _proc_fields(pid: int) -> list[str]:
-        raw = _bounded_regular_read(Path("/proc"), f"{pid}/stat", offset=0, limit=16_385)
+        raw = _bounded_regular_read(
+            Path("/proc"), f"{pid}/stat", offset=0, limit=16_385
+        )
         if len(raw) > 16_384:
             raise OSError("process identity is oversized")
         return raw.decode("ascii", "strict").rsplit(")", 1)[1].split()
@@ -1108,7 +1514,9 @@ class TrustedProcessHandle:
 
     @staticmethod
     def _cgroup_identity(pid: int) -> str:
-        raw = _bounded_regular_read(Path("/proc"), f"{pid}/cgroup", offset=0, limit=16_385)
+        raw = _bounded_regular_read(
+            Path("/proc"), f"{pid}/cgroup", offset=0, limit=16_385
+        )
         if len(raw) > 16_384:
             raise OSError("process cgroup identity is oversized")
         return "sha256:" + __import__("hashlib").sha256(raw).hexdigest()
@@ -1163,8 +1571,7 @@ class TrustedProcessHandle:
                     if (
                         len(fields) <= 3
                         or int(fields[2]) != process_group
-                        or int(fields[3])
-                        != identity.get("process_session_id")
+                        or int(fields[3]) != identity.get("process_session_id")
                         or self._cgroup_identity(pid)
                         != identity.get("process_cgroup_identity")
                     ):
@@ -1203,8 +1610,6 @@ class TrustedProcessHandle:
         except (OSError, subprocess.SubprocessError, ValueError, IndexError):
             return False
 
-
-
     async def _drain_group(
         self,
         process_group: int,
@@ -1219,7 +1624,10 @@ class TrustedProcessHandle:
         except ProcessLookupError:
             return True
         deadline = asyncio.get_running_loop().time() + 0.25
-        while self._group_exists(process_group) and asyncio.get_running_loop().time() < deadline:
+        while (
+            self._group_exists(process_group)
+            and asyncio.get_running_loop().time() < deadline
+        ):
             await asyncio.sleep(0.01)
         if self._group_exists(process_group):
             if not self._group_identity_matches(process_group, identity):
@@ -1229,7 +1637,10 @@ class TrustedProcessHandle:
             except ProcessLookupError:
                 return True
         deadline = asyncio.get_running_loop().time() + 0.75
-        while self._group_exists(process_group) and asyncio.get_running_loop().time() < deadline:
+        while (
+            self._group_exists(process_group)
+            and asyncio.get_running_loop().time() < deadline
+        ):
             await asyncio.sleep(0.01)
         return not self._group_exists(process_group)
 
@@ -1334,10 +1745,7 @@ class TrustedProcessHandle:
                     )
                 read_fd, write_fd = os.pipe()
                 os.set_inheritable(write_fd, True)
-                bootstrap = (
-                    f"printf B >&{write_fd}; "
-                    'kill -STOP $$; exec "$@"'
-                )
+                bootstrap = f'printf B >&{write_fd}; kill -STOP $$; exec "$@"'
                 process = await asyncio.create_subprocess_exec(
                     self._executable.proc_fd_path,
                     "-c",
@@ -1464,6 +1872,50 @@ class TrustedProcessHandle:
             "stderr": stderr.decode("utf-8", "replace"),
         }
 
+    async def measure_repository_base_commit(self) -> str | None:
+        repositories = tuple(
+            entry
+            for entry in self.plan.materialization_plan.entries
+            if entry.role == "repository"
+        )
+        if not repositories:
+            return None
+        if len(repositories) != 1:
+            raise SandboxLaunchError(
+                "workspace base measurement requires exactly one repository mount",
+                code="runtime_preflight_failed",
+                lease_id=self.lease_id,
+            )
+        relative_path = repositories[0].target_logical_path
+        result = await self._run_pinned_argv(
+            (
+                self._executable.proc_fd_path,
+                "-lc",
+                'exec "$2" -C "$1" rev-parse --verify "HEAD^{commit}"',
+                "breadboard-workspace-base",
+                relative_path,
+                self._git_executable,
+            ),
+            timeout_ms=self.plan.limits.action_timeout_ms,
+            output_limit=256,
+        )
+        commit = result.get("stdout", "").strip()
+        if result.get("returncode") != 0:
+            return None
+        if (
+            len(commit) != 40
+            or commit != commit.lower()
+            or any(character not in "0123456789abcdef" for character in commit)
+        ):
+            raise SandboxLaunchError(
+                "workspace base commit measurement failed",
+                code="runtime_preflight_failed",
+                lease_id=self.lease_id,
+            )
+        self.repository_base_commit = commit
+        self.repository_relative_path = relative_path
+        return commit
+
     async def workspace_diff(self) -> Mapping[str, Any]:
         repositories = tuple(
             entry
@@ -1525,12 +1977,19 @@ class TrustedProcessHandle:
 
 
 class TrustedProcessBackend:
-    async def launch(self, plan: SandboxExecutionPlan, workspace: Path, *,
-                     context: RuntimeLaunchContext) -> tuple[RuntimeHandle, SandboxMeasurement]:
+    async def launch(
+        self,
+        plan: SandboxExecutionPlan,
+        workspace: Path,
+        *,
+        context: RuntimeLaunchContext,
+    ) -> tuple[RuntimeHandle, SandboxMeasurement]:
         lease_id = context.lease_id
         workspace_id = context.workspace_id
         if plan.runtime.runtime_class is not RuntimeClass.TRUSTED_PROCESS:
-            raise SandboxLaunchError("trusted process backend class mismatch", code="runtime_unsupported")
+            raise SandboxLaunchError(
+                "trusted process backend class mismatch", code="runtime_unsupported"
+            )
         if context.workspace_fd is None or context.workspace_identity is None:
             raise SandboxLaunchError(
                 "pinned workspace descriptor required",
@@ -1555,9 +2014,15 @@ class TrustedProcessBackend:
                 plan.runtime.measured_binary_digest,
             )
             handle = TrustedProcessHandle(
-                plan, workspace, lease_id, executable, git_executable,
-                context.workspace_fd, context.workspace_identity,
+                plan,
+                workspace,
+                lease_id,
+                executable,
+                git_executable,
+                context.workspace_fd,
+                context.workspace_identity,
             )
+            repository_base_commit = await handle.measure_repository_base_commit()
             requested = {
                 "runtime": plan.runtime.runtime_id,
                 "image": plan.image.image_digest,
@@ -1572,6 +2037,8 @@ class TrustedProcessBackend:
                 "execution": "linux-sealed-memfd",
             }
             effective["workspace_diff_git_path"] = git_executable
+            if repository_base_commit is not None:
+                effective["workspace_base_commit"] = repository_base_commit
             measured = dict(effective)
             measurement = SandboxMeasurement(
                 plan.effective_plan_digest,
@@ -1646,15 +2113,24 @@ class TrustedProcessBackend:
 
 
 class LeaseBackedRunnerWorkspace:
-    def __init__(self, lease: SandboxWorkspaceLease, effective_plan_digest: str,
-                 tool_bindings: tuple[RunnerToolBinding, ...]) -> None:
-        if lease.plan.effective_plan_digest != effective_plan_digest or lease.plan.tool_bindings != tool_bindings:
-            raise SandboxPlanError("runner workspace identity mismatch", code="tool_binding_projection_mismatch")
-        bindings = tuple(tool_bindings)
+    def __init__(
+        self,
+        lease: SandboxWorkspaceLease,
+        effective_plan_digest: str,
+        tool_bindings: tuple[RunnerToolBinding, ...],
+    ) -> None:
         if (
-            any(type(binding) is not RunnerToolBinding for binding in bindings)
-            or len({binding.tool_id for binding in bindings}) != len(bindings)
+            lease.plan.effective_plan_digest != effective_plan_digest
+            or lease.plan.tool_bindings != tool_bindings
         ):
+            raise SandboxPlanError(
+                "runner workspace identity mismatch",
+                code="tool_binding_projection_mismatch",
+            )
+        bindings = tuple(tool_bindings)
+        if any(type(binding) is not RunnerToolBinding for binding in bindings) or len(
+            {binding.tool_id for binding in bindings}
+        ) != len(bindings):
             raise SandboxPlanError(
                 "runner tool bindings are not exact and unique",
                 code="tool_binding_projection_mismatch",
@@ -1663,7 +2139,9 @@ class LeaseBackedRunnerWorkspace:
         self.__tool_bindings = bindings
 
     @property
-    def tool_bindings(self) -> tuple[RunnerToolBinding, ...]: return self.__tool_bindings
+    def tool_bindings(self) -> tuple[RunnerToolBinding, ...]:
+        return self.__tool_bindings
+
     async def invoke_tool(
         self,
         tool_id: str,
@@ -1695,7 +2173,8 @@ class LeaseBackedRunnerWorkspace:
         await lease._begin_operation()
         try:
             bindings = tuple(
-                binding for binding in self.__tool_bindings
+                binding
+                for binding in self.__tool_bindings
                 if binding.tool_id == tool_id
             )
             if tool_id != "terminal" or len(bindings) != 1:
@@ -1735,22 +2214,34 @@ class LeaseBackedRunnerWorkspace:
         finally:
             await lease._end_operation()
 
-
     async def run_shell(self, command: str, *, timeout: int) -> Mapping[str, Any]:
         lease = self.__lease
         await lease._begin_operation()
         try:
             if type(timeout) is not int or timeout <= 0:
-                raise WorkspaceStateError("timeout exceeds admitted ceiling", code="runtime_preflight_failed", lease_id=lease.lease_id)
+                raise WorkspaceStateError(
+                    "timeout exceeds admitted ceiling",
+                    code="runtime_preflight_failed",
+                    lease_id=lease.lease_id,
+                )
             timeout_ms = timeout * 1000
             if timeout_ms > lease.plan.limits.action_timeout_ms:
-                raise WorkspaceStateError("timeout exceeds admitted ceiling", code="runtime_preflight_failed", lease_id=lease.lease_id)
-            return await lease._runtime.run_shell(command, timeout_ms=timeout_ms,
-                                                  output_limit=lease.plan.limits.observation_bytes)
+                raise WorkspaceStateError(
+                    "timeout exceeds admitted ceiling",
+                    code="runtime_preflight_failed",
+                    lease_id=lease.lease_id,
+                )
+            return await lease._runtime.run_shell(
+                command,
+                timeout_ms=timeout_ms,
+                output_limit=lease.plan.limits.observation_bytes,
+            )
         finally:
             await lease._end_operation()
 
-    async def read_text(self, path: str, *, offset: int = 0, limit: int | None = None) -> Mapping[str, Any]:
+    async def read_text(
+        self, path: str, *, offset: int = 0, limit: int | None = None
+    ) -> Mapping[str, Any]:
         lease = self.__lease
         await lease._begin_operation()
         remote_read = getattr(lease._runtime, "read_text", None)
@@ -1764,7 +2255,11 @@ class LeaseBackedRunnerWorkspace:
                 lease._resolve(path)
                 ceiling = lease.plan.limits.observation_bytes
                 if offset < 0 or limit is not None and (limit < 0 or limit > ceiling):
-                    raise WorkspaceStateError("read limit invalid", code="output_limit_exceeded", lease_id=lease.lease_id)
+                    raise WorkspaceStateError(
+                        "read limit invalid",
+                        code="output_limit_exceeded",
+                        lease_id=lease.lease_id,
+                    )
                 read_limit = limit if limit is not None else ceiling + 1
                 try:
                     selected = await asyncio.to_thread(
@@ -1777,10 +2272,23 @@ class LeaseBackedRunnerWorkspace:
                 except FileNotFoundError:
                     raise
                 except OSError as exc:
-                    raise WorkspaceStateError("workspace link authority denied", code="workspace_escape", lease_id=lease.lease_id) from exc
+                    raise WorkspaceStateError(
+                        "workspace link authority denied",
+                        code="workspace_escape",
+                        lease_id=lease.lease_id,
+                    ) from exc
                 if len(selected) > ceiling:
-                    raise WorkspaceStateError("read exceeds admitted ceiling", code="output_limit_exceeded", lease_id=lease.lease_id)
-                return {"path": path, "content": selected.decode("utf-8"), "offset": offset, "bytes": len(selected)}
+                    raise WorkspaceStateError(
+                        "read exceeds admitted ceiling",
+                        code="output_limit_exceeded",
+                        lease_id=lease.lease_id,
+                    )
+                return {
+                    "path": path,
+                    "content": selected.decode("utf-8"),
+                    "offset": offset,
+                    "bytes": len(selected),
+                }
         finally:
             await lease._end_operation()
 
@@ -1798,13 +2306,24 @@ class LeaseBackedRunnerWorkspace:
             async with lease._io_lock:
                 lease._resolve(path, writable=True)
                 if len(payload) > lease.plan.limits.artifact_bytes_each:
-                    raise WorkspaceStateError("write exceeds admitted ceiling", code="output_limit_exceeded", lease_id=lease.lease_id)
+                    raise WorkspaceStateError(
+                        "write exceeds admitted ceiling",
+                        code="output_limit_exceeded",
+                        lease_id=lease.lease_id,
+                    )
                 try:
                     await asyncio.to_thread(
-                        _atomic_regular_write, lease._materialized.workspace_path, path, payload
+                        _atomic_regular_write,
+                        lease._materialized.workspace_path,
+                        path,
+                        payload,
                     )
                 except OSError as exc:
-                    raise WorkspaceStateError("workspace link authority denied", code="workspace_escape", lease_id=lease.lease_id) from exc
+                    raise WorkspaceStateError(
+                        "workspace link authority denied",
+                        code="workspace_escape",
+                        lease_id=lease.lease_id,
+                    ) from exc
                 return {"path": path, "bytes": len(payload)}
         finally:
             await lease._end_operation()
@@ -1821,7 +2340,11 @@ class LeaseBackedRunnerWorkspace:
         try:
             async with lease._io_lock:
                 if depth < 0 or depth > lease.plan.security_policy.snapshot_max_depth:
-                    raise WorkspaceStateError("list depth invalid", code="output_limit_exceeded", lease_id=lease.lease_id)
+                    raise WorkspaceStateError(
+                        "list depth invalid",
+                        code="output_limit_exceeded",
+                        lease_id=lease.lease_id,
+                    )
                 try:
                     values = await asyncio.to_thread(
                         _descriptor_list,
@@ -1849,12 +2372,26 @@ class LeaseBackedRunnerWorkspace:
 
 
 class SandboxWorkspaceLease:
-    def __init__(self, *, manager: SandboxRuntimeManager, lease_id: str, plan: SandboxExecutionPlan,
-                 materialized: MaterializedWorkspace, runtime: RuntimeHandle,
-                 measurement: SandboxMeasurement, owner_token: str, epoch: int) -> None:
-        self.lease_id = lease_id; self.plan = plan; self.measurement = measurement
-        self._manager = manager; self._materialized = materialized; self._runtime = runtime
-        self._owner_token = owner_token; self._epoch = epoch
+    def __init__(
+        self,
+        *,
+        manager: SandboxRuntimeManager,
+        lease_id: str,
+        plan: SandboxExecutionPlan,
+        materialized: MaterializedWorkspace,
+        runtime: RuntimeHandle,
+        measurement: SandboxMeasurement,
+        owner_token: str,
+        epoch: int,
+    ) -> None:
+        self.lease_id = lease_id
+        self.plan = plan
+        self.measurement = measurement
+        self._manager = manager
+        self._materialized = materialized
+        self._runtime = runtime
+        self._owner_token = owner_token
+        self._epoch = epoch
         self._state = WorkspaceLeaseState.ACTIVE
         self._lock = asyncio.Lock()
         self._operations_drained = asyncio.Condition(self._lock)
@@ -1865,8 +2402,12 @@ class SandboxWorkspaceLease:
         self._latest_cleanup = None
         self._close_task_lock = asyncio.Lock()
         self._close_task: asyncio.Task[SandboxCleanupReceipt] | None = None
-        self.runner_workspace = LeaseBackedRunnerWorkspace(self, plan.effective_plan_digest, plan.tool_bindings)
+        self.runner_workspace = LeaseBackedRunnerWorkspace(
+            self, plan.effective_plan_digest, plan.tool_bindings
+        )
         self._verifier_children: list[VerifierWorkspaceLease] = []
+        self._sealed_workspace_diff: Mapping[str, Any] | None = None
+
     @property
     def identity(self) -> SandboxMeasurement:
         return self.measurement
@@ -1878,6 +2419,7 @@ class SandboxWorkspaceLease:
     @property
     def cleanup_receipt(self) -> SandboxCleanupReceipt | None:
         return self._latest_cleanup
+
     async def execute(
         self, argv: Sequence[str], *, timeout_ms: int | None = None
     ) -> Mapping[str, Any]:
@@ -1890,13 +2432,24 @@ class SandboxWorkspaceLease:
                 code="runtime_preflight_failed",
                 lease_id=self.lease_id,
             )
-        effective_timeout = self.plan.limits.action_timeout_ms if timeout_ms is None else timeout_ms
-        if type(effective_timeout) is not int or effective_timeout <= 0 or effective_timeout > self.plan.limits.action_timeout_ms:
-            raise WorkspaceStateError("timeout exceeds admitted ceiling", code="runtime_preflight_failed", lease_id=self.lease_id)
+        effective_timeout = (
+            self.plan.limits.action_timeout_ms if timeout_ms is None else timeout_ms
+        )
+        if (
+            type(effective_timeout) is not int
+            or effective_timeout <= 0
+            or effective_timeout > self.plan.limits.action_timeout_ms
+        ):
+            raise WorkspaceStateError(
+                "timeout exceeds admitted ceiling",
+                code="runtime_preflight_failed",
+                lease_id=self.lease_id,
+            )
         await self._begin_operation()
         try:
             return await self._runtime.run_argv(
-                tuple(argv), timeout_ms=effective_timeout,
+                tuple(argv),
+                timeout_ms=effective_timeout,
                 output_limit=self.plan.limits.observation_bytes,
             )
         finally:
@@ -1927,6 +2480,9 @@ class SandboxWorkspaceLease:
             )
         finally:
             await self._end_operation()
+
+    def sealed_workspace_diff(self) -> Mapping[str, Any] | None:
+        return self._sealed_workspace_diff
 
     async def cancel(self) -> SandboxCleanupReceipt:
         return await self._close_shared(preempt=True)
@@ -1987,13 +2543,18 @@ class SandboxWorkspaceLease:
         return await self.close()
 
     @property
-    def state(self) -> WorkspaceLeaseState: return self._state
+    def state(self) -> WorkspaceLeaseState:
+        return self._state
 
     def _assert_active(self) -> None:
         if self._state is not WorkspaceLeaseState.ACTIVE:
-            raise WorkspaceStateError("workspace lease is not active", code="lease_not_active",
-                                      episode_id=self.plan.episode_id,
-                                      effective_plan_digest=self.plan.effective_plan_digest, lease_id=self.lease_id)
+            raise WorkspaceStateError(
+                "workspace lease is not active",
+                code="lease_not_active",
+                episode_id=self.plan.episode_id,
+                effective_plan_digest=self.plan.effective_plan_digest,
+                lease_id=self.lease_id,
+            )
 
     async def _begin_operation(self) -> None:
         task = asyncio.current_task()
@@ -2030,8 +2591,17 @@ class SandboxWorkspaceLease:
 
     def _resolve(self, logical_path: str, *, writable: bool = False) -> Path:
         relative = Path(logical_path)
-        if not logical_path or relative.is_absolute() or ".." in relative.parts or "\x00" in logical_path:
-            raise WorkspaceStateError("workspace path escapes", code="workspace_escape", lease_id=self.lease_id)
+        if (
+            not logical_path
+            or relative.is_absolute()
+            or ".." in relative.parts
+            or "\x00" in logical_path
+        ):
+            raise WorkspaceStateError(
+                "workspace path escapes",
+                code="workspace_escape",
+                lease_id=self.lease_id,
+            )
         cursor = self._materialized.workspace_path
         for part in relative.parts:
             cursor = cursor / part
@@ -2039,16 +2609,38 @@ class SandboxWorkspaceLease:
                 metadata = cursor.lstat()
             except FileNotFoundError:
                 continue
-            if __import__("stat").S_ISLNK(metadata.st_mode) or (__import__("stat").S_ISREG(metadata.st_mode) and metadata.st_nlink != 1):
-                raise WorkspaceStateError("workspace link authority denied", code="workspace_escape", lease_id=self.lease_id)
+            if __import__("stat").S_ISLNK(metadata.st_mode) or (
+                __import__("stat").S_ISREG(metadata.st_mode) and metadata.st_nlink != 1
+            ):
+                raise WorkspaceStateError(
+                    "workspace link authority denied",
+                    code="workspace_escape",
+                    lease_id=self.lease_id,
+                )
         target = (self._materialized.workspace_path / relative).resolve(strict=False)
-        if self._materialized.workspace_path != target and self._materialized.workspace_path not in target.parents:
-            raise WorkspaceStateError("workspace path escapes", code="workspace_escape", lease_id=self.lease_id)
+        if (
+            self._materialized.workspace_path != target
+            and self._materialized.workspace_path not in target.parents
+        ):
+            raise WorkspaceStateError(
+                "workspace path escapes",
+                code="workspace_escape",
+                lease_id=self.lease_id,
+            )
         if writable:
-            writable_roots = [(self._materialized.workspace_path / item.target_logical_path).resolve()
-                              for item in self.plan.materialization_plan.entries if item.access.value == "rw"]
-            if not any(root == target or root in target.parents for root in writable_roots):
-                raise WorkspaceStateError("path is outside writable authority", code="workspace_escape", lease_id=self.lease_id)
+            writable_roots = [
+                (self._materialized.workspace_path / item.target_logical_path).resolve()
+                for item in self.plan.materialization_plan.entries
+                if item.access.value == "rw"
+            ]
+            if not any(
+                root == target or root in target.parents for root in writable_roots
+            ):
+                raise WorkspaceStateError(
+                    "path is outside writable authority",
+                    code="workspace_escape",
+                    lease_id=self.lease_id,
+                )
         return target
 
     async def seal_for_verifier(self) -> VerifierSnapshotReceipt:
@@ -2056,9 +2648,38 @@ class SandboxWorkspaceLease:
             self._assert_active()
             await self._fence_and_drain(WorkspaceLeaseState.QUIESCING)
             runtime_steps = await self._runtime.terminate()
-            if any(step.state not in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED} for step in runtime_steps):
+            if any(
+                step.state not in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
+                for step in runtime_steps
+            ):
                 self._state = WorkspaceLeaseState.QUARANTINED
-                raise VerifierSnapshotError("runtime did not quiesce", code="snapshot_not_quiescent", lease_id=self.lease_id)
+                raise VerifierSnapshotError(
+                    "runtime did not quiesce",
+                    code="snapshot_not_quiescent",
+                    lease_id=self.lease_id,
+                )
+            base_commit = getattr(self._runtime, "repository_base_commit", None)
+            relative_path = getattr(self._runtime, "repository_relative_path", None)
+            if (base_commit is None) != (relative_path is None):
+                self._state = WorkspaceLeaseState.QUARANTINED
+                raise VerifierSnapshotError(
+                    "workspace base authority is incomplete",
+                    code="snapshot_tampered",
+                    lease_id=self.lease_id,
+                )
+            sealed_diff: Mapping[str, Any] | None = None
+            if base_commit is not None:
+                repository = (
+                    self._materialized.workspace_path
+                    if relative_path == "."
+                    else self._resolve(relative_path)
+                )
+                sealed_diff = await asyncio.to_thread(
+                    _sealed_repository_diff,
+                    repository=repository,
+                    base_commit=base_commit,
+                    plan=self.plan,
+                )
             try:
                 seal_task = asyncio.create_task(
                     asyncio.to_thread(
@@ -2095,21 +2716,49 @@ class SandboxWorkspaceLease:
                         self._state = WorkspaceLeaseState.QUARANTINED
                     raise
                 self._manager._snapshots[receipt.snapshot_id] = (receipt, path)
+                if sealed_diff is not None:
+                    patch_bytes = sealed_diff["stdout"].encode("utf-8")
+                    self._sealed_workspace_diff = MappingProxyType(
+                        {
+                            **sealed_diff,
+                            "patch_digest": (
+                                "sha256:" + hashlib.sha256(patch_bytes).hexdigest()
+                            ),
+                            "snapshot_root_digest": receipt.root_digest,
+                        }
+                    )
                 return receipt
             except Exception as exc:
                 self._state = WorkspaceLeaseState.QUARANTINED
-                raise VerifierSnapshotError("verifier snapshot failed", code=str(exc), lease_id=self.lease_id) from exc
+                raise VerifierSnapshotError(
+                    "verifier snapshot failed", code=str(exc), lease_id=self.lease_id
+                ) from exc
 
     async def close(self) -> SandboxCleanupReceipt:
         return await self._close_shared()
 
+
 class VerifierWorkspaceLease:
-    def __init__(self, *, manager: SandboxRuntimeManager, primary: SandboxWorkspaceLease,
-                 lease_id: str, plan: SandboxExecutionPlan, snapshot: VerifierSnapshotReceipt,
-                 workspace: Path, runtime: RuntimeHandle, measurement: SandboxMeasurement) -> None:
-        self._manager = manager; self._primary = primary; self.lease_id = lease_id
-        self.plan = plan; self.snapshot = snapshot; self.workspace = workspace
-        self._runtime = runtime; self.measurement = measurement
+    def __init__(
+        self,
+        *,
+        manager: SandboxRuntimeManager,
+        primary: SandboxWorkspaceLease,
+        lease_id: str,
+        plan: SandboxExecutionPlan,
+        snapshot: VerifierSnapshotReceipt,
+        workspace: Path,
+        runtime: RuntimeHandle,
+        measurement: SandboxMeasurement,
+    ) -> None:
+        self._manager = manager
+        self._primary = primary
+        self.lease_id = lease_id
+        self.plan = plan
+        self.snapshot = snapshot
+        self.workspace = workspace
+        self._runtime = runtime
+        self.measurement = measurement
         self._closed = False
         self._closing = False
         self._fenced = False
@@ -2120,6 +2769,7 @@ class VerifierWorkspaceLease:
         self._cleanup: SandboxCleanupReceipt | None = None
 
         self._close_task: asyncio.Task[SandboxCleanupReceipt] | None = None
+
     async def execute(self) -> Mapping[str, Any]:
         task = asyncio.current_task()
         if task is None:
@@ -2254,28 +2904,54 @@ class VerifierWorkspaceLease:
             )
             if runtime_released:
                 try:
-                    for root, dirs, files in os.walk(self.workspace, topdown=True, followlinks=False):
+                    for root, dirs, files in os.walk(
+                        self.workspace, topdown=True, followlinks=False
+                    ):
                         root_path = Path(root)
                         os.chmod(root_path, 0o700, follow_symlinks=False)
                         for name in dirs + files:
                             candidate = root_path / name
                             if candidate.is_symlink():
                                 continue
-                            os.chmod(candidate, 0o700 if candidate.is_dir() else 0o600,
-                                     follow_symlinks=False)
-                    await asyncio.to_thread(self._manager.materialization_store.storage_backend.release, self.workspace)
-                    absent = self._manager.materialization_store.storage_backend.verify_absent(self.workspace)
-                    steps.append(CleanupStepReceipt("workspace", CleanupState.RELEASED if absent else CleanupState.FAILED))
+                            os.chmod(
+                                candidate,
+                                0o700 if candidate.is_dir() else 0o600,
+                                follow_symlinks=False,
+                            )
+                    await asyncio.to_thread(
+                        self._manager.materialization_store.storage_backend.release,
+                        self.workspace,
+                    )
+                    absent = self._manager.materialization_store.storage_backend.verify_absent(
+                        self.workspace
+                    )
+                    steps.append(
+                        CleanupStepReceipt(
+                            "workspace",
+                            CleanupState.RELEASED if absent else CleanupState.FAILED,
+                        )
+                    )
                 except FileNotFoundError:
-                    steps.append(CleanupStepReceipt("workspace", CleanupState.ALREADY_RELEASED))
+                    steps.append(
+                        CleanupStepReceipt("workspace", CleanupState.ALREADY_RELEASED)
+                    )
                 except Exception as exc:
-                    steps.append(CleanupStepReceipt("workspace", CleanupState.FAILED, type(exc).__name__))
+                    steps.append(
+                        CleanupStepReceipt(
+                            "workspace", CleanupState.FAILED, type(exc).__name__
+                        )
+                    )
             else:
-                steps.append(CleanupStepReceipt(
-                    "workspace", CleanupState.QUARANTINED, "dependent runtime cleanup incomplete"
-                ))
+                steps.append(
+                    CleanupStepReceipt(
+                        "workspace",
+                        CleanupState.QUARANTINED,
+                        "dependent runtime cleanup incomplete",
+                    )
+                )
             dependencies_released = all(
-                step.state in {
+                step.state
+                in {
                     CleanupState.RELEASED,
                     CleanupState.ALREADY_RELEASED,
                 }
@@ -2301,18 +2977,30 @@ class VerifierWorkspaceLease:
                 if prior_ok:
                     self._manager._unlink_lease_record(self.lease_id)
                     absent = not self._manager._lease_record_exists(self.lease_id)
-                    steps.append(CleanupStepReceipt(
-                        "lease_record", CleanupState.RELEASED if absent else CleanupState.FAILED
-                    ))
+                    steps.append(
+                        CleanupStepReceipt(
+                            "lease_record",
+                            CleanupState.RELEASED if absent else CleanupState.FAILED,
+                        )
+                    )
                 else:
-                    steps.append(CleanupStepReceipt(
-                        "lease_record", CleanupState.QUARANTINED, "dependent cleanup incomplete"
-                    ))
+                    steps.append(
+                        CleanupStepReceipt(
+                            "lease_record",
+                            CleanupState.QUARANTINED,
+                            "dependent cleanup incomplete",
+                        )
+                    )
             except Exception as exc:
-                steps.append(CleanupStepReceipt("lease_record", CleanupState.FAILED, type(exc).__name__))
+                steps.append(
+                    CleanupStepReceipt(
+                        "lease_record", CleanupState.FAILED, type(exc).__name__
+                    )
+                )
             receipt = SandboxCleanupReceipt.from_steps(self.lease_id, tuple(steps))
             if receipt.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}:
-                self._closed = True; self._cleanup = receipt
+                self._closed = True
+                self._cleanup = receipt
             return receipt
 
 
@@ -2325,40 +3013,51 @@ class _PendingLaunchCleanup:
 
 
 class SandboxRuntimeManager:
-    def __init__(self, *, registries: RegistrySnapshotSet,
-                 installed_authorities: InstalledSandboxAuthoritySet,
-                 materialization_store: FilesystemMaterializationStore,
-                 lease_root: str | Path, process_backend: RuntimeBackend,
-                 docker_backend: RuntimeBackend | None, random_bytes: Any,
-                 lease_root_fd: int | None = None) -> None:
-        self.registries = registries; self.installed_authorities = installed_authorities
+    def __init__(
+        self,
+        *,
+        registries: RegistrySnapshotSet,
+        installed_authorities: InstalledSandboxAuthoritySet,
+        materialization_store: FilesystemMaterializationStore,
+        lease_root: str | Path,
+        process_backend: RuntimeBackend,
+        docker_backend: RuntimeBackend | None,
+        random_bytes: Any,
+        lease_root_fd: int | None = None,
+    ) -> None:
+        self.registries = registries
+        self.installed_authorities = installed_authorities
         self.materialization_store = materialization_store
         supplied_lease_root = Path(lease_root).resolve(strict=True)
         self._lease_root_fd = (
             os.dup(lease_root_fd)
             if lease_root_fd is not None
-            else os.open(supplied_lease_root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+            else os.open(
+                supplied_lease_root, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+            )
         )
         try:
             opened_root = os.fstat(self._lease_root_fd)
             supplied_root = os.stat(supplied_lease_root, follow_symlinks=False)
-            if (
-                not stat.S_ISDIR(opened_root.st_mode)
-                or (opened_root.st_dev, opened_root.st_ino)
-                != (supplied_root.st_dev, supplied_root.st_ino)
-            ):
+            if not stat.S_ISDIR(opened_root.st_mode) or (
+                opened_root.st_dev,
+                opened_root.st_ino,
+            ) != (supplied_root.st_dev, supplied_root.st_ino):
                 raise ValueError("lease root descriptor identity mismatch")
         except BaseException:
             os.close(self._lease_root_fd)
             self._lease_root_fd = None
             raise
         self.lease_root = supplied_lease_root
-        self.process_backend = process_backend; self.docker_backend = docker_backend
-        self._random_bytes = random_bytes; self._leases: dict[str, SandboxWorkspaceLease] = {}
+        self.process_backend = process_backend
+        self.docker_backend = docker_backend
+        self._random_bytes = random_bytes
+        self._leases: dict[str, SandboxWorkspaceLease] = {}
         self._snapshots: dict[str, tuple[VerifierSnapshotReceipt, Path]] = {}
         self._pending_launch_cleanups: dict[str, _PendingLaunchCleanup] = {}
         self._lease_owner_locks: dict[str, int] = {}
-        self._lock = asyncio.Lock(); self._closed = False
+        self._lock = asyncio.Lock()
+        self._closed = False
         self._reconcile_lock = asyncio.Lock()
         self._close_task: asyncio.Future[list[SandboxCleanupReceipt]] | None = None
         self._last_close_receipts: tuple[SandboxCleanupReceipt, ...] | None = None
@@ -2379,12 +3078,15 @@ class SandboxRuntimeManager:
 
     def _nonce(self) -> str:
         value = self._random_bytes(16)
-        if type(value) is not bytes or len(value) < 16: raise ValueError("random source returned insufficient bytes")
+        if type(value) is not bytes or len(value) < 16:
+            raise ValueError("random source returned insufficient bytes")
         return value.hex()
 
     @staticmethod
     def _make_workspace_releasable(workspace: Path) -> None:
-        for root, dirs, filenames in os.walk(workspace, topdown=True, followlinks=False):
+        for root, dirs, filenames in os.walk(
+            workspace, topdown=True, followlinks=False
+        ):
             root_path = Path(root)
             os.chmod(root_path, 0o700, follow_symlinks=False)
             for name in dirs + filenames:
@@ -2441,10 +3143,12 @@ class SandboxRuntimeManager:
                 authority
                 if type(authority) is str and authority
                 else f"{type(self.materialization_store.storage_backend).__module__}."
-                     f"{type(self.materialization_store.storage_backend).__qualname__}"
+                f"{type(self.materialization_store.storage_backend).__qualname__}"
             ),
             quota_enforced=quota_enforced is True,
-            quota_bytes=measured_quota if type(measured_quota) is int and measured_quota > 0 else quota_bytes,
+            quota_bytes=measured_quota
+            if type(measured_quota) is int and measured_quota > 0
+            else quota_bytes,
             owner_uid=owner_uid,
             owner_gid=owner_gid,
         )
@@ -2456,8 +3160,9 @@ class SandboxRuntimeManager:
             storage=storage,
             snapshot_relative_path=None if role == "primary" else "snapshot",
             result_relative_path=None if role == "primary" else "result",
-            publish_prepared_identity=lambda identity, lease_id=lease_id:
-                self._publish_runtime_identity(lease_id, identity),
+            publish_prepared_identity=lambda identity, lease_id=lease_id: (
+                self._publish_runtime_identity(lease_id, identity)
+            ),
             workspace_fd=workspace_fd,
             workspace_identity=workspace_identity,
             owner_token=owner_token,
@@ -2520,9 +3225,9 @@ class SandboxRuntimeManager:
         finally:
             os.close(descriptor)
 
-
     def _lease_record_path(self, lease_id: str) -> Path:
         return self.lease_root / (lease_id + ".json")
+
     def _lease_record_exists(self, lease_id: str) -> bool:
         if self._lease_root_fd is None:
             return False
@@ -2546,7 +3251,6 @@ class SandboxRuntimeManager:
         self._release_lease_owner_lock(lease_id, unlink=True)
         os.fsync(self._lease_root_fd)
 
-
     def _write_lease_record(self, lease_id: str, payload: Mapping[str, Any]) -> None:
         if payload.get("lease_id") != lease_id:
             raise WorkspaceStateError(
@@ -2554,7 +3258,9 @@ class SandboxRuntimeManager:
                 code="stale_identity_uncertain",
                 lease_id=lease_id,
             )
-        record = canonical_json_bytes({"payload": dict(payload), "checksum": _wp7_digest(dict(payload))})
+        record = canonical_json_bytes(
+            {"payload": dict(payload), "checksum": _wp7_digest(dict(payload))}
+        )
         path = self._lease_record_path(lease_id)
         temporary = path.name + ".tmp-" + self._nonce()
         if self._lease_root_fd is None:
@@ -2612,7 +3318,9 @@ class SandboxRuntimeManager:
                 raise ValueError
             return MappingProxyType(payload)
         except Exception as exc:
-            raise WorkspaceStateError("workspace lease record is corrupt", code="stale_identity_uncertain") from exc
+            raise WorkspaceStateError(
+                "workspace lease record is corrupt", code="stale_identity_uncertain"
+            ) from exc
 
     async def _publish_runtime_identity(
         self, lease_id: str, identity: RuntimePreparedIdentity
@@ -2640,7 +3348,6 @@ class SandboxRuntimeManager:
         record["runtime_labels"] = dict(identity.labels)
         self._write_lease_record(lease_id, record)
 
-
     def _record_process_identity(
         self, lease_id: str, resource_id: str, identity: Mapping[str, Any] | None
     ) -> None:
@@ -2653,7 +3360,9 @@ class SandboxRuntimeManager:
             or not resource_id
         ):
             raise WorkspaceStateError(
-                "process lease identity changed", code="stale_identity_uncertain", lease_id=lease_id
+                "process lease identity changed",
+                code="stale_identity_uncertain",
+                lease_id=lease_id,
             )
         identities = {
             item["resource_id"]: dict(item)
@@ -2672,21 +3381,27 @@ class SandboxRuntimeManager:
                 or resource_id != f"process-group-{identity.get('process_group_id')}"
             ):
                 raise WorkspaceStateError(
-                    "process identity is incomplete", code="stale_identity_uncertain", lease_id=lease_id
+                    "process identity is incomplete",
+                    code="stale_identity_uncertain",
+                    lease_id=lease_id,
                 )
             if resource_id in identities and identities[resource_id] != {
-                "resource_id": resource_id, **identity
+                "resource_id": resource_id,
+                **identity,
             }:
                 raise WorkspaceStateError(
-                    "process identity changed", code="stale_identity_uncertain", lease_id=lease_id
+                    "process identity changed",
+                    code="stale_identity_uncertain",
+                    lease_id=lease_id,
                 )
             identities[resource_id] = {"resource_id": resource_id, **identity}
-        record["process_identities"] = [
-            identities[key] for key in sorted(identities)
-        ]
+        record["process_identities"] = [identities[key] for key in sorted(identities)]
         for key in (
-            "process_pid", "process_group_id", "process_session_id",
-            "process_start_identity", "process_cgroup_identity",
+            "process_pid",
+            "process_group_id",
+            "process_session_id",
+            "process_start_identity",
+            "process_cgroup_identity",
         ):
             record.pop(key, None)
         self._write_lease_record(lease_id, record)
@@ -2754,13 +3469,18 @@ class SandboxRuntimeManager:
             ",".join(released),
         )
 
-
     async def open(self, request: WorkspaceOpenRequest) -> SandboxWorkspaceLease:
-        plan = build_sandbox_execution_plan(request, self.registries, self.installed_authorities)
+        plan = build_sandbox_execution_plan(
+            request, self.registries, self.installed_authorities
+        )
         async with self._lock:
-            if self._closed: raise WorkspaceStateError("lease manager closed", code="lease_manager_closed")
+            if self._closed:
+                raise WorkspaceStateError(
+                    "lease manager closed", code="lease_manager_closed"
+                )
             lease_id = "lease-" + self._nonce()
-            owner_token = self._nonce(); epoch = 1
+            owner_token = self._nonce()
+            epoch = 1
             materialized: MaterializedWorkspace | None = None
             runtime: RuntimeHandle | None = None
             backend: RuntimeBackend | None = None
@@ -2795,19 +3515,40 @@ class SandboxRuntimeManager:
                     "cache_key_digest": materialized.cache_token.cache_key.digest,
                     "cache_manifest_digest": materialized.cache_receipt.immutable_object_manifest_digest,
                     "cache_source_digests": [
-                        entry.source_digest for entry in plan.materialization_plan.entries
+                        entry.source_digest
+                        for entry in plan.materialization_plan.entries
                     ],
                 }
-                self._write_lease_record(lease_id, {"schema_version": "bb.rl.workspace-lease.v1",
-                    "lease_id": lease_id, "workspace_id": materialized.receipt.workspace_id,
-                    "workspace_path": str(materialized.workspace_path), "cache_lease_id": materialized.receipt.cache_lease_id,
-                    "effective_plan_digest": plan.effective_plan_digest, "owner_token": owner_token, "epoch": epoch,
-                    "expires_at": (issued + self.materialization_store.lease_ttl).isoformat(), "role": "primary",
-                    **cache_identity,
-                    "runtime_id": plan.runtime.runtime_id, "state": "allocating"})
+                self._write_lease_record(
+                    lease_id,
+                    {
+                        "schema_version": "bb.rl.workspace-lease.v1",
+                        "lease_id": lease_id,
+                        "workspace_id": materialized.receipt.workspace_id,
+                        "workspace_path": str(materialized.workspace_path),
+                        "cache_lease_id": materialized.receipt.cache_lease_id,
+                        "effective_plan_digest": plan.effective_plan_digest,
+                        "owner_token": owner_token,
+                        "epoch": epoch,
+                        "expires_at": (
+                            issued + self.materialization_store.lease_ttl
+                        ).isoformat(),
+                        "role": "primary",
+                        **cache_identity,
+                        "runtime_id": plan.runtime.runtime_id,
+                        "state": "allocating",
+                    },
+                )
                 record_written = True
-                backend = self.process_backend if plan.runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS else self.docker_backend
-                if backend is None: raise SandboxLaunchError("runtime backend unavailable", code="runtime_unsupported")
+                backend = (
+                    self.process_backend
+                    if plan.runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS
+                    else self.docker_backend
+                )
+                if backend is None:
+                    raise SandboxLaunchError(
+                        "runtime backend unavailable", code="runtime_unsupported"
+                    )
                 context = self._launch_context(
                     plan=plan,
                     workspace=materialized.workspace_path,
@@ -2825,22 +3566,43 @@ class SandboxRuntimeManager:
                 )
                 if isinstance(runtime, TrustedProcessHandle):
                     runtime.bind_identity_recorder(
-                        lambda resource_id, identity, lease_id=lease_id:
-                            self._record_process_identity(lease_id, resource_id, identity)
+                        lambda resource_id, identity, lease_id=lease_id: (
+                            self._record_process_identity(
+                                lease_id, resource_id, identity
+                            )
+                        )
                     )
                 if measurement.mismatch:
-                    raise SandboxAttestationError("runtime measurement mismatch", code="runtime_measurement_mismatch",
-                                                  lease_id=lease_id)
+                    raise SandboxAttestationError(
+                        "runtime measurement mismatch",
+                        code="runtime_measurement_mismatch",
+                        lease_id=lease_id,
+                    )
                 for setup in plan.setups:
-                    result = await runtime.run_argv(setup.argv,
-                                                    timeout_ms=min(setup.timeout_ms, plan.limits.setup_timeout_ms),
-                                                    output_limit=plan.limits.observation_bytes)
+                    result = await runtime.run_argv(
+                        setup.argv,
+                        timeout_ms=min(setup.timeout_ms, plan.limits.setup_timeout_ms),
+                        output_limit=plan.limits.observation_bytes,
+                    )
                     if result.get("returncode") != 0:
-                        raise SandboxLaunchError("setup failed", code="runtime_launch_failed", lease_id=lease_id)
-                lease = SandboxWorkspaceLease(manager=self, lease_id=lease_id, plan=plan,
-                    materialized=materialized, runtime=runtime, measurement=measurement,
-                    owner_token=owner_token, epoch=epoch)
-                active_record = dict(self._read_lease_record(self._lease_record_path(lease_id)))
+                        raise SandboxLaunchError(
+                            "setup failed",
+                            code="runtime_launch_failed",
+                            lease_id=lease_id,
+                        )
+                lease = SandboxWorkspaceLease(
+                    manager=self,
+                    lease_id=lease_id,
+                    plan=plan,
+                    materialized=materialized,
+                    runtime=runtime,
+                    measurement=measurement,
+                    owner_token=owner_token,
+                    epoch=epoch,
+                )
+                active_record = dict(
+                    self._read_lease_record(self._lease_record_path(lease_id))
+                )
                 prepared_resource_id = active_record.get("runtime_resource_id")
                 if (
                     prepared_resource_id is not None
@@ -2851,16 +3613,19 @@ class SandboxRuntimeManager:
                         code="stale_identity_uncertain",
                         lease_id=lease_id,
                     )
-                active_record.update({
-                    "runtime_authority_id": plan.runtime.runtime_id,
-                    "runtime_resource_id": runtime.runtime_id,
-                    "storage_authority_id": context.storage.authority_id,
-                    "storage_quota_bytes": context.storage.quota_bytes,
-                    "runtime_executable_path": plan.runtime.executable_path,
-                    "runtime_binary_digest": plan.runtime.measured_binary_digest,
-                    "action_timeout_ms": plan.limits.action_timeout_ms,
-                    "observation_bytes": plan.limits.observation_bytes,
-                    "state": "active"})
+                active_record.update(
+                    {
+                        "runtime_authority_id": plan.runtime.runtime_id,
+                        "runtime_resource_id": runtime.runtime_id,
+                        "storage_authority_id": context.storage.authority_id,
+                        "storage_quota_bytes": context.storage.quota_bytes,
+                        "runtime_executable_path": plan.runtime.executable_path,
+                        "runtime_binary_digest": plan.runtime.measured_binary_digest,
+                        "action_timeout_ms": plan.limits.action_timeout_ms,
+                        "observation_bytes": plan.limits.observation_bytes,
+                        "state": "active",
+                    }
+                )
                 self._write_lease_record(lease_id, active_record)
                 self._leases[lease_id] = lease
                 return lease
@@ -2872,25 +3637,31 @@ class SandboxRuntimeManager:
                         cleanup_steps.extend(await runtime.terminate())
                     except BaseException as cleanup_exc:
                         cleanup_errors.append(f"runtime:{type(cleanup_exc).__name__}")
-                        cleanup_steps.append(CleanupStepReceipt("runtime", CleanupState.FAILED,
-                                                                type(cleanup_exc).__name__))
+                        cleanup_steps.append(
+                            CleanupStepReceipt(
+                                "runtime",
+                                CleanupState.FAILED,
+                                type(cleanup_exc).__name__,
+                            )
+                        )
                 backend_cleanup_pending = (
                     runtime is None
                     and backend is self.docker_backend
                     and bool(getattr(backend, "cleanup_pending", False))
                 )
                 runtime_cleanup_pending = (
-                    runtime is not None
-                    and not _runtime_cleanup_released(cleanup_steps)
+                    runtime is not None and not _runtime_cleanup_released(cleanup_steps)
                 )
                 if backend_cleanup_pending:
-                    cleanup_steps.append(CleanupStepReceipt(
-                        "runtime", CleanupState.QUARANTINED,
-                        "backend retained launch cleanup authority",
-                    ))
-                if (
-                    materialized is not None
-                    and (backend_cleanup_pending or runtime_cleanup_pending)
+                    cleanup_steps.append(
+                        CleanupStepReceipt(
+                            "runtime",
+                            CleanupState.QUARANTINED,
+                            "backend retained launch cleanup authority",
+                        )
+                    )
+                if materialized is not None and (
+                    backend_cleanup_pending or runtime_cleanup_pending
                 ):
                     self._pending_launch_cleanups[lease_id] = _PendingLaunchCleanup(
                         workspace=materialized.workspace_path,
@@ -2904,19 +3675,36 @@ class SandboxRuntimeManager:
                 if materialized is not None and runtime_released:
                     try:
                         await asyncio.to_thread(materialized.close)
-                        cleanup_steps.append(CleanupStepReceipt("workspace", CleanupState.RELEASED))
-                        cleanup_steps.append(CleanupStepReceipt("cache_holder", CleanupState.RELEASED))
+                        cleanup_steps.append(
+                            CleanupStepReceipt("workspace", CleanupState.RELEASED)
+                        )
+                        cleanup_steps.append(
+                            CleanupStepReceipt("cache_holder", CleanupState.RELEASED)
+                        )
                     except BaseException as cleanup_exc:
                         cleanup_errors.append(f"workspace:{type(cleanup_exc).__name__}")
-                        cleanup_steps.append(CleanupStepReceipt("workspace", CleanupState.FAILED,
-                                                                type(cleanup_exc).__name__))
+                        cleanup_steps.append(
+                            CleanupStepReceipt(
+                                "workspace",
+                                CleanupState.FAILED,
+                                type(cleanup_exc).__name__,
+                            )
+                        )
                 elif materialized is not None:
-                    cleanup_steps.append(CleanupStepReceipt(
-                        "workspace", CleanupState.QUARANTINED, "dependent runtime cleanup incomplete"
-                    ))
-                    cleanup_steps.append(CleanupStepReceipt(
-                        "cache_holder", CleanupState.QUARANTINED, "dependent runtime cleanup incomplete"
-                    ))
+                    cleanup_steps.append(
+                        CleanupStepReceipt(
+                            "workspace",
+                            CleanupState.QUARANTINED,
+                            "dependent runtime cleanup incomplete",
+                        )
+                    )
+                    cleanup_steps.append(
+                        CleanupStepReceipt(
+                            "cache_holder",
+                            CleanupState.QUARANTINED,
+                            "dependent runtime cleanup incomplete",
+                        )
+                    )
                 dependencies_released = all(
                     step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
                     for step in cleanup_steps
@@ -2924,26 +3712,48 @@ class SandboxRuntimeManager:
                 try:
                     if record_written and dependencies_released:
                         self._unlink_lease_record(lease_id)
-                        cleanup_steps.append(CleanupStepReceipt("lease_record", CleanupState.RELEASED))
+                        cleanup_steps.append(
+                            CleanupStepReceipt("lease_record", CleanupState.RELEASED)
+                        )
                     elif record_written:
-                        cleanup_steps.append(CleanupStepReceipt(
-                            "lease_record", CleanupState.QUARANTINED,
-                            "dependent cleanup incomplete"
-                        ))
+                        cleanup_steps.append(
+                            CleanupStepReceipt(
+                                "lease_record",
+                                CleanupState.QUARANTINED,
+                                "dependent cleanup incomplete",
+                            )
+                        )
                     else:
                         self._release_lease_owner_lock(lease_id, unlink=True)
-                        cleanup_steps.append(CleanupStepReceipt("lease_record", CleanupState.ALREADY_RELEASED))
+                        cleanup_steps.append(
+                            CleanupStepReceipt(
+                                "lease_record", CleanupState.ALREADY_RELEASED
+                            )
+                        )
                 except BaseException as cleanup_exc:
                     cleanup_errors.append(f"lease_record:{type(cleanup_exc).__name__}")
-                    cleanup_steps.append(CleanupStepReceipt("lease_record", CleanupState.FAILED,
-                                                            type(cleanup_exc).__name__))
-                receipt = SandboxCleanupReceipt.from_steps(lease_id, tuple(cleanup_steps))
-                if cleanup_errors or receipt.state not in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}:
-                    raise SandboxFault(primary, receipt, tuple(cleanup_errors)) from primary
+                    cleanup_steps.append(
+                        CleanupStepReceipt(
+                            "lease_record",
+                            CleanupState.FAILED,
+                            type(cleanup_exc).__name__,
+                        )
+                    )
+                receipt = SandboxCleanupReceipt.from_steps(
+                    lease_id, tuple(cleanup_steps)
+                )
+                if cleanup_errors or receipt.state not in {
+                    CleanupState.RELEASED,
+                    CleanupState.ALREADY_RELEASED,
+                }:
+                    raise SandboxFault(
+                        primary, receipt, tuple(cleanup_errors)
+                    ) from primary
                 raise
 
-    async def open_verifier(self, primary: SandboxWorkspaceLease,
-                            snapshot: VerifierSnapshotReceipt) -> VerifierWorkspaceLease:
+    async def open_verifier(
+        self, primary: SandboxWorkspaceLease, snapshot: VerifierSnapshotReceipt
+    ) -> VerifierWorkspaceLease:
         if (
             type(primary) is not SandboxWorkspaceLease
             or primary._manager is not self
@@ -2955,11 +3765,11 @@ class SandboxRuntimeManager:
             )
         async with primary._lock:
             if primary.state is not WorkspaceLeaseState.QUIESCING:
-                raise VerifierSnapshotError("snapshot does not bind quiesced primary", code="snapshot_not_quiescent")
-            if (
-                primary.plan.episode_id
-                != primary.plan.materialization_plan.episode_id
-            ):
+                raise VerifierSnapshotError(
+                    "snapshot does not bind quiesced primary",
+                    code="snapshot_not_quiescent",
+                )
+            if primary.plan.episode_id != primary.plan.materialization_plan.episode_id:
                 raise VerifierSnapshotError(
                     "primary episode identity mismatch", code="snapshot_not_quiescent"
                 )
@@ -2975,8 +3785,9 @@ class SandboxRuntimeManager:
                 )
             verifier = _exact_one(
                 self.installed_authorities.verifiers,
-                lambda item: item.grant.verifier_id
-                == primary.plan.verifier.grant.verifier_id,
+                lambda item: (
+                    item.grant.verifier_id == primary.plan.verifier.grant.verifier_id
+                ),
                 missing_code="verifier_authority_mismatch",
             )
             if verifier != primary.plan.verifier:
@@ -2989,47 +3800,73 @@ class SandboxRuntimeManager:
                 lambda item: item.runtime_id == verifier.runtime_id,
                 missing_code="verifier_authority_mismatch",
             )
-            if (
-                primary.measurement.reward_eligible
-                and runtime.runtime_class not in {
-                    RuntimeClass.HARDENED_DOCKER,
-                    RuntimeClass.HARDENED_GVISOR,
-                }
-            ):
+            if primary.measurement.reward_eligible and runtime.runtime_class not in {
+                RuntimeClass.HARDENED_DOCKER,
+                RuntimeClass.HARDENED_GVISOR,
+            }:
                 raise VerifierExecutionError(
                     "reward-eligible primary requires an isolated verifier",
                     code="verifier_authority_mismatch",
                 )
             canonical = self._snapshots.get(snapshot.snapshot_id)
             if canonical is None or canonical[0] != snapshot:
-                raise VerifierSnapshotError("snapshot receipt is not canonical", code="snapshot_tampered")
+                raise VerifierSnapshotError(
+                    "snapshot receipt is not canonical", code="snapshot_tampered"
+                )
             canonical_receipt, snapshot_path = canonical
             if snapshot.source_lease_id != primary.lease_id or (
                 snapshot.effective_plan_digest != primary.plan.effective_plan_digest
             ):
-                raise VerifierSnapshotError("snapshot identity mismatch", code="snapshot_tampered")
+                raise VerifierSnapshotError(
+                    "snapshot identity mismatch", code="snapshot_tampered"
+                )
             if not snapshot_path.is_dir():
-                raise VerifierSnapshotError("sealed snapshot storage missing", code="snapshot_tampered")
-            image = _exact_one(self.installed_authorities.images,
-                               lambda item: item.image_digest == verifier.grant.image_digest,
-                               missing_code="verifier_authority_mismatch")
-            security = _exact_one(self.installed_authorities.security_policies,
-                                  lambda item: item.policy_digest == verifier.security_policy_digest,
-                                  missing_code="verifier_authority_mismatch")
-            network = _exact_one(self.installed_authorities.network_policies,
-                                 lambda item: item.policy_digest == verifier.grant.network_policy_digest,
-                                 missing_code="verifier_authority_mismatch")
-            if runtime.runtime_class is not verifier.runtime_class or image.runtime_id != runtime.runtime_id:
-                raise VerifierExecutionError("verifier runtime authority mismatch", code="verifier_authority_mismatch")
-            verifier_plan = replace(primary.plan, runtime=runtime, image=image, security_policy=security,
-                                    network_policy=network,
-                                    isolation_disposition=(IsolationDisposition.TRUSTED_PROCESS
-                                        if runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS else IsolationDisposition.ISOLATED))
+                raise VerifierSnapshotError(
+                    "sealed snapshot storage missing", code="snapshot_tampered"
+                )
+            image = _exact_one(
+                self.installed_authorities.images,
+                lambda item: item.image_digest == verifier.grant.image_digest,
+                missing_code="verifier_authority_mismatch",
+            )
+            security = _exact_one(
+                self.installed_authorities.security_policies,
+                lambda item: item.policy_digest == verifier.security_policy_digest,
+                missing_code="verifier_authority_mismatch",
+            )
+            network = _exact_one(
+                self.installed_authorities.network_policies,
+                lambda item: item.policy_digest == verifier.grant.network_policy_digest,
+                missing_code="verifier_authority_mismatch",
+            )
+            if (
+                runtime.runtime_class is not verifier.runtime_class
+                or image.runtime_id != runtime.runtime_id
+            ):
+                raise VerifierExecutionError(
+                    "verifier runtime authority mismatch",
+                    code="verifier_authority_mismatch",
+                )
+            verifier_plan = replace(
+                primary.plan,
+                runtime=runtime,
+                image=image,
+                security_policy=security,
+                network_policy=network,
+                isolation_disposition=(
+                    IsolationDisposition.TRUSTED_PROCESS
+                    if runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS
+                    else IsolationDisposition.ISOLATED
+                ),
+            )
             workspace_id = "verifier-workspace-" + self._nonce()
             lease_id = "verifier-lease-" + self._nonce()
             owner_token = self._nonce()
             issued = self.materialization_store.clock.current()
-            quota_bytes = min(primary.plan.resources.storage_bytes, primary.plan.limits.artifact_bytes_total)
+            quota_bytes = min(
+                primary.plan.resources.storage_bytes,
+                primary.plan.limits.artifact_bytes_total,
+            )
             workspace = self.materialization_store.workspace_root / workspace_id
             try:
                 if not self._claim_lease_owner_lock(lease_id):
@@ -3067,13 +3904,21 @@ class SandboxRuntimeManager:
             backend: RuntimeBackend | None = None
             try:
                 workspace = self.materialization_store.storage_backend.allocate(
-                    workspace_id=workspace_id, root=self.materialization_store.workspace_root,
-                    max_bytes=quota_bytes)
-                workspace_fd = self.materialization_store._workspace.open_dir(workspace_id)
+                    workspace_id=workspace_id,
+                    root=self.materialization_store.workspace_root,
+                    max_bytes=quota_bytes,
+                )
+                workspace_fd = self.materialization_store._workspace.open_dir(
+                    workspace_id
+                )
                 workspace_metadata = os.fstat(workspace_fd)
-                copy_snapshot = getattr(self.materialization_store, "copy_snapshot", None)
+                copy_snapshot = getattr(
+                    self.materialization_store, "copy_snapshot", None
+                )
                 if not callable(copy_snapshot):
-                    raise VerifierSnapshotError("snapshot copier unavailable", code="snapshot_tampered")
+                    raise VerifierSnapshotError(
+                        "snapshot copier unavailable", code="snapshot_tampered"
+                    )
                 try:
                     copy_task = asyncio.create_task(
                         asyncio.to_thread(
@@ -3097,30 +3942,45 @@ class SandboxRuntimeManager:
                         raise
                 except Exception as exc:
                     raise VerifierSnapshotError(
-                        "sealed snapshot authentication failed", code="snapshot_tampered"
+                        "sealed snapshot authentication failed",
+                        code="snapshot_tampered",
                     ) from exc
                 _seal_tree_at(workspace_fd, "snapshot")
                 os.mkdir("result", mode=0o700, dir_fd=workspace_fd)
-                backend = self.process_backend if runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS else self.docker_backend
+                backend = (
+                    self.process_backend
+                    if runtime.runtime_class is RuntimeClass.TRUSTED_PROCESS
+                    else self.docker_backend
+                )
                 if backend is None:
-                    raise VerifierExecutionError("verifier runtime backend unavailable", code="runtime_unsupported")
-                request_bytes = canonical_json_bytes({
-                    "schema_version": VERIFIER_REQUEST_SCHEMA_VERSION,
-                    "episode_id": verifier_plan.episode_id,
-                    "effective_plan_digest": verifier_plan.effective_plan_digest,
-                    "task_digest": snapshot.task_digest,
-                    "snapshot_digest": snapshot.root_digest,
-                    "verifier_digest": verifier_plan.verifier.grant.implementation_digest,
-                })
+                    raise VerifierExecutionError(
+                        "verifier runtime backend unavailable",
+                        code="runtime_unsupported",
+                    )
+                request_bytes = canonical_json_bytes(
+                    {
+                        "schema_version": VERIFIER_REQUEST_SCHEMA_VERSION,
+                        "episode_id": verifier_plan.episode_id,
+                        "effective_plan_digest": verifier_plan.effective_plan_digest,
+                        "task_digest": snapshot.task_digest,
+                        "snapshot_digest": snapshot.root_digest,
+                        "verifier_digest": verifier_plan.verifier.grant.implementation_digest,
+                    }
+                )
                 os.mkdir("input", mode=0o700, dir_fd=workspace_fd)
                 input_dir_fd = os.open(
-                    "input", os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
+                    "input",
+                    os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | os.O_CLOEXEC,
                     dir_fd=workspace_fd,
                 )
                 try:
                     request_fd = os.open(
                         "verifier-request.json",
-                        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC,
+                        os.O_WRONLY
+                        | os.O_CREAT
+                        | os.O_EXCL
+                        | os.O_NOFOLLOW
+                        | os.O_CLOEXEC,
                         0o400,
                         dir_fd=input_dir_fd,
                     )
@@ -3176,7 +4036,10 @@ class SandboxRuntimeManager:
                     epoch=1,
                     quota_bytes=quota_bytes,
                     workspace_fd=workspace_fd,
-                    workspace_identity=(workspace_metadata.st_dev, workspace_metadata.st_ino),
+                    workspace_identity=(
+                        workspace_metadata.st_dev,
+                        workspace_metadata.st_ino,
+                    ),
                     owner_token=owner_token,
                 )
                 workspace_fd = -1
@@ -3185,14 +4048,21 @@ class SandboxRuntimeManager:
                 )
                 if isinstance(launched, TrustedProcessHandle):
                     launched.bind_identity_recorder(
-                        lambda resource_id, identity, lease_id=lease_id:
-                            self._record_process_identity(lease_id, resource_id, identity)
+                        lambda resource_id, identity, lease_id=lease_id: (
+                            self._record_process_identity(
+                                lease_id, resource_id, identity
+                            )
+                        )
                     )
                 if measurement.mismatch:
-                    raise SandboxAttestationError("verifier runtime measurement mismatch", code="runtime_measurement_mismatch",
-                                                  lease_id=lease_id)
+                    raise SandboxAttestationError(
+                        "verifier runtime measurement mismatch",
+                        code="runtime_measurement_mismatch",
+                        lease_id=lease_id,
+                    )
                 if primary.measurement.reward_eligible and (
-                    measurement.isolation_disposition is not IsolationDisposition.ISOLATED
+                    measurement.isolation_disposition
+                    is not IsolationDisposition.ISOLATED
                     or not measurement.isolated
                     or not measurement.reward_eligible
                 ):
@@ -3201,10 +4071,19 @@ class SandboxRuntimeManager:
                         code="runtime_measurement_mismatch",
                         lease_id=lease_id,
                     )
-                lease = VerifierWorkspaceLease(manager=self, primary=primary, lease_id=lease_id,
-                    plan=verifier_plan, snapshot=snapshot, workspace=workspace, runtime=launched,
-                    measurement=measurement)
-                active_record = dict(self._read_lease_record(self._lease_record_path(lease_id)))
+                lease = VerifierWorkspaceLease(
+                    manager=self,
+                    primary=primary,
+                    lease_id=lease_id,
+                    plan=verifier_plan,
+                    snapshot=snapshot,
+                    workspace=workspace,
+                    runtime=launched,
+                    measurement=measurement,
+                )
+                active_record = dict(
+                    self._read_lease_record(self._lease_record_path(lease_id))
+                )
                 prepared_resource_id = active_record.get("runtime_resource_id")
                 if (
                     prepared_resource_id is not None
@@ -3215,17 +4094,19 @@ class SandboxRuntimeManager:
                         code="stale_identity_uncertain",
                         lease_id=lease_id,
                     )
-                active_record.update({
-                    "runtime_authority_id": runtime.runtime_id,
-                    "runtime_resource_id": launched.runtime_id,
-                    "storage_authority_id": context.storage.authority_id,
-                    "storage_quota_bytes": context.storage.quota_bytes,
-                    "runtime_executable_path": runtime.executable_path,
-                    "runtime_binary_digest": runtime.measured_binary_digest,
-                    "action_timeout_ms": verifier_plan.limits.verifier_timeout_ms,
-                    "observation_bytes": verifier_plan.limits.observation_bytes,
-                    "state": "active",
-                })
+                active_record.update(
+                    {
+                        "runtime_authority_id": runtime.runtime_id,
+                        "runtime_resource_id": launched.runtime_id,
+                        "storage_authority_id": context.storage.authority_id,
+                        "storage_quota_bytes": context.storage.quota_bytes,
+                        "runtime_executable_path": runtime.executable_path,
+                        "runtime_binary_digest": runtime.measured_binary_digest,
+                        "action_timeout_ms": verifier_plan.limits.verifier_timeout_ms,
+                        "observation_bytes": verifier_plan.limits.observation_bytes,
+                        "state": "active",
+                    }
+                )
                 self._write_lease_record(lease_id, active_record)
                 primary._verifier_children.append(lease)
                 return lease
@@ -3240,9 +4121,13 @@ class SandboxRuntimeManager:
                         cleanup_steps.extend(await launched.terminate())
                     except BaseException as cleanup_error:
                         cleanup_errors.append(f"runtime:{type(cleanup_error).__name__}")
-                        cleanup_steps.append(CleanupStepReceipt(
-                            "runtime", CleanupState.FAILED, type(cleanup_error).__name__
-                        ))
+                        cleanup_steps.append(
+                            CleanupStepReceipt(
+                                "runtime",
+                                CleanupState.FAILED,
+                                type(cleanup_error).__name__,
+                            )
+                        )
                 backend_cleanup_pending = (
                     launched is None
                     and backend is self.docker_backend
@@ -3253,10 +4138,13 @@ class SandboxRuntimeManager:
                     and not _runtime_cleanup_released(cleanup_steps)
                 )
                 if backend_cleanup_pending:
-                    cleanup_steps.append(CleanupStepReceipt(
-                        "runtime", CleanupState.QUARANTINED,
-                        "backend retained launch cleanup authority",
-                    ))
+                    cleanup_steps.append(
+                        CleanupStepReceipt(
+                            "runtime",
+                            CleanupState.QUARANTINED,
+                            "backend retained launch cleanup authority",
+                        )
+                    )
                 if backend_cleanup_pending or runtime_cleanup_pending:
                     self._pending_launch_cleanups[lease_id] = _PendingLaunchCleanup(
                         workspace=workspace,
@@ -3273,40 +4161,70 @@ class SandboxRuntimeManager:
                             self._make_workspace_releasable, workspace
                         )
                         await asyncio.to_thread(
-                            self.materialization_store.storage_backend.release, workspace
+                            self.materialization_store.storage_backend.release,
+                            workspace,
                         )
-                        absent = self.materialization_store.storage_backend.verify_absent(workspace)
-                        cleanup_steps.append(CleanupStepReceipt(
-                            "workspace", CleanupState.RELEASED if absent else CleanupState.FAILED
-                        ))
+                        absent = (
+                            self.materialization_store.storage_backend.verify_absent(
+                                workspace
+                            )
+                        )
+                        cleanup_steps.append(
+                            CleanupStepReceipt(
+                                "workspace",
+                                CleanupState.RELEASED
+                                if absent
+                                else CleanupState.FAILED,
+                            )
+                        )
                     except FileNotFoundError:
-                        cleanup_steps.append(CleanupStepReceipt("workspace", CleanupState.ALREADY_RELEASED))
+                        cleanup_steps.append(
+                            CleanupStepReceipt(
+                                "workspace", CleanupState.ALREADY_RELEASED
+                            )
+                        )
                     except BaseException as cleanup_error:
-                        cleanup_errors.append(f"workspace:{type(cleanup_error).__name__}")
-                        cleanup_steps.append(CleanupStepReceipt(
-                            "workspace", CleanupState.FAILED, type(cleanup_error).__name__
-                        ))
+                        cleanup_errors.append(
+                            f"workspace:{type(cleanup_error).__name__}"
+                        )
+                        cleanup_steps.append(
+                            CleanupStepReceipt(
+                                "workspace",
+                                CleanupState.FAILED,
+                                type(cleanup_error).__name__,
+                            )
+                        )
                 else:
-                    cleanup_steps.append(CleanupStepReceipt(
-                        "workspace", CleanupState.QUARANTINED,
-                        "dependent runtime cleanup incomplete",
-                    ))
+                    cleanup_steps.append(
+                        CleanupStepReceipt(
+                            "workspace",
+                            CleanupState.QUARANTINED,
+                            "dependent runtime cleanup incomplete",
+                        )
+                    )
                 dependencies_released = all(
                     step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
                     for step in cleanup_steps
                 )
                 if dependencies_released:
                     self._unlink_lease_record(lease_id)
-                    cleanup_steps.append(CleanupStepReceipt("lease_record", CleanupState.RELEASED))
+                    cleanup_steps.append(
+                        CleanupStepReceipt("lease_record", CleanupState.RELEASED)
+                    )
                 else:
-                    cleanup_steps.append(CleanupStepReceipt(
-                        "lease_record", CleanupState.FAILED, "dependent cleanup incomplete"
-                    ))
+                    cleanup_steps.append(
+                        CleanupStepReceipt(
+                            "lease_record",
+                            CleanupState.FAILED,
+                            "dependent cleanup incomplete",
+                        )
+                    )
                 cleanup_receipt = SandboxCleanupReceipt.from_steps(
                     lease_id, tuple(cleanup_steps)
                 )
                 if cleanup_errors or cleanup_receipt.state not in {
-                    CleanupState.RELEASED, CleanupState.ALREADY_RELEASED
+                    CleanupState.RELEASED,
+                    CleanupState.ALREADY_RELEASED,
                 }:
                     raise SandboxFault(
                         primary_error, cleanup_receipt, tuple(cleanup_errors)
@@ -3315,7 +4233,8 @@ class SandboxRuntimeManager:
 
     async def _close_lease(self, lease: SandboxWorkspaceLease) -> SandboxCleanupReceipt:
         async with lease._lock:
-            if lease._cleanup is not None: return lease._cleanup
+            if lease._cleanup is not None:
+                return lease._cleanup
             await lease._fence_and_drain(WorkspaceLeaseState.RELEASING)
             steps: list[CleanupStepReceipt] = []
             child_states: list[CleanupState] = []
@@ -3344,9 +4263,7 @@ class SandboxRuntimeManager:
                 )
             )
             lease._verifier_children[:] = [
-                child
-                for child in lease._verifier_children
-                if not child._closed
+                child for child in lease._verifier_children if not child._closed
             ]
             if not incomplete_child_ids:
                 snapshot_ids = tuple(
@@ -3365,39 +4282,74 @@ class SandboxRuntimeManager:
                 try:
                     cache = await asyncio.to_thread(lease._materialized.close)
                     steps.append(CleanupStepReceipt("workspace", CleanupState.RELEASED))
-                    steps.append(CleanupStepReceipt(
-                        "cache_holder",
-                        CleanupState.RELEASED
-                        if cache.release_state.value == "released"
-                        else CleanupState.FAILED,
-                    ))
+                    steps.append(
+                        CleanupStepReceipt(
+                            "cache_holder",
+                            CleanupState.RELEASED
+                            if cache.release_state.value == "released"
+                            else CleanupState.FAILED,
+                        )
+                    )
                 except Exception as exc:
-                    steps.append(CleanupStepReceipt("workspace", CleanupState.FAILED, type(exc).__name__))
-                    steps.append(CleanupStepReceipt("cache_holder", CleanupState.FAILED, type(exc).__name__))
+                    steps.append(
+                        CleanupStepReceipt(
+                            "workspace", CleanupState.FAILED, type(exc).__name__
+                        )
+                    )
+                    steps.append(
+                        CleanupStepReceipt(
+                            "cache_holder", CleanupState.FAILED, type(exc).__name__
+                        )
+                    )
             else:
-                steps.append(CleanupStepReceipt(
-                    "workspace", CleanupState.QUARANTINED, "dependent runtime cleanup incomplete"
-                ))
-                steps.append(CleanupStepReceipt(
-                    "cache_holder", CleanupState.QUARANTINED, "dependent runtime cleanup incomplete"
-                ))
-            prior_ok = all(step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED} for step in steps)
+                steps.append(
+                    CleanupStepReceipt(
+                        "workspace",
+                        CleanupState.QUARANTINED,
+                        "dependent runtime cleanup incomplete",
+                    )
+                )
+                steps.append(
+                    CleanupStepReceipt(
+                        "cache_holder",
+                        CleanupState.QUARANTINED,
+                        "dependent runtime cleanup incomplete",
+                    )
+                )
+            prior_ok = all(
+                step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
+                for step in steps
+            )
             try:
                 if prior_ok:
                     self._unlink_lease_record(lease.lease_id)
                     absent = not self._lease_record_exists(lease.lease_id)
-                    steps.append(CleanupStepReceipt("lease_record", CleanupState.RELEASED if absent else CleanupState.FAILED))
+                    steps.append(
+                        CleanupStepReceipt(
+                            "lease_record",
+                            CleanupState.RELEASED if absent else CleanupState.FAILED,
+                        )
+                    )
                 else:
-                    steps.append(CleanupStepReceipt(
-                        "lease_record", CleanupState.QUARANTINED, "dependent cleanup incomplete"
-                    ))
+                    steps.append(
+                        CleanupStepReceipt(
+                            "lease_record",
+                            CleanupState.QUARANTINED,
+                            "dependent cleanup incomplete",
+                        )
+                    )
             except Exception as exc:
-                steps.append(CleanupStepReceipt("lease_record", CleanupState.FAILED, type(exc).__name__))
+                steps.append(
+                    CleanupStepReceipt(
+                        "lease_record", CleanupState.FAILED, type(exc).__name__
+                    )
+                )
             receipt = SandboxCleanupReceipt.from_steps(lease.lease_id, tuple(steps))
             lease._latest_cleanup = receipt
             lease._state = (
                 WorkspaceLeaseState.RELEASED
-                if receipt.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
+                if receipt.state
+                in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
                 else WorkspaceLeaseState.QUARANTINED
                 if receipt.state is CleanupState.QUARANTINED
                 else WorkspaceLeaseState.FAILED
@@ -3417,9 +4369,7 @@ class SandboxRuntimeManager:
         if any(retained.backend_cleanup_pending for _, retained in pending):
             reconcile = getattr(self.docker_backend, "reconcile_quarantined", None)
             if not callable(reconcile):
-                backend_failure = RuntimeError(
-                    "backend cleanup authority unavailable"
-                )
+                backend_failure = RuntimeError("backend cleanup authority unavailable")
             else:
                 try:
                     await reconcile()
@@ -3432,52 +4382,69 @@ class SandboxRuntimeManager:
                 try:
                     steps.extend(await retained.runtime.terminate())
                 except BaseException as exc:
-                    steps.append(CleanupStepReceipt(
-                        "runtime", CleanupState.FAILED, type(exc).__name__
-                    ))
+                    steps.append(
+                        CleanupStepReceipt(
+                            "runtime", CleanupState.FAILED, type(exc).__name__
+                        )
+                    )
                 runtime_released = _runtime_cleanup_released(steps)
             elif retained.backend_cleanup_pending and backend_failure is not None:
-                steps.append(CleanupStepReceipt(
-                    "runtime", CleanupState.QUARANTINED,
-                    type(backend_failure).__name__,
-                ))
+                steps.append(
+                    CleanupStepReceipt(
+                        "runtime",
+                        CleanupState.QUARANTINED,
+                        type(backend_failure).__name__,
+                    )
+                )
                 runtime_released = False
             elif retained.backend_cleanup_pending:
-                steps.append(CleanupStepReceipt(
-                    "runtime", CleanupState.RELEASED
-                ))
+                steps.append(CleanupStepReceipt("runtime", CleanupState.RELEASED))
                 runtime_released = True
             else:
-                steps.append(CleanupStepReceipt(
-                    "runtime", CleanupState.FAILED,
-                    "retained cleanup authority is incomplete",
-                ))
+                steps.append(
+                    CleanupStepReceipt(
+                        "runtime",
+                        CleanupState.FAILED,
+                        "retained cleanup authority is incomplete",
+                    )
+                )
                 runtime_released = False
             if not runtime_released:
-                steps.append(CleanupStepReceipt(
-                    "workspace", CleanupState.QUARANTINED,
-                    "dependent runtime cleanup incomplete",
-                ))
-                if retained.materialized is not None:
-                    steps.append(CleanupStepReceipt(
-                        "cache_holder", CleanupState.QUARANTINED,
+                steps.append(
+                    CleanupStepReceipt(
+                        "workspace",
+                        CleanupState.QUARANTINED,
                         "dependent runtime cleanup incomplete",
-                    ))
-                steps.append(CleanupStepReceipt(
-                    "lease_record", CleanupState.QUARANTINED,
-                    "dependent cleanup incomplete",
-                ))
-                receipts.append(SandboxCleanupReceipt.from_steps(
-                    lease_id, tuple(steps)
-                ))
+                    )
+                )
+                if retained.materialized is not None:
+                    steps.append(
+                        CleanupStepReceipt(
+                            "cache_holder",
+                            CleanupState.QUARANTINED,
+                            "dependent runtime cleanup incomplete",
+                        )
+                    )
+                steps.append(
+                    CleanupStepReceipt(
+                        "lease_record",
+                        CleanupState.QUARANTINED,
+                        "dependent cleanup incomplete",
+                    )
+                )
+                receipts.append(
+                    SandboxCleanupReceipt.from_steps(lease_id, tuple(steps))
+                )
                 continue
             try:
                 if retained.materialized is not None:
                     await asyncio.to_thread(retained.materialized.close)
-                    steps.extend((
-                        CleanupStepReceipt("workspace", CleanupState.RELEASED),
-                        CleanupStepReceipt("cache_holder", CleanupState.RELEASED),
-                    ))
+                    steps.extend(
+                        (
+                            CleanupStepReceipt("workspace", CleanupState.RELEASED),
+                            CleanupStepReceipt("cache_holder", CleanupState.RELEASED),
+                        )
+                    )
                 else:
                     await asyncio.to_thread(
                         self._make_workspace_releasable, retained.workspace
@@ -3489,24 +4456,34 @@ class SandboxRuntimeManager:
                     absent = self.materialization_store.storage_backend.verify_absent(
                         retained.workspace
                     )
-                    steps.extend((
-                        CleanupStepReceipt(
-                            "workspace",
-                            CleanupState.RELEASED if absent else CleanupState.FAILED,
-                        ),
+                    steps.extend(
+                        (
+                            CleanupStepReceipt(
+                                "workspace",
+                                CleanupState.RELEASED
+                                if absent
+                                else CleanupState.FAILED,
+                            ),
+                            CleanupStepReceipt(
+                                "cache_holder", CleanupState.ALREADY_RELEASED
+                            ),
+                        )
+                    )
+            except FileNotFoundError:
+                steps.extend(
+                    (
+                        CleanupStepReceipt("workspace", CleanupState.ALREADY_RELEASED),
                         CleanupStepReceipt(
                             "cache_holder", CleanupState.ALREADY_RELEASED
                         ),
-                    ))
-            except FileNotFoundError:
-                steps.extend((
-                    CleanupStepReceipt("workspace", CleanupState.ALREADY_RELEASED),
-                    CleanupStepReceipt("cache_holder", CleanupState.ALREADY_RELEASED),
-                ))
+                    )
+                )
             except BaseException as exc:
-                steps.append(CleanupStepReceipt(
-                    "workspace", CleanupState.FAILED, type(exc).__name__
-                ))
+                steps.append(
+                    CleanupStepReceipt(
+                        "workspace", CleanupState.FAILED, type(exc).__name__
+                    )
+                )
             dependencies_released = all(
                 step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
                 for step in steps
@@ -3514,31 +4491,32 @@ class SandboxRuntimeManager:
             if dependencies_released:
                 try:
                     self._unlink_lease_record(lease_id)
-                    steps.append(CleanupStepReceipt(
-                        "lease_record", CleanupState.RELEASED
-                    ))
+                    steps.append(
+                        CleanupStepReceipt("lease_record", CleanupState.RELEASED)
+                    )
                     self._pending_launch_cleanups.pop(lease_id, None)
                 except BaseException as exc:
-                    steps.append(CleanupStepReceipt(
-                        "lease_record", CleanupState.FAILED, type(exc).__name__
-                    ))
+                    steps.append(
+                        CleanupStepReceipt(
+                            "lease_record", CleanupState.FAILED, type(exc).__name__
+                        )
+                    )
             else:
-                steps.append(CleanupStepReceipt(
-                    "lease_record", CleanupState.QUARANTINED,
-                    "dependent cleanup incomplete",
-                ))
-            receipts.append(SandboxCleanupReceipt.from_steps(
-                lease_id, tuple(steps)
-            ))
+                steps.append(
+                    CleanupStepReceipt(
+                        "lease_record",
+                        CleanupState.QUARANTINED,
+                        "dependent cleanup incomplete",
+                    )
+                )
+            receipts.append(SandboxCleanupReceipt.from_steps(lease_id, tuple(steps)))
         return tuple(receipts)
-
 
     async def reconcile_stale(self) -> tuple[SandboxCleanupReceipt, ...]:
         async with self._reconcile_lock:
             if self._lease_root_fd is None:
                 return ()
             return await self._reconcile_stale_owner()
-
 
     async def _reconcile_stale_owner(
         self,
@@ -3549,15 +4527,12 @@ class SandboxRuntimeManager:
         if self._lease_root_fd is None:
             return ()
         names = tuple(
-            name for name in os.listdir(self._lease_root_fd)
+            name
+            for name in os.listdir(self._lease_root_fd)
             if "/" not in name and name not in {".", ".."}
         )
-        record_names = frozenset(
-            name for name in names if name.endswith(".json")
-        )
-        for lock_name in sorted(
-            name for name in names if name.endswith(".owner.lock")
-        ):
+        record_names = frozenset(name for name in names if name.endswith(".json"))
+        for lock_name in sorted(name for name in names if name.endswith(".owner.lock")):
             lease_id = lock_name.removesuffix(".owner.lock")
             if (
                 lease_id + ".json" in record_names
@@ -3652,8 +4627,16 @@ class SandboxRuntimeManager:
             try:
                 record = self._read_lease_record(path)
             except WorkspaceStateError as exc:
-                receipts.append(SandboxCleanupReceipt.from_steps(path.stem, (
-                    CleanupStepReceipt("lease_record", CleanupState.QUARANTINED, exc.code),)))
+                receipts.append(
+                    SandboxCleanupReceipt.from_steps(
+                        path.stem,
+                        (
+                            CleanupStepReceipt(
+                                "lease_record", CleanupState.QUARANTINED, exc.code
+                            ),
+                        ),
+                    )
+                )
                 continue
             try:
                 expires_at = record["expires_at"]
@@ -3739,10 +4722,8 @@ class SandboxRuntimeManager:
                     CleanupState.RELEASED,
                     CleanupState.ALREADY_RELEASED,
                 }:
-                    snapshot_step = (
-                        await self._release_durable_snapshots_for_lease(
-                            path.stem
-                        )
+                    snapshot_step = await self._release_durable_snapshots_for_lease(
+                        path.stem
                     )
                 else:
                     snapshot_step = CleanupStepReceipt(
@@ -3751,19 +4732,24 @@ class SandboxRuntimeManager:
                         "dependent verifier cleanup incomplete",
                     )
             reconciliation_prefix = tuple(
-                step
-                for step in (child_step, snapshot_step)
-                if step is not None
+                step for step in (child_step, snapshot_step) if step is not None
             )
             runtime_authority_id = str(
                 record.get("runtime_authority_id", record.get("runtime_id", ""))
             )
             trusted_runtime_ids = {
-                item.runtime_id for item in self.installed_authorities.runtimes
+                item.runtime_id
+                for item in self.installed_authorities.runtimes
                 if item.runtime_class is RuntimeClass.TRUSTED_PROCESS
             }
-            backend = self.process_backend if runtime_authority_id in trusted_runtime_ids else self.docker_backend
-            reconcile = getattr(backend, "reconcile", None) if backend is not None else None
+            backend = (
+                self.process_backend
+                if runtime_authority_id in trusted_runtime_ids
+                else self.docker_backend
+            )
+            reconcile = (
+                getattr(backend, "reconcile", None) if backend is not None else None
+            )
             if not callable(reconcile):
                 unavailable_steps = (
                     CleanupStepReceipt(
@@ -3795,61 +4781,51 @@ class SandboxRuntimeManager:
                 )
                 continue
             raw_steps = reconciliation_prefix + tuple(await reconcile(record))
-            if (
-                {step.resource for step in raw_steps}
-                == (
-                    {
-                        "child_verifier",
-                        *(("snapshot",) if snapshot_step is not None else ()),
-                        "runtime",
-                        "workspace",
-                        "cache_holder",
-                        "lease_record",
-                    }
-                    if role == "primary"
-                    else {
-                        "runtime",
-                        "workspace",
-                        "cache_holder",
-                        "lease_record",
-                    }
-                )
-                and all(
-                    step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
-                    for step in raw_steps
-                )
+            if {step.resource for step in raw_steps} == (
+                {
+                    "child_verifier",
+                    *(("snapshot",) if snapshot_step is not None else ()),
+                    "runtime",
+                    "workspace",
+                    "cache_holder",
+                    "lease_record",
+                }
+                if role == "primary"
+                else {
+                    "runtime",
+                    "workspace",
+                    "cache_holder",
+                    "lease_record",
+                }
+            ) and all(
+                step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
+                for step in raw_steps
             ):
                 self._unlink_lease_record(path.stem)
-                receipts.append(SandboxCleanupReceipt.from_steps(
-                    str(record["lease_id"]), raw_steps
-                ))
+                receipts.append(
+                    SandboxCleanupReceipt.from_steps(str(record["lease_id"]), raw_steps)
+                )
                 continue
             runtime_steps = tuple(
                 step for step in raw_steps if step.resource == "runtime"
             )
             runtime_released = bool(runtime_steps) and all(
-                step.state
-                in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
+                step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
                 for step in runtime_steps
             )
             steps = list(raw_steps)
-            if (
-                runtime_released
-                and (
-                    child_step is None
-                    or child_step.state
-                    in {
-                        CleanupState.RELEASED,
-                        CleanupState.ALREADY_RELEASED,
-                    }
-                )
+            if runtime_released and (
+                child_step is None
+                or child_step.state
+                in {
+                    CleanupState.RELEASED,
+                    CleanupState.ALREADY_RELEASED,
+                }
             ):
                 workspace_id = record.get("workspace_id")
                 workspace_path = record.get("workspace_path")
                 workspace_prefix = (
-                    "verifier-workspace-"
-                    if role == "verifier"
-                    else "workspace-"
+                    "verifier-workspace-" if role == "verifier" else "workspace-"
                 )
                 valid_workspace_id = (
                     type(workspace_id) is str
@@ -3857,7 +4833,7 @@ class SandboxRuntimeManager:
                     and len(workspace_id) == len(workspace_prefix) + 32
                     and all(
                         character in "0123456789abcdef"
-                        for character in workspace_id[len(workspace_prefix):]
+                        for character in workspace_id[len(workspace_prefix) :]
                     )
                 )
                 expected_workspace = (
@@ -3878,35 +4854,55 @@ class SandboxRuntimeManager:
                             self.materialization_store.storage_backend.release,
                             expected_workspace,
                         )
-                        absent = self.materialization_store.storage_backend.verify_absent(
-                            expected_workspace
+                        absent = (
+                            self.materialization_store.storage_backend.verify_absent(
+                                expected_workspace
+                            )
                         )
-                        steps.append(CleanupStepReceipt(
-                            "workspace",
-                            CleanupState.RELEASED if absent else CleanupState.FAILED,
-                        ))
+                        steps.append(
+                            CleanupStepReceipt(
+                                "workspace",
+                                CleanupState.RELEASED
+                                if absent
+                                else CleanupState.FAILED,
+                            )
+                        )
                     except FileNotFoundError:
-                        steps.append(CleanupStepReceipt(
-                            "workspace", CleanupState.ALREADY_RELEASED
-                        ))
+                        steps.append(
+                            CleanupStepReceipt(
+                                "workspace", CleanupState.ALREADY_RELEASED
+                            )
+                        )
                     except Exception as exc:
-                        steps.append(CleanupStepReceipt(
-                            "workspace", CleanupState.FAILED, type(exc).__name__
-                        ))
+                        steps.append(
+                            CleanupStepReceipt(
+                                "workspace", CleanupState.FAILED, type(exc).__name__
+                            )
+                        )
                 else:
-                    steps.append(CleanupStepReceipt(
-                        "workspace", CleanupState.QUARANTINED, "stale_identity_uncertain"
-                    ))
+                    steps.append(
+                        CleanupStepReceipt(
+                            "workspace",
+                            CleanupState.QUARANTINED,
+                            "stale_identity_uncertain",
+                        )
+                    )
             else:
-                steps.append(CleanupStepReceipt(
-                    "workspace", CleanupState.QUARANTINED, "stale_identity_uncertain"
-                ))
+                steps.append(
+                    CleanupStepReceipt(
+                        "workspace",
+                        CleanupState.QUARANTINED,
+                        "stale_identity_uncertain",
+                    )
+                )
             dependencies_released = all(
                 step.state in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
                 for step in steps
             )
             if role == "verifier" and dependencies_released:
-                steps.append(CleanupStepReceipt("cache_holder", CleanupState.ALREADY_RELEASED))
+                steps.append(
+                    CleanupStepReceipt("cache_holder", CleanupState.ALREADY_RELEASED)
+                )
                 self._unlink_lease_record(path.stem)
                 steps.append(CleanupStepReceipt("lease_record", CleanupState.RELEASED))
             elif role == "primary" and dependencies_released:
@@ -3917,30 +4913,53 @@ class SandboxRuntimeManager:
                     cache_step = await asyncio.to_thread(recover_cache, record)
                 else:
                     cache_step = CleanupStepReceipt(
-                        "cache_holder", CleanupState.QUARANTINED, "stale_identity_uncertain"
+                        "cache_holder",
+                        CleanupState.QUARANTINED,
+                        "stale_identity_uncertain",
                     )
                 steps.append(cache_step)
                 if cache_step.state in {
-                    CleanupState.RELEASED, CleanupState.ALREADY_RELEASED
+                    CleanupState.RELEASED,
+                    CleanupState.ALREADY_RELEASED,
                 }:
                     self._unlink_lease_record(path.stem)
-                    steps.append(CleanupStepReceipt("lease_record", CleanupState.RELEASED))
+                    steps.append(
+                        CleanupStepReceipt("lease_record", CleanupState.RELEASED)
+                    )
                 else:
-                    steps.append(CleanupStepReceipt(
-                        "lease_record", CleanupState.QUARANTINED, "stale_identity_uncertain"
-                    ))
+                    steps.append(
+                        CleanupStepReceipt(
+                            "lease_record",
+                            CleanupState.QUARANTINED,
+                            "stale_identity_uncertain",
+                        )
+                    )
             else:
-                steps.append(CleanupStepReceipt(
-                    "cache_holder", CleanupState.QUARANTINED, "stale_identity_uncertain"
-                ))
-                steps.append(CleanupStepReceipt(
-                    "lease_record", CleanupState.QUARANTINED, "stale_identity_uncertain"
-                ))
-            receipts.append(SandboxCleanupReceipt.from_steps(
-                str(record["lease_id"]), tuple(steps)
-            ))
-        receipts.extend([await self._close_lease(lease) for lease in tuple(self._leases.values())
-                         if lease.state in {WorkspaceLeaseState.FAILED, WorkspaceLeaseState.QUARANTINED}])
+                steps.append(
+                    CleanupStepReceipt(
+                        "cache_holder",
+                        CleanupState.QUARANTINED,
+                        "stale_identity_uncertain",
+                    )
+                )
+                steps.append(
+                    CleanupStepReceipt(
+                        "lease_record",
+                        CleanupState.QUARANTINED,
+                        "stale_identity_uncertain",
+                    )
+                )
+            receipts.append(
+                SandboxCleanupReceipt.from_steps(str(record["lease_id"]), tuple(steps))
+            )
+        receipts.extend(
+            [
+                await self._close_lease(lease)
+                for lease in tuple(self._leases.values())
+                if lease.state
+                in {WorkspaceLeaseState.FAILED, WorkspaceLeaseState.QUARANTINED}
+            ]
+        )
         return tuple(receipts)
 
     async def _close_all(
@@ -3950,9 +4969,7 @@ class SandboxRuntimeManager:
         receipts.extend(await self._reconcile_pending_launch_cleanups())
         for snapshot_id in tuple(self._snapshots):
             step = await self._release_snapshot(snapshot_id)
-            receipts.append(
-                SandboxCleanupReceipt.from_steps(snapshot_id, (step,))
-            )
+            receipts.append(SandboxCleanupReceipt.from_steps(snapshot_id, (step,)))
         return receipts
 
     async def _close_all_serialized(
@@ -3977,9 +4994,7 @@ class SandboxRuntimeManager:
                     return self._last_close_receipts or ()
                 self._closed = True
                 leases = tuple(self._leases.values())
-                close_task = asyncio.create_task(
-                    self._close_all_serialized(leases)
-                )
+                close_task = asyncio.create_task(self._close_all_serialized(leases))
                 self._close_task = close_task
         try:
             result = tuple(await asyncio.shield(close_task))
@@ -3989,10 +5004,10 @@ class SandboxRuntimeManager:
                     if self._close_task is close_task:
                         self._close_task = None
         pending = tuple(
-            receipt for receipt in result
-            if receipt.state not in {
-                CleanupState.RELEASED, CleanupState.ALREADY_RELEASED
-            }
+            receipt
+            for receipt in result
+            if receipt.state
+            not in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
         )
         if not pending:
             self._last_close_receipts = result
@@ -4011,17 +5026,41 @@ class SandboxRuntimeManager:
 
 
 __all__ = [
-    "CacheLeaseError", "InstalledImage", "InstalledRuntime", "InstalledSandboxAuthoritySet",
-    "InstalledVerifier", "LeaseBackedRunnerWorkspace", "MaterializationError", "RuntimeBackend",
-    "RuntimeHandle", "RuntimeLaunchContext", "RuntimePreparedIdentity", "SandboxAttestationError",
-    "SandboxCleanupReceipt", "SandboxExecutionPlan", "SandboxFault", "SandboxLaunchError",
-    "SandboxMeasurement", "SandboxNetworkPolicy",
-    "SandboxPlanError", "SandboxRuntimeError", "SandboxRuntimeManager", "SandboxSecurityPolicy",
-    "SandboxWorkspaceLease", "TrustedProcessBackend", "TrustedProcessHandle",
-    "SANDBOX_CAPABILITY_MATRIX_RESOURCE", "SANDBOX_CAPABILITY_MATRIX_SCHEMA_VERSION",
+    "CacheLeaseError",
+    "InstalledImage",
+    "InstalledRuntime",
+    "InstalledSandboxAuthoritySet",
+    "InstalledVerifier",
+    "LeaseBackedRunnerWorkspace",
+    "MaterializationError",
+    "RuntimeBackend",
+    "RuntimeHandle",
+    "RuntimeLaunchContext",
+    "RuntimePreparedIdentity",
+    "SandboxAttestationError",
+    "SandboxCleanupReceipt",
+    "SandboxExecutionPlan",
+    "SandboxFault",
+    "SandboxLaunchError",
+    "SandboxMeasurement",
+    "SandboxNetworkPolicy",
+    "SandboxPlanError",
+    "SandboxRuntimeError",
+    "SandboxRuntimeManager",
+    "SandboxSecurityPolicy",
+    "SandboxWorkspaceLease",
+    "TrustedProcessBackend",
+    "TrustedProcessHandle",
+    "SANDBOX_CAPABILITY_MATRIX_RESOURCE",
+    "SANDBOX_CAPABILITY_MATRIX_SCHEMA_VERSION",
     "SANDBOX_CAPABILITY_MATRIX_SHA256",
-    "VERIFIER_REQUEST_RELATIVE_PATH", "VERIFIER_REQUEST_SCHEMA_VERSION",
-    "VerifierExecutionError", "VerifierSnapshotError", "VerifierWorkspaceLease",
-    "WorkspaceStateError", "WorkspaceStorageIdentity", "build_sandbox_execution_plan",
+    "VERIFIER_REQUEST_RELATIVE_PATH",
+    "VERIFIER_REQUEST_SCHEMA_VERSION",
+    "VerifierExecutionError",
+    "VerifierSnapshotError",
+    "VerifierWorkspaceLease",
+    "WorkspaceStateError",
+    "WorkspaceStorageIdentity",
+    "build_sandbox_execution_plan",
     "load_sandbox_capability_matrix",
 ]

--- a/breadboard/rl/harness/sandbox.py
+++ b/breadboard/rl/harness/sandbox.py
@@ -8,9 +8,11 @@ import os
 import shutil
 import signal
 import stat
+import selectors
 import subprocess
 import sys
 import tempfile
+import time
 import uuid
 from dataclasses import dataclass, replace
 from datetime import datetime
@@ -1094,67 +1096,205 @@ def _sealed_repository_diff(
         *,
         environment: Mapping[str, str],
         stdout_limit: int,
+        cwd: Path = repository,
     ) -> tuple[int, bytes, bytes]:
-        with tempfile.TemporaryFile() as stdout, tempfile.TemporaryFile() as stderr:
+        try:
+            process = subprocess.Popen(
+                (pinned.proc_fd_path, *arguments),
+                cwd=cwd,
+                env=dict(environment),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                pass_fds=(pinned.fd,),
+                start_new_session=True,
+            )
+        except OSError as exc:
+            raise VerifierSnapshotError(
+                "sealed workspace diff command failed", code="snapshot_tampered"
+            ) from exc
+        if process.stdout is None or process.stderr is None:
+            process.kill()
+            process.wait()
+            raise VerifierSnapshotError(
+                "sealed workspace diff pipes are unavailable", code="snapshot_tampered"
+            )
+        stdout = bytearray()
+        stderr = bytearray()
+        streams = {
+            process.stdout.fileno(): (stdout, stdout_limit),
+            process.stderr.fileno(): (stderr, 64 * 1024),
+        }
+        deadline = time.monotonic() + timeout_seconds
+        selector = selectors.DefaultSelector()
+
+        def kill_process_group() -> None:
             try:
-                completed = subprocess.run(
-                    (pinned.proc_fd_path, *arguments),
-                    cwd=repository,
-                    env=dict(environment),
-                    stdin=subprocess.DEVNULL,
-                    stdout=stdout,
-                    stderr=stderr,
-                    timeout=timeout_seconds,
-                    check=False,
-                    pass_fds=(pinned.fd,),
-                )
-            except (OSError, subprocess.TimeoutExpired) as exc:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait()
+
+        try:
+            for descriptor in streams:
+                os.set_blocking(descriptor, False)
+                selector.register(descriptor, selectors.EVENT_READ)
+            while selector.get_map():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    kill_process_group()
+                    raise VerifierSnapshotError(
+                        "sealed workspace diff command timed out",
+                        code="snapshot_tampered",
+                    )
+                events = selector.select(remaining)
+                if not events:
+                    continue
+                for key, _ in events:
+                    descriptor = key.fd
+                    buffer, limit = streams[descriptor]
+                    chunk = os.read(descriptor, min(65536, limit - len(buffer) + 1))
+                    if not chunk:
+                        selector.unregister(descriptor)
+                        continue
+                    buffer.extend(chunk)
+                    if len(buffer) > limit:
+                        kill_process_group()
+                        raise VerifierSnapshotError(
+                            "sealed workspace diff exceeded its output limit",
+                            code="output_limit_exceeded",
+                        )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                kill_process_group()
                 raise VerifierSnapshotError(
-                    "sealed workspace diff command failed", code="snapshot_tampered"
+                    "sealed workspace diff command timed out",
+                    code="snapshot_tampered",
+                )
+            try:
+                returncode = process.wait(timeout=remaining)
+            except subprocess.TimeoutExpired as exc:
+                kill_process_group()
+                raise VerifierSnapshotError(
+                    "sealed workspace diff command timed out",
+                    code="snapshot_tampered",
                 ) from exc
-            stdout_size = os.fstat(stdout.fileno()).st_size
-            stderr_size = os.fstat(stderr.fileno()).st_size
-            if (
-                stdout_size > stdout_limit
-                or stderr_size > 64 * 1024
-            ):
-                raise VerifierSnapshotError(
-                    "sealed workspace diff exceeded its output limit",
-                    code="output_limit_exceeded",
-                )
-            stdout.seek(0)
-            stderr.seek(0)
-            return completed.returncode, stdout.read(), stderr.read()
+            return returncode, bytes(stdout), bytes(stderr)
+        finally:
+            selector.close()
+            process.stdout.close()
+            process.stderr.close()
+            if process.poll() is None:
+                kill_process_group()
 
     try:
         identity = repository.stat(follow_symlinks=False)
-        if not stat.S_ISDIR(identity.st_mode):
+        source_git_directory = repository / ".git"
+        source_objects = source_git_directory / "objects"
+        if (
+            not stat.S_ISDIR(identity.st_mode)
+            or not source_git_directory.is_dir()
+            or not source_objects.is_dir()
+        ):
             raise VerifierSnapshotError(
-                "sealed workspace repository is not a directory",
+                "sealed workspace repository layout is unsupported",
                 code="snapshot_tampered",
             )
-        with tempfile.TemporaryDirectory(prefix="breadboard-sealed-diff-") as temporary:
-            environment = {
+        forbidden_object_authorities = (
+            source_objects / "info" / "alternates",
+            source_objects / "info" / "http-alternates",
+            source_git_directory / "info" / "grafts",
+            source_git_directory / "shallow",
+        )
+        if any(path.exists() for path in forbidden_object_authorities):
+            raise VerifierSnapshotError(
+                "sealed workspace contains external Git object authority",
+                code="snapshot_tampered",
+            )
+        for current, directories, files in os.walk(repository):
+            current_path = Path(current)
+            if current_path == repository:
+                directories.remove(".git")
+                continue
+            if ".git" in directories or ".git" in files:
+                raise VerifierSnapshotError(
+                    "sealed workspace contains an embedded Git repository",
+                    code="snapshot_tampered",
+                )
+        with tempfile.TemporaryDirectory(
+            prefix="breadboard-sealed-diff-"
+        ) as temporary_text:
+            temporary = Path(temporary_text)
+            private_git_directory = temporary / "git"
+            template_directory = temporary / "template"
+            template_directory.mkdir(mode=0o700)
+            base_environment = {
+                "GIT_ATTR_NOSYSTEM": "1",
                 "GIT_CONFIG_GLOBAL": os.devnull,
                 "GIT_CONFIG_NOSYSTEM": "1",
-                "GIT_INDEX_FILE": os.path.join(temporary, "index"),
                 "GIT_OPTIONAL_LOCKS": "0",
                 "GIT_TERMINAL_PROMPT": "0",
-                "HOME": temporary,
+                "HOME": temporary_text,
                 "LANG": "C",
                 "LC_ALL": "C",
                 "PATH": os.pathsep.join(
                     (os.path.dirname(git_path), "/usr/local/bin", "/usr/bin", "/bin")
                 ),
             }
+            returncode, _, stderr = invoke(
+                (
+                    "init",
+                    "--quiet",
+                    "--bare",
+                    f"--template={template_directory}",
+                    str(private_git_directory),
+                ),
+                environment=base_environment,
+                stdout_limit=64 * 1024,
+                cwd=temporary,
+            )
+            if returncode != 0:
+                raise VerifierSnapshotError(
+                    "sealed workspace diff repository initialization failed",
+                    code="snapshot_tampered",
+                    details={"stderr": stderr.decode("utf-8", "replace")[:4096]},
+                )
+            attributes_directory = private_git_directory / "info"
+            attributes_directory.mkdir(mode=0o700, exist_ok=True)
+            (attributes_directory / "attributes").write_text(
+                "* -text -filter -diff -working-tree-encoding -eol\n",
+                encoding="utf-8",
+            )
+            environment = {
+                **base_environment,
+                "GIT_ALTERNATE_OBJECT_DIRECTORIES": str(source_objects),
+                "GIT_DIR": str(private_git_directory),
+                "GIT_INDEX_FILE": str(temporary / "index"),
+                "GIT_NO_REPLACE_OBJECTS": "1",
+                "GIT_OBJECT_DIRECTORY": str(private_git_directory / "objects"),
+                "GIT_WORK_TREE": str(repository),
+            }
             common = (
-                "-c", "core.attributesFile=/dev/null",
-                "-c", "core.hooksPath=/dev/null",
-                "-c", "diff.external=",
+                "-c",
+                "core.autocrlf=false",
+                "-c",
+                "core.hooksPath=/dev/null",
+                "-c",
+                "core.safecrlf=false",
+                "-c",
+                "diff.external=",
             )
             for command in (
                 (*common, "read-tree", base_commit),
-                (*common, "add", "--intent-to-add", "--force", "--", "."),
+                (
+                    *common,
+                    "add",
+                    "--all",
+                    "--force",
+                    "--",
+                    ".",
+                    ":(top,exclude).git",
+                ),
             ):
                 returncode, _, stderr = invoke(
                     command, environment=environment, stdout_limit=64 * 1024
@@ -1167,9 +1307,18 @@ def _sealed_repository_diff(
                     )
             returncode, stdout, stderr = invoke(
                 (
-                    *common, "diff", "--no-ext-diff", "--no-textconv", "--binary",
-                    "--full-index", "--no-renames", "--ignore-submodules=none",
-                    base_commit, "--", ".",
+                    *common,
+                    "diff",
+                    "--cached",
+                    "--no-ext-diff",
+                    "--no-textconv",
+                    "--binary",
+                    "--full-index",
+                    "--no-renames",
+                    "--ignore-submodules=none",
+                    base_commit,
+                    "--",
+                    ".",
                 ),
                 environment=environment,
                 stdout_limit=plan.limits.artifact_bytes_each,
@@ -2245,9 +2394,17 @@ class SandboxWorkspaceLease:
             self._assert_active()
             await self._fence_and_drain(WorkspaceLeaseState.QUIESCING)
             runtime_steps = await self._runtime.terminate()
-            if any(step.state not in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED} for step in runtime_steps):
+            if any(
+                step.state
+                not in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
+                for step in runtime_steps
+            ):
                 self._state = WorkspaceLeaseState.QUARANTINED
-                raise VerifierSnapshotError("runtime did not quiesce", code="snapshot_not_quiescent", lease_id=self.lease_id)
+                raise VerifierSnapshotError(
+                    "runtime did not quiesce",
+                    code="snapshot_not_quiescent",
+                    lease_id=self.lease_id,
+                )
             base_commit = getattr(self._runtime, "repository_base_commit", None)
             relative_path = getattr(self._runtime, "repository_relative_path", None)
             if (base_commit is None) != (relative_path is None):
@@ -2256,19 +2413,6 @@ class SandboxWorkspaceLease:
                     "workspace base authority is incomplete",
                     code="snapshot_tampered",
                     lease_id=self.lease_id,
-                )
-            sealed_diff: Mapping[str, Any] | None = None
-            if base_commit is not None:
-                repository = (
-                    self._materialized.workspace_path
-                    if relative_path == "."
-                    else self._resolve(relative_path)
-                )
-                sealed_diff = await asyncio.to_thread(
-                    _sealed_repository_diff,
-                    repository=repository,
-                    base_commit=base_commit,
-                    plan=self.plan,
                 )
             try:
                 seal_task = asyncio.create_task(
@@ -2306,7 +2450,34 @@ class SandboxWorkspaceLease:
                         self._state = WorkspaceLeaseState.QUARANTINED
                     raise
                 self._manager._snapshots[receipt.snapshot_id] = (receipt, path)
-                if sealed_diff is not None:
+                if base_commit is not None:
+                    snapshot_repository = (
+                        path if relative_path == "." else path.joinpath(*_workspace_parts(relative_path))
+                    )
+                    diff_task = asyncio.create_task(
+                        asyncio.to_thread(
+                            _sealed_repository_diff,
+                            repository=snapshot_repository,
+                            base_commit=base_commit,
+                            plan=self.plan,
+                        )
+                    )
+                    try:
+                        sealed_diff = await asyncio.shield(diff_task)
+                    except BaseException:
+                        try:
+                            await diff_task
+                        except BaseException:
+                            pass
+                        snapshot_cleanup = await self._manager._release_snapshot(
+                            receipt.snapshot_id
+                        )
+                        if snapshot_cleanup.state not in {
+                            CleanupState.RELEASED,
+                            CleanupState.ALREADY_RELEASED,
+                        }:
+                            self._state = WorkspaceLeaseState.QUARANTINED
+                        raise
                     patch_bytes = sealed_diff["stdout"].encode("utf-8")
                     self._sealed_workspace_diff = MappingProxyType(
                         {
@@ -2320,7 +2491,9 @@ class SandboxWorkspaceLease:
                 return receipt
             except Exception as exc:
                 self._state = WorkspaceLeaseState.QUARANTINED
-                raise VerifierSnapshotError("verifier snapshot failed", code=str(exc), lease_id=self.lease_id) from exc
+                raise VerifierSnapshotError(
+                    "verifier snapshot failed", code=str(exc), lease_id=self.lease_id
+                ) from exc
 
     async def close(self) -> SandboxCleanupReceipt:
         return await self._close_shared()

--- a/breadboard/rl/harness/sandbox.py
+++ b/breadboard/rl/harness/sandbox.py
@@ -56,7 +56,7 @@ VERIFIER_REQUEST_SCHEMA_VERSION = "bb.rl.verifier-request.v1"
 SANDBOX_CAPABILITY_MATRIX_RESOURCE = "SANDBOX_CAPABILITY_MATRIX.json"
 SANDBOX_CAPABILITY_MATRIX_SCHEMA_VERSION = "bb.rl.sandbox-capability-matrix.v1"
 SANDBOX_CAPABILITY_MATRIX_SHA256 = (
-    "996389caba529c555c1d6755aeda0727ade5d29ae7fd83b0e1da51643dee7538"
+    "c24e24766e0e34527af921ba3794b06da4bec468df0e059e90e5deb0a20147df"
 )
 _MAX_SANDBOX_CAPABILITY_MATRIX_BYTES = 64 * 1024
 _SANDBOX_ADAPTER_STATUSES = {
@@ -1076,6 +1076,7 @@ class RuntimeHandle(Protocol):
 def _sealed_repository_diff(
     *,
     repository: Path,
+    scratch_directory: Path,
     base_commit: str,
     plan: SandboxExecutionPlan,
 ) -> Mapping[str, Any]:
@@ -1228,8 +1229,15 @@ def _sealed_repository_diff(
                     "sealed workspace contains an embedded Git repository",
                     code="snapshot_tampered",
                 )
+        scratch_identity = scratch_directory.stat(follow_symlinks=False)
+        if not stat.S_ISDIR(scratch_identity.st_mode):
+            raise VerifierSnapshotError(
+                "sealed workspace scratch authority is invalid",
+                code="snapshot_tampered",
+            )
         with tempfile.TemporaryDirectory(
-            prefix="breadboard-sealed-diff-"
+            prefix=".breadboard-sealed-diff-",
+            dir=scratch_directory,
         ) as temporary_text:
             temporary = Path(temporary_text)
             private_git_directory = temporary / "git"
@@ -2472,6 +2480,7 @@ class SandboxWorkspaceLease:
                         asyncio.to_thread(
                             _sealed_repository_diff,
                             repository=snapshot_repository,
+                            scratch_directory=self._materialized.workspace_path,
                             base_commit=base_commit,
                             plan=self.plan,
                         )

--- a/breadboard/rl/harness/sandbox_docker.py
+++ b/breadboard/rl/harness/sandbox_docker.py
@@ -2132,6 +2132,7 @@ class DockerRuntimeHandle:
         mount_stager: DockerDescriptorMountStager | None = None,
         staged_mounts: Sequence[StagedDockerDescriptorMount] = (),
         lease_id: str | None = None,
+        launch_complete: bool = True,
     ) -> None:
         self.adapter = adapter
         self.plan = plan
@@ -2147,8 +2148,17 @@ class DockerRuntimeHandle:
         self._mount_stager = mount_stager
         self._staged_mounts = list(staged_mounts)
         self._lease_id = lease_id
+        self._launching = not launch_complete
         self.repository_base_commit: str | None = None
         self.repository_relative_path: str | None = None
+    def complete_launch(self) -> None:
+        if self._closed or not self._launching:
+            raise DockerAdapterError(
+                "runtime_preflight_failed",
+                "Docker runtime launch ownership is not exact",
+            )
+        self._launching = False
+
 
     def _record_terminal_cleanup(self, receipts: tuple[Any, ...]) -> None:
         from .materialization import CleanupState
@@ -2183,7 +2193,7 @@ class DockerRuntimeHandle:
                 exc.code == "output_limit_exceeded"
                 or (exc.code == "runtime_launch_failed" and "returncode" not in exc.details)
             )
-            if indeterminate:
+            if indeterminate and not self._launching:
                 self._fenced = True
                 cleanup = await asyncio.shield(self._retry_cleanup())
                 if isinstance(exc, DockerAdapterError):
@@ -3008,6 +3018,7 @@ class DockerSandboxBackend:
                 container_name=container_name, labels=labels, held_fds=held_fds,
                 mount_stager=self.mount_stager, staged_mounts=staged_mounts,
                 lease_id=context.lease_id,
+                launch_complete=False,
             )
             repository_base_commit = await handle.measure_repository_base_commit()
             if repository_base_commit is not None:
@@ -3024,7 +3035,9 @@ class DockerSandboxBackend:
                     "effective Docker controls contradict requested controls",
                     details={"mismatch": mismatch},
                 )
+            handle.complete_launch()
             held_fds = []
+            staged_mounts = []
             return handle, SandboxMeasurement(
                 effective_plan_digest=plan.effective_plan_digest,
                 lease_id=context.lease_id, workspace_id=context.workspace_id,

--- a/breadboard/rl/harness/sandbox_docker.py
+++ b/breadboard/rl/harness/sandbox_docker.py
@@ -24,9 +24,8 @@ def _container_workspace_path(logical_path: str) -> str:
     if type(logical_path) is not str or not logical_path or "\x00" in logical_path:
         raise DockerAdapterError("workspace_escape", "workspace path is invalid")
     path = PurePosixPath(logical_path)
-    if (
-        path.is_absolute()
-        or any(part in {"", ".", ".."} for part in logical_path.split("/"))
+    if path.is_absolute() or any(
+        part in {"", ".", ".."} for part in logical_path.split("/")
     ):
         raise DockerAdapterError("workspace_escape", "workspace path is invalid")
     return f"{CONTAINER_WORKSPACE_ROOT}/{path.as_posix()}"
@@ -421,9 +420,7 @@ class SubprocessDockerCliExecutor:
             env=dict(environment),
             start_new_session=True,
             stdin=(
-                asyncio.subprocess.PIPE
-                if input_bytes
-                else asyncio.subprocess.DEVNULL
+                asyncio.subprocess.PIPE if input_bytes else asyncio.subprocess.DEVNULL
             ),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -478,8 +475,7 @@ class SubprocessDockerCliExecutor:
                     raise
             deadline = asyncio.get_running_loop().time() + 0.25
             while (
-                process_group_exists()
-                and asyncio.get_running_loop().time() < deadline
+                process_group_exists() and asyncio.get_running_loop().time() < deadline
             ):
                 await asyncio.sleep(0.01)
             if process_group_exists():
@@ -492,8 +488,7 @@ class SubprocessDockerCliExecutor:
                         raise
             deadline = asyncio.get_running_loop().time() + 0.75
             while (
-                process_group_exists()
-                and asyncio.get_running_loop().time() < deadline
+                process_group_exists() and asyncio.get_running_loop().time() < deadline
             ):
                 await asyncio.sleep(0.01)
             if process_group_exists():
@@ -540,13 +535,19 @@ class SubprocessDockerCliExecutor:
                         task.cancel()
                     await asyncio.gather(*io_tasks, return_exceptions=True)
         return DockerCommandResult(
-            logical_argv, process.returncode, bytes(captured[0]), bytes(captured[1]),
-            timed_out=timed_out, output_limited=limited,
+            logical_argv,
+            process.returncode,
+            bytes(captured[0]),
+            bytes(captured[1]),
+            timed_out=timed_out,
+            output_limited=limited,
         )
 
 
 class DockerAdapterError(RuntimeError):
-    def __init__(self, code: str, message: str, *, details: Mapping[str, Any] | None = None) -> None:
+    def __init__(
+        self, code: str, message: str, *, details: Mapping[str, Any] | None = None
+    ) -> None:
         super().__init__(message)
         self.code = code
         self.details = dict(details or {})
@@ -559,16 +560,14 @@ def observe_binary_digest(path: str | Path) -> str:
             hasher.update(chunk)
     return "sha256:" + hasher.hexdigest()
 
+
 _O_PATH = getattr(os, "O_PATH", 0o10000000)
 _RESOLVE_NO_XDEV = 0x01
 _RESOLVE_NO_MAGICLINKS = 0x02
 _RESOLVE_NO_SYMLINKS = 0x04
 _RESOLVE_BENEATH = 0x08
 _OPENAT2_RESOLVE = (
-    _RESOLVE_BENEATH
-    | _RESOLVE_NO_SYMLINKS
-    | _RESOLVE_NO_MAGICLINKS
-    | _RESOLVE_NO_XDEV
+    _RESOLVE_BENEATH | _RESOLVE_NO_SYMLINKS | _RESOLVE_NO_MAGICLINKS | _RESOLVE_NO_XDEV
 )
 
 
@@ -626,8 +625,6 @@ def _openat2_beneath(
     return int(result)
 
 
-
-
 def _validate_mount_descriptor(
     descriptor: int,
     *,
@@ -652,7 +649,13 @@ def _validate_mount_descriptor(
 
 
 _CONTAINER_ID = re.compile(r"[0-9a-f]{64}")
-_IDENTITY_LABELS = ("bb.lease_id", "bb.plan_digest", "bb.epoch", "bb.workspace_id", "bb.role")
+_IDENTITY_LABELS = (
+    "bb.lease_id",
+    "bb.plan_digest",
+    "bb.epoch",
+    "bb.workspace_id",
+    "bb.role",
+)
 
 
 def _regular_file_metadata_identity(metadata: os.stat_result) -> tuple[int, ...]:
@@ -719,11 +722,9 @@ def _bounded_regular_file_descriptor_bytes(
             "runtime_preflight_failed",
             "security profile descriptor changed while reading",
         ) from exc
-    if (
-        extra
-        or _regular_file_metadata_identity(after)
-        != _regular_file_metadata_identity(before)
-    ):
+    if extra or _regular_file_metadata_identity(
+        after
+    ) != _regular_file_metadata_identity(before):
         raise DockerAdapterError(
             "runtime_preflight_failed",
             "security profile descriptor metadata changed while reading",
@@ -759,6 +760,7 @@ def _mount_argument(source: str, destination: str, *, readonly: bool) -> str:
     value = f"type=bind,src={source},dst={destination}"
     return value + (",readonly" if readonly else "")
 
+
 def _tmpfs_argument(destination: str, options: str) -> str:
     if (
         type(destination) is not str
@@ -766,7 +768,9 @@ def _tmpfs_argument(destination: str, options: str) -> str:
         or any(character in destination for character in ("\x00", "\\", ",", ":"))
         or any(part in {"", ".", ".."} for part in destination.split("/")[1:])
     ):
-        raise DockerAdapterError("runtime_preflight_failed", "invalid tmpfs destination")
+        raise DockerAdapterError(
+            "runtime_preflight_failed", "invalid tmpfs destination"
+        )
     tokens = options.split(",") if type(options) is str else []
     if not tokens or len(tokens) != len(set(tokens)):
         raise DockerAdapterError("runtime_preflight_failed", "invalid tmpfs options")
@@ -775,10 +779,20 @@ def _tmpfs_argument(destination: str, options: str) -> str:
     flags = {token for token in tokens if "=" not in token}
     assignments = [token for token in tokens if "=" in token]
     if flags < required_flags or not flags <= allowed_flags or len(assignments) != 1:
-        raise DockerAdapterError("runtime_preflight_failed", "tmpfs options are not closed and bounded")
+        raise DockerAdapterError(
+            "runtime_preflight_failed", "tmpfs options are not closed and bounded"
+        )
     key, separator, value = assignments[0].partition("=")
-    if key != "size" or separator != "=" or not value.isascii() or not value.isdigit() or int(value) <= 0:
-        raise DockerAdapterError("runtime_preflight_failed", "tmpfs size must be a positive byte count")
+    if (
+        key != "size"
+        or separator != "="
+        or not value.isascii()
+        or not value.isdigit()
+        or int(value) <= 0
+    ):
+        raise DockerAdapterError(
+            "runtime_preflight_failed", "tmpfs size must be a positive byte count"
+        )
     return f"{destination}:{options}"
 
 
@@ -820,7 +834,9 @@ def _validate_mount_authority(
             raise DockerAdapterError(
                 "runtime_preflight_failed", "duplicate Docker mount destination"
             )
-        pending = [child for key, child in node.items() if key and isinstance(child, dict)]
+        pending = [
+            child for key, child in node.items() if key and isinstance(child, dict)
+        ]
         descendants: list[tuple[bool, str]] = []
         while pending and not descendants:
             child = pending.pop()
@@ -856,7 +872,8 @@ def _validate_lsm_policy(security: Any) -> None:
             or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", apparmor) is None
         ):
             raise DockerAdapterError(
-                "runtime_preflight_failed", "AppArmor authority is disabling or malformed"
+                "runtime_preflight_failed",
+                "AppArmor authority is disabling or malformed",
             )
     elif selinux is not None:
         if (
@@ -866,15 +883,26 @@ def _validate_lsm_policy(security: Any) -> None:
             or re.fullmatch(r"[A-Za-z0-9_.:-]{3,255}", selinux) is None
         ):
             raise DockerAdapterError(
-                "runtime_preflight_failed", "SELinux authority is disabling or malformed"
+                "runtime_preflight_failed",
+                "SELinux authority is disabling or malformed",
             )
     else:
-        raise DockerAdapterError("runtime_preflight_failed", "an exact LSM authority is mandatory")
+        raise DockerAdapterError(
+            "runtime_preflight_failed", "an exact LSM authority is mandatory"
+        )
 
 
-def build_create_argv(plan: Any, *, lease_id: str, workspace_id: str, epoch: int,
-                      role: str, skeleton_path: Path,
-                      mounts: Sequence[tuple[Path, str, bool]], security_profile_path: Path) -> tuple[str, ...]:
+def build_create_argv(
+    plan: Any,
+    *,
+    lease_id: str,
+    workspace_id: str,
+    epoch: int,
+    role: str,
+    skeleton_path: Path,
+    mounts: Sequence[tuple[Path, str, bool]],
+    security_profile_path: Path,
+) -> tuple[str, ...]:
     runtime = plan.runtime
     security = plan.security_policy
     network = plan.network_policy
@@ -887,16 +915,26 @@ def build_create_argv(plan: Any, *, lease_id: str, workspace_id: str, epoch: int
         or not network.default_deny
         or network.egress_route_ids
     ):
-        raise DockerAdapterError("runtime_unsupported", "only Docker network none is supported")
+        raise DockerAdapterError(
+            "runtime_unsupported", "only Docker network none is supported"
+        )
     if (
         type(security.uid) is not int
         or type(security.gid) is not int
         or security.uid <= 0
         or security.gid <= 0
     ):
-        raise DockerAdapterError("runtime_preflight_failed", "numeric non-root identity is mandatory")
-    if not security.read_only_root or not security.drop_all_capabilities or not security.no_new_privileges:
-        raise DockerAdapterError("runtime_preflight_failed", "hardened security flags are mandatory")
+        raise DockerAdapterError(
+            "runtime_preflight_failed", "numeric non-root identity is mandatory"
+        )
+    if (
+        not security.read_only_root
+        or not security.drop_all_capabilities
+        or not security.no_new_privileges
+    ):
+        raise DockerAdapterError(
+            "runtime_preflight_failed", "hardened security flags are mandatory"
+        )
     if security.namespace_flags:
         raise DockerAdapterError(
             "runtime_preflight_failed",
@@ -916,38 +954,60 @@ def build_create_argv(plan: Any, *, lease_id: str, workspace_id: str, epoch: int
     for key in _IDENTITY_LABELS:
         argv += ["--label", f"{key}={labels[key]}"]
     argv += [
-        "--runtime", runtime.oci_runtime_name,
-        "--network", "none",
-        "--cgroupns", "private",
-        "--ipc", "private",
-        "--user", f"{security.uid}:{security.gid}",
+        "--runtime",
+        runtime.oci_runtime_name,
+        "--network",
+        "none",
+        "--cgroupns",
+        "private",
+        "--ipc",
+        "private",
+        "--user",
+        f"{security.uid}:{security.gid}",
         "--read-only",
-        "--cap-drop", "ALL",
-        "--security-opt", "no-new-privileges",
-        "--security-opt", f"seccomp={security_profile_path}",
+        "--cap-drop",
+        "ALL",
+        "--security-opt",
+        "no-new-privileges",
+        "--security-opt",
+        f"seccomp={security_profile_path}",
     ]
     if security.apparmor_profile is not None:
         argv += ["--security-opt", f"apparmor={security.apparmor_profile}"]
     elif security.selinux_label is not None:
         argv += ["--security-opt", f"label={security.selinux_label}"]
     argv += [
-        "--pids-limit", str(resources.pids),
-        "--memory", str(resources.memory_bytes),
-        "--memory-swap", str(resources.memory_bytes),
-        "--cpu-period", "100000",
-        "--cpu-quota", str(resources.cpu_millis * 100),
-        "--ulimit", f"nofile={resources.open_files}:{resources.open_files}",
-        "--mount", _mount_argument(str(skeleton_path), CONTAINER_WORKSPACE_ROOT, readonly=True),
+        "--pids-limit",
+        str(resources.pids),
+        "--memory",
+        str(resources.memory_bytes),
+        "--memory-swap",
+        str(resources.memory_bytes),
+        "--cpu-period",
+        "100000",
+        "--cpu-quota",
+        str(resources.cpu_millis * 100),
+        "--ulimit",
+        f"nofile={resources.open_files}:{resources.open_files}",
+        "--mount",
+        _mount_argument(str(skeleton_path), CONTAINER_WORKSPACE_ROOT, readonly=True),
     ]
     destinations: set[str] = {CONTAINER_WORKSPACE_ROOT}
     for source, destination, readonly in sorted(mounts, key=lambda item: item[1]):
         if destination in destinations:
-            raise DockerAdapterError("runtime_preflight_failed", "duplicate Docker mount destination")
+            raise DockerAdapterError(
+                "runtime_preflight_failed", "duplicate Docker mount destination"
+            )
         destinations.add(destination)
-        argv += ["--mount", _mount_argument(str(source), destination, readonly=readonly)]
+        argv += [
+            "--mount",
+            _mount_argument(str(source), destination, readonly=readonly),
+        ]
     for destination, options in security.tmpfs_mounts:
         if destination in destinations:
-            raise DockerAdapterError("runtime_preflight_failed", "duplicate Docker mount destination")
+            raise DockerAdapterError(
+                "runtime_preflight_failed", "duplicate Docker mount destination"
+            )
         destinations.add(destination)
         argv += ["--tmpfs", _tmpfs_argument(destination, options)]
     argv += ["--workdir", CONTAINER_WORKSPACE_ROOT]
@@ -955,7 +1015,9 @@ def build_create_argv(plan: Any, *, lease_id: str, workspace_id: str, epoch: int
         argv += ["--env", f"{key}={value}"]
     argv += ["--pull", "never", plan.image.image_digest, *runtime.idle_argv]
     if any("docker.sock" in value for value in argv):
-        raise DockerAdapterError("runtime_preflight_failed", "forbidden Docker authority")
+        raise DockerAdapterError(
+            "runtime_preflight_failed", "forbidden Docker authority"
+        )
     return tuple(argv)
 
 
@@ -963,18 +1025,26 @@ def _json_object(payload: bytes, *, label: str) -> dict[str, Any]:
     try:
         value = json.loads(payload.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise DockerAdapterError("runtime_preflight_failed", f"Docker {label} output is malformed") from exc
+        raise DockerAdapterError(
+            "runtime_preflight_failed", f"Docker {label} output is malformed"
+        ) from exc
     if type(value) is not dict:
-        raise DockerAdapterError("runtime_preflight_failed", f"Docker {label} output has an unexpected schema")
+        raise DockerAdapterError(
+            "runtime_preflight_failed",
+            f"Docker {label} output has an unexpected schema",
+        )
     return value
 
 
-def _registered_runtime(info: Mapping[str, Any], runtime_name: str) -> Mapping[str, Any] | None:
+def _registered_runtime(
+    info: Mapping[str, Any], runtime_name: str
+) -> Mapping[str, Any] | None:
     if "Error" in info:
         return None
     runtimes = info.get("Runtimes")
     if type(runtimes) is not dict or any(
-        type(key) is not str or type(value) is not dict for key, value in runtimes.items()
+        type(key) is not str or type(value) is not dict
+        for key, value in runtimes.items()
     ):
         return None
     return runtimes.get(runtime_name)
@@ -984,10 +1054,15 @@ def _image_identity_matches(payload: bytes, expected_digest: str) -> bool:
     try:
         value = json.loads(payload.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise DockerAdapterError("runtime_preflight_failed", "Docker image output is malformed") from exc
+        raise DockerAdapterError(
+            "runtime_preflight_failed", "Docker image output is malformed"
+        ) from exc
     if type(value) is list:
         if len(value) != 1 or type(value[0]) is not dict:
-            raise DockerAdapterError("runtime_preflight_failed", "Docker image output has an unexpected schema")
+            raise DockerAdapterError(
+                "runtime_preflight_failed",
+                "Docker image output has an unexpected schema",
+            )
         value = value[0]
     if type(value) is not dict or "Error" in value:
         return False
@@ -1002,7 +1077,8 @@ def _image_identity_matches(payload: bytes, expected_digest: str) -> bool:
         return False
     id_matches = type(image_id) is str and image_id == expected_digest
     refs_match = type(repo_digests) is list and any(
-        reference.rpartition("@")[1] == "@" and reference.rpartition("@")[2] == expected_digest
+        reference.rpartition("@")[1] == "@"
+        and reference.rpartition("@")[2] == expected_digest
         for reference in repo_digests
     )
     return id_matches or refs_match
@@ -1011,14 +1087,20 @@ def _image_identity_matches(payload: bytes, expected_digest: str) -> bool:
 def _platform_version(payload: Mapping[str, Any]) -> str:
     server = payload.get("Server")
     if type(server) is not dict:
-        raise DockerAdapterError("runtime_unsupported", "Docker server version is unavailable")
+        raise DockerAdapterError(
+            "runtime_unsupported", "Docker server version is unavailable"
+        )
     platform = server.get("Platform")
     if type(platform) is not dict:
-        raise DockerAdapterError("runtime_unsupported", "Docker server platform is unavailable")
+        raise DockerAdapterError(
+            "runtime_unsupported", "Docker server platform is unavailable"
+        )
     name = platform.get("Name")
     version = server.get("Version")
     if type(name) is not str or not name or type(version) is not str or not version:
-        raise DockerAdapterError("runtime_unsupported", "Docker server platform version is malformed")
+        raise DockerAdapterError(
+            "runtime_unsupported", "Docker server platform version is malformed"
+        )
     return f"{name}/{version}"
 
 
@@ -1031,7 +1113,8 @@ def _inspect_object(payload: bytes) -> dict[str, Any]:
         ) from exc
     if type(decoded) is not list or len(decoded) != 1 or type(decoded[0]) is not dict:
         raise DockerAdapterError(
-            "runtime_measurement_mismatch", "Docker inspect output has an unexpected schema"
+            "runtime_measurement_mismatch",
+            "Docker inspect output has an unexpected schema",
         )
     return decoded[0]
 
@@ -1057,7 +1140,10 @@ def _observed_identity(payload: bytes) -> tuple[str, str, Mapping[str, str]]:
         or type(name) is not str
         or not name.startswith("/")
         or type(labels) is not dict
-        or any(type(key) is not str or type(value) is not str for key, value in labels.items())
+        or any(
+            type(key) is not str or type(value) is not str
+            for key, value in labels.items()
+        )
     ):
         raise DockerAdapterError(
             "runtime_measurement_mismatch", "Docker inspect identity is malformed"
@@ -1073,14 +1159,17 @@ def _validate_identity(
     expected_labels: Mapping[str, str],
 ) -> str:
     container_id, name, labels = _observed_identity(payload)
-    observed_binding = {key: value for key, value in labels.items() if key.startswith("bb.")}
+    observed_binding = {
+        key: value for key, value in labels.items() if key.startswith("bb.")
+    }
     if (
         (expected_id is not None and container_id != expected_id)
         or name != expected_name
         or observed_binding != dict(expected_labels)
     ):
         raise DockerAdapterError(
-            "stale_identity_uncertain", "Docker container identity does not match its binding"
+            "stale_identity_uncertain",
+            "Docker container identity does not match its binding",
         )
     return container_id
 
@@ -1134,7 +1223,8 @@ def decode_docker_inspect(
         or host.get("Tmpfs") != expected_tmpfs
     ):
         raise DockerAdapterError(
-            "runtime_measurement_mismatch", "Docker inspect security schema is not closed"
+            "runtime_measurement_mismatch",
+            "Docker inspect security schema is not closed",
         )
     expected_security = {
         "no-new-privileges",
@@ -1147,11 +1237,15 @@ def decode_docker_inspect(
         expected_security.add(f"label={plan.security_policy.selinux_label}")
     if set(security_options) != expected_security:
         raise DockerAdapterError(
-            "runtime_measurement_mismatch", "Docker inspect security options contradict the plan"
+            "runtime_measurement_mismatch",
+            "Docker inspect security options contradict the plan",
         )
     expected_mounts = [
         (str(skeleton_path), CONTAINER_WORKSPACE_ROOT, False),
-        *[(str(source), destination, not readonly) for source, destination, readonly in mounts],
+        *[
+            (str(source), destination, not readonly)
+            for source, destination, readonly in mounts
+        ],
     ]
     observed_mounts: list[tuple[str, str, bool]] = []
     for record in mount_records:
@@ -1169,7 +1263,8 @@ def decode_docker_inspect(
             or type(writable) is not bool
         ):
             raise DockerAdapterError(
-                "runtime_measurement_mismatch", "Docker inspect mount is not a typed bind"
+                "runtime_measurement_mismatch",
+                "Docker inspect mount is not a typed bind",
             )
         observed_mounts.append((source, destination, writable))
     if sorted(observed_mounts, key=lambda value: value[1]) != sorted(
@@ -1179,7 +1274,8 @@ def decode_docker_inspect(
             "runtime_measurement_mismatch", "Docker inspect mounts contradict the plan"
         )
     nofile = [
-        value for value in ulimits
+        value
+        for value in ulimits
         if type(value) is dict and value.get("Name") == "nofile"
     ]
     if len(nofile) != 1:
@@ -1201,7 +1297,9 @@ def decode_docker_inspect(
         ),
         "mount_sources": tuple(
             (str(source), destination, readonly)
-            for source, destination, readonly in sorted(mounts, key=lambda value: value[1])
+            for source, destination, readonly in sorted(
+                mounts, key=lambda value: value[1]
+            )
         ),
         "workspace_root": str(skeleton_path),
         "tmpfs": tuple(sorted(plan.security_policy.tmpfs_mounts)),
@@ -1242,7 +1340,8 @@ def decode_docker_inspect(
         or host.get("UTSMode") != ""
     ):
         raise DockerAdapterError(
-            "runtime_measurement_mismatch", "Docker inspect image or privilege state contradicts the plan"
+            "runtime_measurement_mismatch",
+            "Docker inspect image or privilege state contradicts the plan",
         )
     return values
 
@@ -1384,7 +1483,8 @@ class PrivateDockerDaemonBinding:
                 self.daemon_executable_size,
                 self.config_size,
                 self.runtime_size,
-            ) <= 0
+            )
+            <= 0
             or type(self.daemon_pid) is not int
             or self.daemon_pid <= 0
             or type(self.daemon_starttime) is not str
@@ -1558,7 +1658,14 @@ def _require_daemon_runtime_binding(
 
 
 class DockerRuntimeAdapter:
-    def __init__(self, *, executor: DockerCliExecutor, cli_environment: tuple[tuple[str, str], ...], mechanics_invocation: ExecutableInvocation | None = None, daemon_binding: PrivateDockerDaemonBinding | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        executor: DockerCliExecutor,
+        cli_environment: tuple[tuple[str, str], ...],
+        mechanics_invocation: ExecutableInvocation | None = None,
+        daemon_binding: PrivateDockerDaemonBinding | None = None,
+    ) -> None:
         if cli_environment:
             raise ValueError(
                 "Docker CLI mechanics environment must be empty; container environment is projected at create"
@@ -1573,18 +1680,26 @@ class DockerRuntimeAdapter:
             or mechanics_invocation.executable_fd < 0
             or not mechanics_invocation.executable_descriptor_path
         ):
-            raise ValueError("mechanics invocation must identify an inherited executable descriptor")
+            raise ValueError(
+                "mechanics invocation must identify an inherited executable descriptor"
+            )
         self._pinned: Any | None = None
         self._invocation: ExecutableInvocation | None = mechanics_invocation
 
     def _pin(self, plan: Any) -> ExecutableInvocation:
         current = self._invocation
         if current is not None:
-            if (current.argv0 != plan.runtime.executable_path
-                    or current.digest != plan.runtime.measured_binary_digest):
-                raise DockerAdapterError("runtime_preflight_failed", "Docker CLI authority changed during adapter lifetime")
+            if (
+                current.argv0 != plan.runtime.executable_path
+                or current.digest != plan.runtime.measured_binary_digest
+            ):
+                raise DockerAdapterError(
+                    "runtime_preflight_failed",
+                    "Docker CLI authority changed during adapter lifetime",
+                )
             return current
         from .sandbox import SandboxLaunchError, _snapshot_installed_executable
+
         try:
             pinned = _snapshot_installed_executable(
                 plan.runtime.executable_path, plan.runtime.measured_binary_digest
@@ -1620,10 +1735,15 @@ class DockerRuntimeAdapter:
     ) -> DockerCommandResult:
         invocation = self._invocation if plan is None else self._pin(plan)
         if invocation is None:
-            raise DockerAdapterError("runtime_preflight_failed", "Docker CLI invocation is not pinned")
+            raise DockerAdapterError(
+                "runtime_preflight_failed", "Docker CLI invocation is not pinned"
+            )
         logical = tuple(argv)
         if not logical or logical[0] != invocation.argv0:
-            raise DockerAdapterError("runtime_preflight_failed", "Docker CLI argv0 contradicts pinned authority")
+            raise DockerAdapterError(
+                "runtime_preflight_failed",
+                "Docker CLI argv0 contradicts pinned authority",
+            )
         tail = logical[1:]
         if self._daemon_binding is not None:
             self._daemon_binding.validate_live()
@@ -1649,16 +1769,27 @@ class DockerRuntimeAdapter:
             environment=self._environment,
         )
 
-    async def _execute(self, argv: Sequence[str], *, timeout_ms: int, output_limit: int,
-                       code: str = "runtime_preflight_failed") -> DockerCommandResult:
+    async def _execute(
+        self,
+        argv: Sequence[str],
+        *,
+        timeout_ms: int,
+        output_limit: int,
+        code: str = "runtime_preflight_failed",
+    ) -> DockerCommandResult:
         result = await self._raw(argv, timeout_ms=timeout_ms, output_limit=output_limit)
         if result.output_limited:
-            raise DockerAdapterError("output_limit_exceeded", "Docker CLI output exceeded the admitted limit")
+            raise DockerAdapterError(
+                "output_limit_exceeded", "Docker CLI output exceeded the admitted limit"
+            )
         if result.timed_out:
             raise DockerAdapterError(code, "Docker CLI operation timed out")
         if result.returncode:
-            raise DockerAdapterError(code, "Docker CLI operation failed",
-                                     details={"returncode": result.returncode})
+            raise DockerAdapterError(
+                code,
+                "Docker CLI operation failed",
+                details={"returncode": result.returncode},
+            )
         return result
 
     async def preflight(self, plan: Any) -> DockerPreflightObservation:
@@ -1667,20 +1798,30 @@ class DockerRuntimeAdapter:
         output_limit = plan.limits.observation_bytes
         version = await self._execute(
             (invocation.argv0, "version", "--format", "{{json .}}"),
-            timeout_ms=plan.limits.action_timeout_ms, output_limit=output_limit,
+            timeout_ms=plan.limits.action_timeout_ms,
+            output_limit=output_limit,
         )
         version_payload = _json_object(version.stdout, label="version")
         platform_version = _platform_version(version_payload)
-        if not runtime.supported_platform_versions or platform_version not in runtime.supported_platform_versions:
-            raise DockerAdapterError("runtime_unsupported", "Docker server platform version is not installed authority")
+        if (
+            not runtime.supported_platform_versions
+            or platform_version not in runtime.supported_platform_versions
+        ):
+            raise DockerAdapterError(
+                "runtime_unsupported",
+                "Docker server platform version is not installed authority",
+            )
         info = await self._execute(
             (invocation.argv0, "info", "--format", "{{json .}}"),
-            timeout_ms=plan.limits.action_timeout_ms, output_limit=output_limit,
+            timeout_ms=plan.limits.action_timeout_ms,
+            output_limit=output_limit,
         )
         info_payload = _json_object(info.stdout, label="info")
         registration = _registered_runtime(info_payload, runtime.oci_runtime_name)
         if registration is None:
-            raise DockerAdapterError("runtime_unsupported", "requested OCI runtime is not registered")
+            raise DockerAdapterError(
+                "runtime_unsupported", "requested OCI runtime is not registered"
+            )
         advertised = registration.get("path")
         arguments = registration.get("runtimeArgs", [])
         authority_path = runtime.oci_runtime_binary_path
@@ -1706,6 +1847,7 @@ class DockerRuntimeAdapter:
                     "OCI runtime registration is not installed authority",
                 )
             from .sandbox import _open_installed_regular
+
             descriptor = -1
             try:
                 descriptor = _open_installed_regular(authority_path)
@@ -1735,24 +1877,37 @@ class DockerRuntimeAdapter:
                 )
             observed_digest = binding.runtime_digest
         if observed_digest != authority_digest:
-            raise DockerAdapterError("runtime_preflight_failed", "registered OCI runtime binary identity mismatch")
+            raise DockerAdapterError(
+                "runtime_preflight_failed",
+                "registered OCI runtime binary identity mismatch",
+            )
         if runtime.runtime_class.value == "hardened_gvisor" and (
             runtime.runsc_binary_path != authority_path
             or runtime.runsc_binary_digest != observed_digest
         ):
-            raise DockerAdapterError("runtime_unsupported", "runsc authority is contradictory")
+            raise DockerAdapterError(
+                "runtime_unsupported", "runsc authority is contradictory"
+            )
         image = await self._execute(
             (invocation.argv0, "image", "inspect", plan.image.image_digest),
-            timeout_ms=plan.limits.action_timeout_ms, output_limit=output_limit,
+            timeout_ms=plan.limits.action_timeout_ms,
+            output_limit=output_limit,
         )
         if not _image_identity_matches(image.stdout, plan.image.image_digest):
-            raise DockerAdapterError("runtime_preflight_failed", "immutable image identity mismatch")
+            raise DockerAdapterError(
+                "runtime_preflight_failed", "immutable image identity mismatch"
+            )
         return DockerPreflightObservation(
-            docker_cli_digest=invocation.digest, platform_version=platform_version,
-            runtime_name=runtime.oci_runtime_name, advertised_path=advertised,
-            observed_oci_digest=observed_digest, observed_oci_device=metadata.st_dev,
-            observed_oci_inode=metadata.st_ino, version_payload=version.stdout,
-            info_payload=info.stdout, image_payload=image.stdout,
+            docker_cli_digest=invocation.digest,
+            platform_version=platform_version,
+            runtime_name=runtime.oci_runtime_name,
+            advertised_path=advertised,
+            observed_oci_digest=observed_digest,
+            observed_oci_device=metadata.st_dev,
+            observed_oci_inode=metadata.st_ino,
+            version_payload=version.stdout,
+            info_payload=info.stdout,
+            image_payload=image.stdout,
             daemon_binding=binding,
         )
 
@@ -1765,7 +1920,12 @@ class DockerRuntimeAdapter:
 
     @staticmethod
     def _is_not_found(result: DockerCommandResult, reference: str) -> bool:
-        if result.timed_out or result.output_limited or result.returncode == 0 or result.stdout.strip():
+        if (
+            result.timed_out
+            or result.output_limited
+            or result.returncode == 0
+            or result.stdout.strip()
+        ):
             return False
         stderr = result.stderr.strip()
         return stderr in {
@@ -1797,12 +1957,20 @@ class DockerRuntimeAdapter:
         except DockerAdapterError:
             return None, "stale_identity_uncertain"
 
-    async def prepare(self, plan: Any, *, lease_id: str, workspace_id: str, epoch: int,
-                      role: str, skeleton_path: Path,
-                      mounts: Sequence[tuple[Path, str, bool]],
-                      security_profile_path: Path,
-                      security_profile_descriptor: int,
-                      security_profile_metadata: os.stat_result) -> tuple[str, str, tuple[str, ...]]:
+    async def prepare(
+        self,
+        plan: Any,
+        *,
+        lease_id: str,
+        workspace_id: str,
+        epoch: int,
+        role: str,
+        skeleton_path: Path,
+        mounts: Sequence[tuple[Path, str, bool]],
+        security_profile_path: Path,
+        security_profile_descriptor: int,
+        security_profile_metadata: os.stat_result,
+    ) -> tuple[str, str, tuple[str, ...]]:
         self._pin(plan)
         profile = _bounded_regular_file_descriptor_bytes(
             security_profile_descriptor,
@@ -1814,7 +1982,9 @@ class DockerRuntimeAdapter:
             or "sha256:" + hashlib.sha256(profile).hexdigest()
             != plan.security_policy.seccomp_digest
         ):
-            raise DockerAdapterError("runtime_preflight_failed", "seccomp profile identity mismatch")
+            raise DockerAdapterError(
+                "runtime_preflight_failed", "seccomp profile identity mismatch"
+            )
         argv = build_create_argv(
             plan,
             lease_id=lease_id,
@@ -1895,12 +2065,20 @@ class DockerRuntimeAdapter:
             code="runtime_launch_failed",
         )
 
-    async def create_start(self, plan: Any, *, lease_id: str, workspace_id: str, epoch: int,
-                           role: str, skeleton_path: Path,
-                           mounts: Sequence[tuple[Path, str, bool]],
-                           security_profile_path: Path,
-                           security_profile_descriptor: int,
-                           security_profile_metadata: os.stat_result) -> tuple[str, str, tuple[str, ...]]:
+    async def create_start(
+        self,
+        plan: Any,
+        *,
+        lease_id: str,
+        workspace_id: str,
+        epoch: int,
+        role: str,
+        skeleton_path: Path,
+        mounts: Sequence[tuple[Path, str, bool]],
+        security_profile_path: Path,
+        security_profile_descriptor: int,
+        security_profile_metadata: os.stat_result,
+    ) -> tuple[str, str, tuple[str, ...]]:
         prepared = await self.prepare(
             plan,
             lease_id=lease_id,
@@ -1949,9 +2127,7 @@ class DockerRuntimeAdapter:
     ) -> Mapping[str, Any]:
         self._pin(plan)
         captured_output_limit = (
-            plan.limits.observation_bytes
-            if output_limit is None
-            else output_limit
+            plan.limits.observation_bytes if output_limit is None else output_limit
         )
         raw_argv = (
             plan.runtime.executable_path,
@@ -2020,17 +2196,25 @@ class DockerRuntimeAdapter:
             return (identity,)
         attempted: list[tuple[str, DockerCommandResult]] = []
         for resource, argv in (
-            ("runtime_stop", (plan.runtime.executable_path, "stop", "--time", "5", bound_id)),
-            ("runtime_remove", (plan.runtime.executable_path, "rm", "--force", bound_id)),
+            (
+                "runtime_stop",
+                (plan.runtime.executable_path, "stop", "--time", "5", bound_id),
+            ),
+            (
+                "runtime_remove",
+                (plan.runtime.executable_path, "rm", "--force", bound_id),
+            ),
         ):
-            attempted.append((
-                resource,
-                await self._raw(
-                    argv,
-                    timeout_ms=plan.limits.action_timeout_ms,
-                    output_limit=plan.limits.observation_bytes,
-                ),
-            ))
+            attempted.append(
+                (
+                    resource,
+                    await self._raw(
+                        argv,
+                        timeout_ms=plan.limits.action_timeout_ms,
+                        output_limit=plan.limits.observation_bytes,
+                    ),
+                )
+            )
         final = await self._inspect_raw(plan, bound_id)
         if not self._is_not_found(final, bound_id):
             reason = (
@@ -2038,12 +2222,16 @@ class DockerRuntimeAdapter:
                 if not final.timed_out and not final.output_limited
                 else "stale_identity_uncertain"
             )
-            return tuple(
-                (resource, "failed", reason) for resource, _ in attempted
-            ) + (("runtime_absence", "failed", reason),)
+            return tuple((resource, "failed", reason) for resource, _ in attempted) + (
+                ("runtime_absence", "failed", reason),
+            )
         normalized: list[tuple[str, str, str]] = []
         for resource, result in attempted:
-            if not result.timed_out and not result.output_limited and result.returncode == 0:
+            if (
+                not result.timed_out
+                and not result.output_limited
+                and result.returncode == 0
+            ):
                 normalized.append((resource, "released", ""))
             elif self._is_not_found(result, bound_id):
                 normalized.append((resource, "already_released", ""))
@@ -2053,9 +2241,10 @@ class DockerRuntimeAdapter:
         return tuple(normalized)
 
 
-
 class DockerMeasurementProvider(Protocol):
-    async def measure(self, plan: Any, container_name: str, inspect_payload: bytes) -> Mapping[str, Any]: ...
+    async def measure(
+        self, plan: Any, container_name: str, inspect_payload: bytes
+    ) -> Mapping[str, Any]: ...
 
 
 def requested_measurement(
@@ -2072,7 +2261,8 @@ def requested_measurement(
         "capabilities": "drop_all",
         "no_new_privileges": plan.security_policy.no_new_privileges,
         "seccomp": plan.security_policy.seccomp_digest,
-        "lsm": plan.security_policy.apparmor_profile or plan.security_policy.selinux_label,
+        "lsm": plan.security_policy.apparmor_profile
+        or plan.security_policy.selinux_label,
         "read_only_root": plan.security_policy.read_only_root,
         "mounts": tuple(
             (destination, readonly)
@@ -2080,7 +2270,9 @@ def requested_measurement(
         ),
         "mount_sources": tuple(
             (str(source), destination, readonly)
-            for source, destination, readonly in sorted(mounts, key=lambda item: item[1])
+            for source, destination, readonly in sorted(
+                mounts, key=lambda item: item[1]
+            )
         ),
         "tmpfs": tuple(sorted(plan.security_policy.tmpfs_mounts)),
         "network": "none",
@@ -2090,7 +2282,9 @@ def requested_measurement(
         "memory_swap": plan.resources.memory_bytes,
         "pids": plan.resources.pids,
         "nofile": plan.resources.open_files,
-        "storage": plan.resources.storage_bytes if storage_bytes is None else storage_bytes,
+        "storage": plan.resources.storage_bytes
+        if storage_bytes is None
+        else storage_bytes,
         "output_limit": plan.limits.observation_bytes,
         "cgroups": ("", "private"),
         "namespaces": (
@@ -2106,8 +2300,12 @@ def requested_measurement(
     return measured
 
 
-def measurement_mismatches(requested: Mapping[str, Any], measured: Mapping[str, Any]) -> tuple[str, ...]:
-    return tuple(sorted(key for key, value in requested.items() if measured.get(key) != value))
+def measurement_mismatches(
+    requested: Mapping[str, Any], measured: Mapping[str, Any]
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(key for key, value in requested.items() if measured.get(key) != value)
+    )
 
 
 class InspectDockerMeasurementProvider:
@@ -2147,9 +2345,12 @@ class DockerRuntimeHandle:
         self._mount_stager = mount_stager
         self._staged_mounts = list(staged_mounts)
         self._lease_id = lease_id
+        self.repository_base_commit: str | None = None
+        self.repository_relative_path: str | None = None
 
     def _record_terminal_cleanup(self, receipts: tuple[Any, ...]) -> None:
         from .materialization import CleanupState
+
         states = {item.state for item in receipts}
         if states <= {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}:
             self._closed = True
@@ -2179,7 +2380,10 @@ class DockerRuntimeHandle:
         except BaseException as exc:
             indeterminate = not isinstance(exc, DockerAdapterError) or (
                 exc.code == "output_limit_exceeded"
-                or (exc.code == "runtime_launch_failed" and "returncode" not in exc.details)
+                or (
+                    exc.code == "runtime_launch_failed"
+                    and "returncode" not in exc.details
+                )
             )
             if indeterminate:
                 self._fenced = True
@@ -2240,7 +2444,9 @@ class DockerRuntimeHandle:
         ceiling: int,
     ) -> Mapping[str, Any]:
         if type(offset) is not int or offset < 0:
-            raise DockerAdapterError("runtime_preflight_failed", "read offset is invalid")
+            raise DockerAdapterError(
+                "runtime_preflight_failed", "read offset is invalid"
+            )
         if limit is not None and (
             type(limit) is not int or limit < 0 or limit > ceiling
         ):
@@ -2301,10 +2507,14 @@ class DockerRuntimeHandle:
 
     async def write_text(self, path: str, content: str) -> Mapping[str, Any]:
         if type(content) is not str:
-            raise DockerAdapterError("runtime_preflight_failed", "write content is invalid")
+            raise DockerAdapterError(
+                "runtime_preflight_failed", "write content is invalid"
+            )
         payload = content.encode("utf-8")
         if len(payload) > self.plan.limits.artifact_bytes_each:
-            raise DockerAdapterError("output_limit_exceeded", "write exceeds admitted ceiling")
+            raise DockerAdapterError(
+                "output_limit_exceeded", "write exceeds admitted ceiling"
+            )
         result = await self._run(
             _workspace_python_argv(
                 "write",
@@ -2319,8 +2529,14 @@ class DockerRuntimeHandle:
         return {"path": path, "bytes": len(payload)}
 
     async def list_files(self, path: str, *, depth: int) -> Mapping[str, Any]:
-        if type(depth) is not int or depth < 0 or depth > self.plan.security_policy.snapshot_max_depth:
-            raise DockerAdapterError("output_limit_exceeded", "list depth exceeds admitted ceiling")
+        if (
+            type(depth) is not int
+            or depth < 0
+            or depth > self.plan.security_policy.snapshot_max_depth
+        ):
+            raise DockerAdapterError(
+                "output_limit_exceeded", "list depth exceeds admitted ceiling"
+            )
         result = await self._run(
             _workspace_python_argv(
                 "list",
@@ -2371,6 +2587,46 @@ class DockerRuntimeHandle:
             )
         return {"path": path, "files": values}
 
+    async def measure_repository_base_commit(self) -> str | None:
+        if not callable(getattr(self.adapter, "exec", None)):
+            return None
+        repositories = tuple(
+            entry
+            for entry in self.plan.materialization_plan.entries
+            if entry.role == "repository"
+        )
+        if len(repositories) > 1:
+            raise DockerAdapterError(
+                "runtime_preflight_failed",
+                "workspace base measurement requires at most one repository mount",
+            )
+        relative_path = repositories[0].target_logical_path if repositories else "."
+        repository_root = (
+            _container_workspace_path(relative_path)
+            if repositories
+            else CONTAINER_WORKSPACE_ROOT
+        )
+        result = await self._run(
+            ("git", "-C", repository_root, "rev-parse", "--verify", "HEAD^{commit}"),
+            timeout_ms=self.plan.limits.action_timeout_ms,
+            output_limit=256,
+        )
+        commit = result.get("stdout", "").strip()
+        if result.get("returncode") != 0:
+            return None
+        if (
+            len(commit) != 40
+            or commit != commit.lower()
+            or any(character not in "0123456789abcdef" for character in commit)
+        ):
+            raise DockerAdapterError(
+                "runtime_preflight_failed",
+                "workspace base commit measurement failed",
+            )
+        self.repository_base_commit = commit
+        self.repository_relative_path = relative_path
+        return commit
+
     async def workspace_diff(self) -> Mapping[str, Any]:
         repositories = tuple(
             entry
@@ -2382,9 +2638,7 @@ class DockerRuntimeHandle:
                 "runtime_preflight_failed",
                 "workspace diff requires exactly one repository mount",
             )
-        repository_root = _container_workspace_path(
-            repositories[0].target_logical_path
-        )
+        repository_root = _container_workspace_path(repositories[0].target_logical_path)
         result = await self._run(
             ("git", "-C", repository_root, "diff", "--no-ext-diff", "--binary"),
             timeout_ms=self.plan.limits.action_timeout_ms,
@@ -2398,6 +2652,7 @@ class DockerRuntimeHandle:
 
     async def _terminate_bound(self) -> tuple[Any, ...]:
         from .materialization import CleanupState, CleanupStepReceipt
+
         try:
             reference = self.container_id or self.container_name
             raw = await self.adapter.cleanup(
@@ -2422,7 +2677,8 @@ class DockerRuntimeHandle:
             "quarantined": CleanupState.QUARANTINED,
         }
         return tuple(
-            CleanupStepReceipt(name, states[state], detail) for name, state, detail in raw
+            CleanupStepReceipt(name, states[state], detail)
+            for name, state, detail in raw
         )
 
     async def _retry_cleanup(self) -> tuple[Any, ...]:
@@ -2518,6 +2774,7 @@ class DockerRuntimeHandle:
 
     async def terminate(self) -> tuple[Any, ...]:
         from .materialization import CleanupState, CleanupStepReceipt
+
         if self._terminal_cleanup is not None:
             return self._terminal_cleanup
         if self._closed:
@@ -2526,20 +2783,31 @@ class DockerRuntimeHandle:
 
 
 class DockerSandboxBackend:
-    def __init__(self, *, adapter: DockerRuntimeAdapter, measurement_provider: DockerMeasurementProvider,
-                 security_profile_root: str | Path,
-                 mount_stager: DockerDescriptorMountStager | None = None,
-                 skeleton_path: str | Path | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        adapter: DockerRuntimeAdapter,
+        measurement_provider: DockerMeasurementProvider,
+        security_profile_root: str | Path,
+        mount_stager: DockerDescriptorMountStager | None = None,
+        skeleton_path: str | Path | None = None,
+    ) -> None:
         self.adapter = adapter
         self.measurement_provider = measurement_provider
         self.mount_stager = mount_stager
         self.security_profile_root = Path(security_profile_root)
-        if (
-            not self.security_profile_root.is_absolute()
-            or os.path.normpath(self.security_profile_root) != str(self.security_profile_root)
-        ):
-            raise ValueError("Docker security profile root must be absolute and normalized")
-        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        if not self.security_profile_root.is_absolute() or os.path.normpath(
+            self.security_profile_root
+        ) != str(self.security_profile_root):
+            raise ValueError(
+                "Docker security profile root must be absolute and normalized"
+            )
+        flags = (
+            os.O_RDONLY
+            | getattr(os, "O_DIRECTORY", 0)
+            | getattr(os, "O_CLOEXEC", 0)
+            | getattr(os, "O_NOFOLLOW", 0)
+        )
         self._security_root_fd = os.open(self.security_profile_root, flags)
         self._quarantined_fds: list[int] = []
         self._quarantined_handles: list[DockerRuntimeHandle] = []
@@ -2548,7 +2816,6 @@ class DockerSandboxBackend:
     @property
     def cleanup_pending(self) -> bool:
         return bool(self._quarantined_handles or self._quarantined_stages)
-
 
     def close(self) -> None:
         if self._quarantined_handles or self._quarantined_stages:
@@ -2618,7 +2885,9 @@ class DockerSandboxBackend:
         def read_installed() -> bytes:
             descriptor = os.open(
                 name,
-                os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+                os.O_RDONLY
+                | getattr(os, "O_CLOEXEC", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
                 dir_fd=self._security_root_fd,
             )
             try:
@@ -2665,9 +2934,7 @@ class DockerSandboxBackend:
                 os.fsync(descriptor)
                 os.close(descriptor)
                 descriptor = -1
-                os.replace(
-                    temporary, name, src_dir_fd=directory, dst_dir_fd=directory
-                )
+                os.replace(temporary, name, src_dir_fd=directory, dst_dir_fd=directory)
                 os.fsync(directory)
             finally:
                 if descriptor >= 0:
@@ -2687,14 +2954,22 @@ class DockerSandboxBackend:
             or "sha256:" + hashlib.sha256(current).hexdigest()
             != plan.security_policy.seccomp_digest
         ):
-            raise DockerAdapterError("runtime_preflight_failed", "installed seccomp profile is tampered")
+            raise DockerAdapterError(
+                "runtime_preflight_failed", "installed seccomp profile is tampered"
+            )
         return Path(name)
 
     @staticmethod
     def _validate_context(plan: Any, context: Any) -> None:
         from .sandbox import RuntimeLaunchContext, WorkspaceStorageIdentity
-        if type(context) is not RuntimeLaunchContext or type(context.storage) is not WorkspaceStorageIdentity:
-            raise DockerAdapterError("runtime_preflight_failed", "exact runtime launch context required")
+
+        if (
+            type(context) is not RuntimeLaunchContext
+            or type(context.storage) is not WorkspaceStorageIdentity
+        ):
+            raise DockerAdapterError(
+                "runtime_preflight_failed", "exact runtime launch context required"
+            )
         storage = context.storage
         if (
             type(storage.authority_id) is not str
@@ -2705,7 +2980,9 @@ class DockerSandboxBackend:
             or type(storage.owner_uid) is not int
             or type(storage.owner_gid) is not int
         ):
-            raise DockerAdapterError("runtime_preflight_failed", "workspace quota authority is not enforced")
+            raise DockerAdapterError(
+                "runtime_preflight_failed", "workspace quota authority is not enforced"
+            )
         if context.role == "primary":
             valid = (
                 context.snapshot_relative_path is None
@@ -2722,14 +2999,24 @@ class DockerSandboxBackend:
         else:
             valid = False
         if not valid:
-            raise DockerAdapterError("runtime_preflight_failed", "runtime launch context is contradictory")
+            raise DockerAdapterError(
+                "runtime_preflight_failed", "runtime launch context is contradictory"
+            )
 
     @staticmethod
     def _mount_specs(plan: Any, context: Any) -> tuple[tuple[str, str, bool], ...]:
         if context.role == "verifier":
             return (
-                (context.snapshot_relative_path, f"{CONTAINER_WORKSPACE_ROOT}/snapshot", True),
-                (context.result_relative_path, f"{CONTAINER_WORKSPACE_ROOT}/result", False),
+                (
+                    context.snapshot_relative_path,
+                    f"{CONTAINER_WORKSPACE_ROOT}/snapshot",
+                    True,
+                ),
+                (
+                    context.result_relative_path,
+                    f"{CONTAINER_WORKSPACE_ROOT}/result",
+                    False,
+                ),
             )
         return tuple(
             (
@@ -2739,6 +3026,7 @@ class DockerSandboxBackend:
             )
             for entry in plan.materialization_plan.entries
         )
+
     async def launch(
         self, plan: Any, workspace: Path, *, context: Any
     ) -> tuple[DockerRuntimeHandle, Any]:
@@ -2751,9 +3039,7 @@ class DockerSandboxBackend:
         workspace_fd = getattr(context, "workspace_fd", None)
         workspace_identity = getattr(context, "workspace_identity", None)
         held_fds = (
-            [workspace_fd]
-            if type(workspace_fd) is int and workspace_fd >= 0
-            else []
+            [workspace_fd] if type(workspace_fd) is int and workspace_fd >= 0 else []
         )
         creation_attempted = False
         container_id: str | None = None
@@ -2825,7 +3111,9 @@ class DockerSandboxBackend:
                 expected_identity=workspace_identity,
             )
             admitted_mounts: list[tuple[int, str, bool, os.stat_result]] = []
-            for relative_path, destination, readonly in self._mount_specs(plan, context):
+            for relative_path, destination, readonly in self._mount_specs(
+                plan, context
+            ):
                 child_fd = _openat2_beneath(workspace_fd, relative_path)
                 held_fds.append(child_fd)
                 child_metadata = _validate_mount_descriptor(
@@ -2872,9 +3160,13 @@ class DockerSandboxBackend:
             )
             held_fds.append(profile_fd)
             profile_metadata = os.fstat(profile_fd)
-            if not stat.S_ISREG(profile_metadata.st_mode) or profile_metadata.st_nlink != 1:
+            if (
+                not stat.S_ISREG(profile_metadata.st_mode)
+                or profile_metadata.st_nlink != 1
+            ):
                 raise DockerAdapterError(
-                    "runtime_preflight_failed", "seccomp profile descriptor is not immutable authority"
+                    "runtime_preflight_failed",
+                    "seccomp profile descriptor is not immutable authority",
                 )
             profile_stage = await self.mount_stager.stage(
                 profile_fd,
@@ -2897,9 +3189,14 @@ class DockerSandboxBackend:
                 await self.mount_stager.validate(staged, descriptor)
             creation_attempted = True
             container_id, container_name, _ = await self.adapter.prepare(
-                plan, lease_id=context.lease_id, workspace_id=context.workspace_id,
-                epoch=context.epoch, role=context.role, skeleton_path=workspace_source,
-                mounts=tuple(descriptor_mounts), security_profile_path=profile_source,
+                plan,
+                lease_id=context.lease_id,
+                workspace_id=context.workspace_id,
+                epoch=context.epoch,
+                role=context.role,
+                skeleton_path=workspace_source,
+                mounts=tuple(descriptor_mounts),
+                security_profile_path=profile_source,
                 security_profile_descriptor=profile_fd,
                 security_profile_metadata=profile_metadata,
             )
@@ -2927,16 +3224,22 @@ class DockerSandboxBackend:
                 staged.validate_descriptor(descriptor)
                 await self.mount_stager.validate(staged, descriptor)
             measured = decode_docker_inspect(
-                inspect_payload, plan, container_id=container_id,
-                container_name=container_name, labels=labels,
-                skeleton_path=workspace_source, mounts=tuple(descriptor_mounts),
+                inspect_payload,
+                plan,
+                container_id=container_id,
+                container_name=container_name,
+                labels=labels,
+                skeleton_path=workspace_source,
+                mounts=tuple(descriptor_mounts),
                 security_profile_path=profile_source,
                 storage_bytes=context.storage.quota_bytes,
             )
             effective = dict(measured)
-            external = dict(await self.measurement_provider.measure(
-                plan, container_name, inspect_payload
-            ))
+            external = dict(
+                await self.measurement_provider.measure(
+                    plan, container_name, inspect_payload
+                )
+            )
             unknown = set(external) - set(measured)
             if unknown:
                 raise DockerAdapterError(
@@ -2947,8 +3250,10 @@ class DockerSandboxBackend:
             measured.update(external)
             identity = (container_id, container_name, identity_labels)
             requested = requested_measurement(
-                plan, tuple(descriptor_mounts),
-                storage_bytes=context.storage.quota_bytes, identity=identity,
+                plan,
+                tuple(descriptor_mounts),
+                storage_bytes=context.storage.quota_bytes,
+                identity=identity,
             )
             storage_identity = (
                 context.storage.authority_id,
@@ -2961,34 +3266,53 @@ class DockerSandboxBackend:
             requested["storage_identity"] = storage_identity
             measured["storage_identity"] = storage_identity
             effective["storage_identity"] = storage_identity
-            mismatch = tuple(sorted({
-                *measurement_mismatches(requested, effective),
-                *measurement_mismatches(requested, measured),
-            }))
+            handle = DockerRuntimeHandle(
+                adapter=self.adapter,
+                plan=plan,
+                container_id=container_id,
+                container_name=container_name,
+                labels=labels,
+                held_fds=held_fds,
+                mount_stager=self.mount_stager,
+                staged_mounts=staged_mounts,
+                lease_id=context.lease_id,
+            )
+            repository_base_commit = await handle.measure_repository_base_commit()
+            if repository_base_commit is not None:
+                requested["workspace_base_commit"] = repository_base_commit
+                effective["workspace_base_commit"] = repository_base_commit
+                measured["workspace_base_commit"] = repository_base_commit
+            mismatch = tuple(
+                sorted(
+                    {
+                        *measurement_mismatches(requested, effective),
+                        *measurement_mismatches(requested, measured),
+                    }
+                )
+            )
             if mismatch:
                 raise DockerAdapterError(
                     "runtime_measurement_mismatch",
                     "effective Docker controls contradict requested controls",
                     details={"mismatch": mismatch},
                 )
-            handle = DockerRuntimeHandle(
-                adapter=self.adapter, plan=plan, container_id=container_id,
-                container_name=container_name, labels=labels, held_fds=held_fds,
-                mount_stager=self.mount_stager, staged_mounts=staged_mounts,
-                lease_id=context.lease_id,
-            )
             held_fds = []
             return handle, SandboxMeasurement(
                 effective_plan_digest=plan.effective_plan_digest,
-                lease_id=context.lease_id, workspace_id=context.workspace_id,
+                lease_id=context.lease_id,
+                workspace_id=context.workspace_id,
                 runtime_id=plan.runtime.runtime_id,
                 runtime_class=plan.runtime.runtime_class.value,
                 driver_binary_digest=plan.runtime.measured_binary_digest,
-                image_digest=plan.image.image_digest, requested=requested,
-                effective=effective, measured=measured,
-                runtime_resource_id=container_id, mismatch=(),
+                image_digest=plan.image.image_digest,
+                requested=requested,
+                effective=effective,
+                measured=measured,
+                runtime_resource_id=container_id,
+                mismatch=(),
                 isolation_disposition=IsolationDisposition.ISOLATED,
-                isolated=True, reward_eligible=True,
+                isolated=True,
+                reward_eligible=True,
             )
         except BaseException as primary:
             if isinstance(primary, DockerAdapterError):
@@ -2999,31 +3323,34 @@ class DockerSandboxBackend:
                 ):
                     container_id = candidate
                 reported_cleanup = primary.details.get("cleanup")
-                if (
-                    type(reported_cleanup) in {list, tuple}
-                    and all(
-                        type(item) in {list, tuple}
-                        and len(item) == 3
-                        and all(type(value) is str for value in item)
-                        for item in reported_cleanup
-                    )
+                if type(reported_cleanup) in {list, tuple} and all(
+                    type(item) in {list, tuple}
+                    and len(item) == 3
+                    and all(type(value) is str for value in item)
+                    for item in reported_cleanup
                 ):
                     cleanup = tuple(tuple(item) for item in reported_cleanup)
             if container_id is not None:
                 try:
                     cleanup = await self.adapter.cleanup(
-                        plan, container_id, expected_id=container_id,
-                        expected_name=container_name, labels=labels,
+                        plan,
+                        container_id,
+                        expected_id=container_id,
+                        expected_name=container_name,
+                        labels=labels,
                     )
                 except BaseException as cleanup_error:
                     cleanup = (
-                        ("runtime_identity", "quarantined", type(cleanup_error).__name__),
+                        (
+                            "runtime_identity",
+                            "quarantined",
+                            type(cleanup_error).__name__,
+                        ),
                     )
                 if isinstance(primary, DockerAdapterError):
                     primary.details["cleanup"] = cleanup
             absence = any(
-                name == "runtime_absence"
-                and state in {"released", "already_released"}
+                name == "runtime_absence" and state in {"released", "already_released"}
                 for name, state, _ in cleanup
             )
             runtime_cleanup_pending = creation_attempted and not absence
@@ -3109,9 +3436,9 @@ class DockerSandboxBackend:
             while held_fds:
                 os.close(held_fds.pop())
 
-
     async def reconcile(self, record: Mapping[str, Any]) -> tuple[Any, ...]:
         from .materialization import CleanupState, CleanupStepReceipt
+
         # Legacy records contain only pathname/digest observations.  They do not
         # carry a durable daemon binding proving which OCI executable dockerd
         # consumed, so executing any CLI command could invoke unadmitted code.
@@ -3124,11 +3451,24 @@ class DockerSandboxBackend:
         )
 
 
-__all__ = ["DockerAdapterError", "DockerCliExecutor", "SubprocessDockerCliExecutor", "DockerCommandResult", "ExecutableInvocation",
-           "DockerPreflightObservation", "PrivateDockerDaemonBinding",
-           "StagedDockerDescriptorMount", "DockerDescriptorMountStager",
-           "DockerRuntimeAdapter",
-           "DockerMeasurementProvider", "InspectDockerMeasurementProvider",
-           "DockerRuntimeHandle", "DockerSandboxBackend",
-           "build_create_argv", "decode_docker_inspect", "observe_binary_digest",
-           "measurement_mismatches", "requested_measurement"]
+__all__ = [
+    "DockerAdapterError",
+    "DockerCliExecutor",
+    "SubprocessDockerCliExecutor",
+    "DockerCommandResult",
+    "ExecutableInvocation",
+    "DockerPreflightObservation",
+    "PrivateDockerDaemonBinding",
+    "StagedDockerDescriptorMount",
+    "DockerDescriptorMountStager",
+    "DockerRuntimeAdapter",
+    "DockerMeasurementProvider",
+    "InspectDockerMeasurementProvider",
+    "DockerRuntimeHandle",
+    "DockerSandboxBackend",
+    "build_create_argv",
+    "decode_docker_inspect",
+    "observe_binary_digest",
+    "measurement_mismatches",
+    "requested_measurement",
+]

--- a/breadboard/rl/harness/sandbox_docker.py
+++ b/breadboard/rl/harness/sandbox_docker.py
@@ -24,8 +24,9 @@ def _container_workspace_path(logical_path: str) -> str:
     if type(logical_path) is not str or not logical_path or "\x00" in logical_path:
         raise DockerAdapterError("workspace_escape", "workspace path is invalid")
     path = PurePosixPath(logical_path)
-    if path.is_absolute() or any(
-        part in {"", ".", ".."} for part in logical_path.split("/")
+    if (
+        path.is_absolute()
+        or any(part in {"", ".", ".."} for part in logical_path.split("/"))
     ):
         raise DockerAdapterError("workspace_escape", "workspace path is invalid")
     return f"{CONTAINER_WORKSPACE_ROOT}/{path.as_posix()}"
@@ -420,7 +421,9 @@ class SubprocessDockerCliExecutor:
             env=dict(environment),
             start_new_session=True,
             stdin=(
-                asyncio.subprocess.PIPE if input_bytes else asyncio.subprocess.DEVNULL
+                asyncio.subprocess.PIPE
+                if input_bytes
+                else asyncio.subprocess.DEVNULL
             ),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -475,7 +478,8 @@ class SubprocessDockerCliExecutor:
                     raise
             deadline = asyncio.get_running_loop().time() + 0.25
             while (
-                process_group_exists() and asyncio.get_running_loop().time() < deadline
+                process_group_exists()
+                and asyncio.get_running_loop().time() < deadline
             ):
                 await asyncio.sleep(0.01)
             if process_group_exists():
@@ -488,7 +492,8 @@ class SubprocessDockerCliExecutor:
                         raise
             deadline = asyncio.get_running_loop().time() + 0.75
             while (
-                process_group_exists() and asyncio.get_running_loop().time() < deadline
+                process_group_exists()
+                and asyncio.get_running_loop().time() < deadline
             ):
                 await asyncio.sleep(0.01)
             if process_group_exists():
@@ -535,19 +540,13 @@ class SubprocessDockerCliExecutor:
                         task.cancel()
                     await asyncio.gather(*io_tasks, return_exceptions=True)
         return DockerCommandResult(
-            logical_argv,
-            process.returncode,
-            bytes(captured[0]),
-            bytes(captured[1]),
-            timed_out=timed_out,
-            output_limited=limited,
+            logical_argv, process.returncode, bytes(captured[0]), bytes(captured[1]),
+            timed_out=timed_out, output_limited=limited,
         )
 
 
 class DockerAdapterError(RuntimeError):
-    def __init__(
-        self, code: str, message: str, *, details: Mapping[str, Any] | None = None
-    ) -> None:
+    def __init__(self, code: str, message: str, *, details: Mapping[str, Any] | None = None) -> None:
         super().__init__(message)
         self.code = code
         self.details = dict(details or {})
@@ -560,14 +559,16 @@ def observe_binary_digest(path: str | Path) -> str:
             hasher.update(chunk)
     return "sha256:" + hasher.hexdigest()
 
-
 _O_PATH = getattr(os, "O_PATH", 0o10000000)
 _RESOLVE_NO_XDEV = 0x01
 _RESOLVE_NO_MAGICLINKS = 0x02
 _RESOLVE_NO_SYMLINKS = 0x04
 _RESOLVE_BENEATH = 0x08
 _OPENAT2_RESOLVE = (
-    _RESOLVE_BENEATH | _RESOLVE_NO_SYMLINKS | _RESOLVE_NO_MAGICLINKS | _RESOLVE_NO_XDEV
+    _RESOLVE_BENEATH
+    | _RESOLVE_NO_SYMLINKS
+    | _RESOLVE_NO_MAGICLINKS
+    | _RESOLVE_NO_XDEV
 )
 
 
@@ -625,6 +626,8 @@ def _openat2_beneath(
     return int(result)
 
 
+
+
 def _validate_mount_descriptor(
     descriptor: int,
     *,
@@ -649,13 +652,7 @@ def _validate_mount_descriptor(
 
 
 _CONTAINER_ID = re.compile(r"[0-9a-f]{64}")
-_IDENTITY_LABELS = (
-    "bb.lease_id",
-    "bb.plan_digest",
-    "bb.epoch",
-    "bb.workspace_id",
-    "bb.role",
-)
+_IDENTITY_LABELS = ("bb.lease_id", "bb.plan_digest", "bb.epoch", "bb.workspace_id", "bb.role")
 
 
 def _regular_file_metadata_identity(metadata: os.stat_result) -> tuple[int, ...]:
@@ -722,9 +719,11 @@ def _bounded_regular_file_descriptor_bytes(
             "runtime_preflight_failed",
             "security profile descriptor changed while reading",
         ) from exc
-    if extra or _regular_file_metadata_identity(
-        after
-    ) != _regular_file_metadata_identity(before):
+    if (
+        extra
+        or _regular_file_metadata_identity(after)
+        != _regular_file_metadata_identity(before)
+    ):
         raise DockerAdapterError(
             "runtime_preflight_failed",
             "security profile descriptor metadata changed while reading",
@@ -760,7 +759,6 @@ def _mount_argument(source: str, destination: str, *, readonly: bool) -> str:
     value = f"type=bind,src={source},dst={destination}"
     return value + (",readonly" if readonly else "")
 
-
 def _tmpfs_argument(destination: str, options: str) -> str:
     if (
         type(destination) is not str
@@ -768,9 +766,7 @@ def _tmpfs_argument(destination: str, options: str) -> str:
         or any(character in destination for character in ("\x00", "\\", ",", ":"))
         or any(part in {"", ".", ".."} for part in destination.split("/")[1:])
     ):
-        raise DockerAdapterError(
-            "runtime_preflight_failed", "invalid tmpfs destination"
-        )
+        raise DockerAdapterError("runtime_preflight_failed", "invalid tmpfs destination")
     tokens = options.split(",") if type(options) is str else []
     if not tokens or len(tokens) != len(set(tokens)):
         raise DockerAdapterError("runtime_preflight_failed", "invalid tmpfs options")
@@ -779,20 +775,10 @@ def _tmpfs_argument(destination: str, options: str) -> str:
     flags = {token for token in tokens if "=" not in token}
     assignments = [token for token in tokens if "=" in token]
     if flags < required_flags or not flags <= allowed_flags or len(assignments) != 1:
-        raise DockerAdapterError(
-            "runtime_preflight_failed", "tmpfs options are not closed and bounded"
-        )
+        raise DockerAdapterError("runtime_preflight_failed", "tmpfs options are not closed and bounded")
     key, separator, value = assignments[0].partition("=")
-    if (
-        key != "size"
-        or separator != "="
-        or not value.isascii()
-        or not value.isdigit()
-        or int(value) <= 0
-    ):
-        raise DockerAdapterError(
-            "runtime_preflight_failed", "tmpfs size must be a positive byte count"
-        )
+    if key != "size" or separator != "=" or not value.isascii() or not value.isdigit() or int(value) <= 0:
+        raise DockerAdapterError("runtime_preflight_failed", "tmpfs size must be a positive byte count")
     return f"{destination}:{options}"
 
 
@@ -834,9 +820,7 @@ def _validate_mount_authority(
             raise DockerAdapterError(
                 "runtime_preflight_failed", "duplicate Docker mount destination"
             )
-        pending = [
-            child for key, child in node.items() if key and isinstance(child, dict)
-        ]
+        pending = [child for key, child in node.items() if key and isinstance(child, dict)]
         descendants: list[tuple[bool, str]] = []
         while pending and not descendants:
             child = pending.pop()
@@ -872,8 +856,7 @@ def _validate_lsm_policy(security: Any) -> None:
             or re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", apparmor) is None
         ):
             raise DockerAdapterError(
-                "runtime_preflight_failed",
-                "AppArmor authority is disabling or malformed",
+                "runtime_preflight_failed", "AppArmor authority is disabling or malformed"
             )
     elif selinux is not None:
         if (
@@ -883,26 +866,15 @@ def _validate_lsm_policy(security: Any) -> None:
             or re.fullmatch(r"[A-Za-z0-9_.:-]{3,255}", selinux) is None
         ):
             raise DockerAdapterError(
-                "runtime_preflight_failed",
-                "SELinux authority is disabling or malformed",
+                "runtime_preflight_failed", "SELinux authority is disabling or malformed"
             )
     else:
-        raise DockerAdapterError(
-            "runtime_preflight_failed", "an exact LSM authority is mandatory"
-        )
+        raise DockerAdapterError("runtime_preflight_failed", "an exact LSM authority is mandatory")
 
 
-def build_create_argv(
-    plan: Any,
-    *,
-    lease_id: str,
-    workspace_id: str,
-    epoch: int,
-    role: str,
-    skeleton_path: Path,
-    mounts: Sequence[tuple[Path, str, bool]],
-    security_profile_path: Path,
-) -> tuple[str, ...]:
+def build_create_argv(plan: Any, *, lease_id: str, workspace_id: str, epoch: int,
+                      role: str, skeleton_path: Path,
+                      mounts: Sequence[tuple[Path, str, bool]], security_profile_path: Path) -> tuple[str, ...]:
     runtime = plan.runtime
     security = plan.security_policy
     network = plan.network_policy
@@ -915,26 +887,16 @@ def build_create_argv(
         or not network.default_deny
         or network.egress_route_ids
     ):
-        raise DockerAdapterError(
-            "runtime_unsupported", "only Docker network none is supported"
-        )
+        raise DockerAdapterError("runtime_unsupported", "only Docker network none is supported")
     if (
         type(security.uid) is not int
         or type(security.gid) is not int
         or security.uid <= 0
         or security.gid <= 0
     ):
-        raise DockerAdapterError(
-            "runtime_preflight_failed", "numeric non-root identity is mandatory"
-        )
-    if (
-        not security.read_only_root
-        or not security.drop_all_capabilities
-        or not security.no_new_privileges
-    ):
-        raise DockerAdapterError(
-            "runtime_preflight_failed", "hardened security flags are mandatory"
-        )
+        raise DockerAdapterError("runtime_preflight_failed", "numeric non-root identity is mandatory")
+    if not security.read_only_root or not security.drop_all_capabilities or not security.no_new_privileges:
+        raise DockerAdapterError("runtime_preflight_failed", "hardened security flags are mandatory")
     if security.namespace_flags:
         raise DockerAdapterError(
             "runtime_preflight_failed",
@@ -954,60 +916,38 @@ def build_create_argv(
     for key in _IDENTITY_LABELS:
         argv += ["--label", f"{key}={labels[key]}"]
     argv += [
-        "--runtime",
-        runtime.oci_runtime_name,
-        "--network",
-        "none",
-        "--cgroupns",
-        "private",
-        "--ipc",
-        "private",
-        "--user",
-        f"{security.uid}:{security.gid}",
+        "--runtime", runtime.oci_runtime_name,
+        "--network", "none",
+        "--cgroupns", "private",
+        "--ipc", "private",
+        "--user", f"{security.uid}:{security.gid}",
         "--read-only",
-        "--cap-drop",
-        "ALL",
-        "--security-opt",
-        "no-new-privileges",
-        "--security-opt",
-        f"seccomp={security_profile_path}",
+        "--cap-drop", "ALL",
+        "--security-opt", "no-new-privileges",
+        "--security-opt", f"seccomp={security_profile_path}",
     ]
     if security.apparmor_profile is not None:
         argv += ["--security-opt", f"apparmor={security.apparmor_profile}"]
     elif security.selinux_label is not None:
         argv += ["--security-opt", f"label={security.selinux_label}"]
     argv += [
-        "--pids-limit",
-        str(resources.pids),
-        "--memory",
-        str(resources.memory_bytes),
-        "--memory-swap",
-        str(resources.memory_bytes),
-        "--cpu-period",
-        "100000",
-        "--cpu-quota",
-        str(resources.cpu_millis * 100),
-        "--ulimit",
-        f"nofile={resources.open_files}:{resources.open_files}",
-        "--mount",
-        _mount_argument(str(skeleton_path), CONTAINER_WORKSPACE_ROOT, readonly=True),
+        "--pids-limit", str(resources.pids),
+        "--memory", str(resources.memory_bytes),
+        "--memory-swap", str(resources.memory_bytes),
+        "--cpu-period", "100000",
+        "--cpu-quota", str(resources.cpu_millis * 100),
+        "--ulimit", f"nofile={resources.open_files}:{resources.open_files}",
+        "--mount", _mount_argument(str(skeleton_path), CONTAINER_WORKSPACE_ROOT, readonly=True),
     ]
     destinations: set[str] = {CONTAINER_WORKSPACE_ROOT}
     for source, destination, readonly in sorted(mounts, key=lambda item: item[1]):
         if destination in destinations:
-            raise DockerAdapterError(
-                "runtime_preflight_failed", "duplicate Docker mount destination"
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "duplicate Docker mount destination")
         destinations.add(destination)
-        argv += [
-            "--mount",
-            _mount_argument(str(source), destination, readonly=readonly),
-        ]
+        argv += ["--mount", _mount_argument(str(source), destination, readonly=readonly)]
     for destination, options in security.tmpfs_mounts:
         if destination in destinations:
-            raise DockerAdapterError(
-                "runtime_preflight_failed", "duplicate Docker mount destination"
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "duplicate Docker mount destination")
         destinations.add(destination)
         argv += ["--tmpfs", _tmpfs_argument(destination, options)]
     argv += ["--workdir", CONTAINER_WORKSPACE_ROOT]
@@ -1015,9 +955,7 @@ def build_create_argv(
         argv += ["--env", f"{key}={value}"]
     argv += ["--pull", "never", plan.image.image_digest, *runtime.idle_argv]
     if any("docker.sock" in value for value in argv):
-        raise DockerAdapterError(
-            "runtime_preflight_failed", "forbidden Docker authority"
-        )
+        raise DockerAdapterError("runtime_preflight_failed", "forbidden Docker authority")
     return tuple(argv)
 
 
@@ -1025,26 +963,18 @@ def _json_object(payload: bytes, *, label: str) -> dict[str, Any]:
     try:
         value = json.loads(payload.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise DockerAdapterError(
-            "runtime_preflight_failed", f"Docker {label} output is malformed"
-        ) from exc
+        raise DockerAdapterError("runtime_preflight_failed", f"Docker {label} output is malformed") from exc
     if type(value) is not dict:
-        raise DockerAdapterError(
-            "runtime_preflight_failed",
-            f"Docker {label} output has an unexpected schema",
-        )
+        raise DockerAdapterError("runtime_preflight_failed", f"Docker {label} output has an unexpected schema")
     return value
 
 
-def _registered_runtime(
-    info: Mapping[str, Any], runtime_name: str
-) -> Mapping[str, Any] | None:
+def _registered_runtime(info: Mapping[str, Any], runtime_name: str) -> Mapping[str, Any] | None:
     if "Error" in info:
         return None
     runtimes = info.get("Runtimes")
     if type(runtimes) is not dict or any(
-        type(key) is not str or type(value) is not dict
-        for key, value in runtimes.items()
+        type(key) is not str or type(value) is not dict for key, value in runtimes.items()
     ):
         return None
     return runtimes.get(runtime_name)
@@ -1054,15 +984,10 @@ def _image_identity_matches(payload: bytes, expected_digest: str) -> bool:
     try:
         value = json.loads(payload.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise DockerAdapterError(
-            "runtime_preflight_failed", "Docker image output is malformed"
-        ) from exc
+        raise DockerAdapterError("runtime_preflight_failed", "Docker image output is malformed") from exc
     if type(value) is list:
         if len(value) != 1 or type(value[0]) is not dict:
-            raise DockerAdapterError(
-                "runtime_preflight_failed",
-                "Docker image output has an unexpected schema",
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "Docker image output has an unexpected schema")
         value = value[0]
     if type(value) is not dict or "Error" in value:
         return False
@@ -1077,8 +1002,7 @@ def _image_identity_matches(payload: bytes, expected_digest: str) -> bool:
         return False
     id_matches = type(image_id) is str and image_id == expected_digest
     refs_match = type(repo_digests) is list and any(
-        reference.rpartition("@")[1] == "@"
-        and reference.rpartition("@")[2] == expected_digest
+        reference.rpartition("@")[1] == "@" and reference.rpartition("@")[2] == expected_digest
         for reference in repo_digests
     )
     return id_matches or refs_match
@@ -1087,20 +1011,14 @@ def _image_identity_matches(payload: bytes, expected_digest: str) -> bool:
 def _platform_version(payload: Mapping[str, Any]) -> str:
     server = payload.get("Server")
     if type(server) is not dict:
-        raise DockerAdapterError(
-            "runtime_unsupported", "Docker server version is unavailable"
-        )
+        raise DockerAdapterError("runtime_unsupported", "Docker server version is unavailable")
     platform = server.get("Platform")
     if type(platform) is not dict:
-        raise DockerAdapterError(
-            "runtime_unsupported", "Docker server platform is unavailable"
-        )
+        raise DockerAdapterError("runtime_unsupported", "Docker server platform is unavailable")
     name = platform.get("Name")
     version = server.get("Version")
     if type(name) is not str or not name or type(version) is not str or not version:
-        raise DockerAdapterError(
-            "runtime_unsupported", "Docker server platform version is malformed"
-        )
+        raise DockerAdapterError("runtime_unsupported", "Docker server platform version is malformed")
     return f"{name}/{version}"
 
 
@@ -1113,8 +1031,7 @@ def _inspect_object(payload: bytes) -> dict[str, Any]:
         ) from exc
     if type(decoded) is not list or len(decoded) != 1 or type(decoded[0]) is not dict:
         raise DockerAdapterError(
-            "runtime_measurement_mismatch",
-            "Docker inspect output has an unexpected schema",
+            "runtime_measurement_mismatch", "Docker inspect output has an unexpected schema"
         )
     return decoded[0]
 
@@ -1140,10 +1057,7 @@ def _observed_identity(payload: bytes) -> tuple[str, str, Mapping[str, str]]:
         or type(name) is not str
         or not name.startswith("/")
         or type(labels) is not dict
-        or any(
-            type(key) is not str or type(value) is not str
-            for key, value in labels.items()
-        )
+        or any(type(key) is not str or type(value) is not str for key, value in labels.items())
     ):
         raise DockerAdapterError(
             "runtime_measurement_mismatch", "Docker inspect identity is malformed"
@@ -1159,17 +1073,14 @@ def _validate_identity(
     expected_labels: Mapping[str, str],
 ) -> str:
     container_id, name, labels = _observed_identity(payload)
-    observed_binding = {
-        key: value for key, value in labels.items() if key.startswith("bb.")
-    }
+    observed_binding = {key: value for key, value in labels.items() if key.startswith("bb.")}
     if (
         (expected_id is not None and container_id != expected_id)
         or name != expected_name
         or observed_binding != dict(expected_labels)
     ):
         raise DockerAdapterError(
-            "stale_identity_uncertain",
-            "Docker container identity does not match its binding",
+            "stale_identity_uncertain", "Docker container identity does not match its binding"
         )
     return container_id
 
@@ -1223,8 +1134,7 @@ def decode_docker_inspect(
         or host.get("Tmpfs") != expected_tmpfs
     ):
         raise DockerAdapterError(
-            "runtime_measurement_mismatch",
-            "Docker inspect security schema is not closed",
+            "runtime_measurement_mismatch", "Docker inspect security schema is not closed"
         )
     expected_security = {
         "no-new-privileges",
@@ -1237,15 +1147,11 @@ def decode_docker_inspect(
         expected_security.add(f"label={plan.security_policy.selinux_label}")
     if set(security_options) != expected_security:
         raise DockerAdapterError(
-            "runtime_measurement_mismatch",
-            "Docker inspect security options contradict the plan",
+            "runtime_measurement_mismatch", "Docker inspect security options contradict the plan"
         )
     expected_mounts = [
         (str(skeleton_path), CONTAINER_WORKSPACE_ROOT, False),
-        *[
-            (str(source), destination, not readonly)
-            for source, destination, readonly in mounts
-        ],
+        *[(str(source), destination, not readonly) for source, destination, readonly in mounts],
     ]
     observed_mounts: list[tuple[str, str, bool]] = []
     for record in mount_records:
@@ -1263,8 +1169,7 @@ def decode_docker_inspect(
             or type(writable) is not bool
         ):
             raise DockerAdapterError(
-                "runtime_measurement_mismatch",
-                "Docker inspect mount is not a typed bind",
+                "runtime_measurement_mismatch", "Docker inspect mount is not a typed bind"
             )
         observed_mounts.append((source, destination, writable))
     if sorted(observed_mounts, key=lambda value: value[1]) != sorted(
@@ -1274,8 +1179,7 @@ def decode_docker_inspect(
             "runtime_measurement_mismatch", "Docker inspect mounts contradict the plan"
         )
     nofile = [
-        value
-        for value in ulimits
+        value for value in ulimits
         if type(value) is dict and value.get("Name") == "nofile"
     ]
     if len(nofile) != 1:
@@ -1297,9 +1201,7 @@ def decode_docker_inspect(
         ),
         "mount_sources": tuple(
             (str(source), destination, readonly)
-            for source, destination, readonly in sorted(
-                mounts, key=lambda value: value[1]
-            )
+            for source, destination, readonly in sorted(mounts, key=lambda value: value[1])
         ),
         "workspace_root": str(skeleton_path),
         "tmpfs": tuple(sorted(plan.security_policy.tmpfs_mounts)),
@@ -1340,8 +1242,7 @@ def decode_docker_inspect(
         or host.get("UTSMode") != ""
     ):
         raise DockerAdapterError(
-            "runtime_measurement_mismatch",
-            "Docker inspect image or privilege state contradicts the plan",
+            "runtime_measurement_mismatch", "Docker inspect image or privilege state contradicts the plan"
         )
     return values
 
@@ -1483,8 +1384,7 @@ class PrivateDockerDaemonBinding:
                 self.daemon_executable_size,
                 self.config_size,
                 self.runtime_size,
-            )
-            <= 0
+            ) <= 0
             or type(self.daemon_pid) is not int
             or self.daemon_pid <= 0
             or type(self.daemon_starttime) is not str
@@ -1658,14 +1558,7 @@ def _require_daemon_runtime_binding(
 
 
 class DockerRuntimeAdapter:
-    def __init__(
-        self,
-        *,
-        executor: DockerCliExecutor,
-        cli_environment: tuple[tuple[str, str], ...],
-        mechanics_invocation: ExecutableInvocation | None = None,
-        daemon_binding: PrivateDockerDaemonBinding | None = None,
-    ) -> None:
+    def __init__(self, *, executor: DockerCliExecutor, cli_environment: tuple[tuple[str, str], ...], mechanics_invocation: ExecutableInvocation | None = None, daemon_binding: PrivateDockerDaemonBinding | None = None) -> None:
         if cli_environment:
             raise ValueError(
                 "Docker CLI mechanics environment must be empty; container environment is projected at create"
@@ -1680,26 +1573,18 @@ class DockerRuntimeAdapter:
             or mechanics_invocation.executable_fd < 0
             or not mechanics_invocation.executable_descriptor_path
         ):
-            raise ValueError(
-                "mechanics invocation must identify an inherited executable descriptor"
-            )
+            raise ValueError("mechanics invocation must identify an inherited executable descriptor")
         self._pinned: Any | None = None
         self._invocation: ExecutableInvocation | None = mechanics_invocation
 
     def _pin(self, plan: Any) -> ExecutableInvocation:
         current = self._invocation
         if current is not None:
-            if (
-                current.argv0 != plan.runtime.executable_path
-                or current.digest != plan.runtime.measured_binary_digest
-            ):
-                raise DockerAdapterError(
-                    "runtime_preflight_failed",
-                    "Docker CLI authority changed during adapter lifetime",
-                )
+            if (current.argv0 != plan.runtime.executable_path
+                    or current.digest != plan.runtime.measured_binary_digest):
+                raise DockerAdapterError("runtime_preflight_failed", "Docker CLI authority changed during adapter lifetime")
             return current
         from .sandbox import SandboxLaunchError, _snapshot_installed_executable
-
         try:
             pinned = _snapshot_installed_executable(
                 plan.runtime.executable_path, plan.runtime.measured_binary_digest
@@ -1735,15 +1620,10 @@ class DockerRuntimeAdapter:
     ) -> DockerCommandResult:
         invocation = self._invocation if plan is None else self._pin(plan)
         if invocation is None:
-            raise DockerAdapterError(
-                "runtime_preflight_failed", "Docker CLI invocation is not pinned"
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "Docker CLI invocation is not pinned")
         logical = tuple(argv)
         if not logical or logical[0] != invocation.argv0:
-            raise DockerAdapterError(
-                "runtime_preflight_failed",
-                "Docker CLI argv0 contradicts pinned authority",
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "Docker CLI argv0 contradicts pinned authority")
         tail = logical[1:]
         if self._daemon_binding is not None:
             self._daemon_binding.validate_live()
@@ -1769,27 +1649,16 @@ class DockerRuntimeAdapter:
             environment=self._environment,
         )
 
-    async def _execute(
-        self,
-        argv: Sequence[str],
-        *,
-        timeout_ms: int,
-        output_limit: int,
-        code: str = "runtime_preflight_failed",
-    ) -> DockerCommandResult:
+    async def _execute(self, argv: Sequence[str], *, timeout_ms: int, output_limit: int,
+                       code: str = "runtime_preflight_failed") -> DockerCommandResult:
         result = await self._raw(argv, timeout_ms=timeout_ms, output_limit=output_limit)
         if result.output_limited:
-            raise DockerAdapterError(
-                "output_limit_exceeded", "Docker CLI output exceeded the admitted limit"
-            )
+            raise DockerAdapterError("output_limit_exceeded", "Docker CLI output exceeded the admitted limit")
         if result.timed_out:
             raise DockerAdapterError(code, "Docker CLI operation timed out")
         if result.returncode:
-            raise DockerAdapterError(
-                code,
-                "Docker CLI operation failed",
-                details={"returncode": result.returncode},
-            )
+            raise DockerAdapterError(code, "Docker CLI operation failed",
+                                     details={"returncode": result.returncode})
         return result
 
     async def preflight(self, plan: Any) -> DockerPreflightObservation:
@@ -1798,30 +1667,20 @@ class DockerRuntimeAdapter:
         output_limit = plan.limits.observation_bytes
         version = await self._execute(
             (invocation.argv0, "version", "--format", "{{json .}}"),
-            timeout_ms=plan.limits.action_timeout_ms,
-            output_limit=output_limit,
+            timeout_ms=plan.limits.action_timeout_ms, output_limit=output_limit,
         )
         version_payload = _json_object(version.stdout, label="version")
         platform_version = _platform_version(version_payload)
-        if (
-            not runtime.supported_platform_versions
-            or platform_version not in runtime.supported_platform_versions
-        ):
-            raise DockerAdapterError(
-                "runtime_unsupported",
-                "Docker server platform version is not installed authority",
-            )
+        if not runtime.supported_platform_versions or platform_version not in runtime.supported_platform_versions:
+            raise DockerAdapterError("runtime_unsupported", "Docker server platform version is not installed authority")
         info = await self._execute(
             (invocation.argv0, "info", "--format", "{{json .}}"),
-            timeout_ms=plan.limits.action_timeout_ms,
-            output_limit=output_limit,
+            timeout_ms=plan.limits.action_timeout_ms, output_limit=output_limit,
         )
         info_payload = _json_object(info.stdout, label="info")
         registration = _registered_runtime(info_payload, runtime.oci_runtime_name)
         if registration is None:
-            raise DockerAdapterError(
-                "runtime_unsupported", "requested OCI runtime is not registered"
-            )
+            raise DockerAdapterError("runtime_unsupported", "requested OCI runtime is not registered")
         advertised = registration.get("path")
         arguments = registration.get("runtimeArgs", [])
         authority_path = runtime.oci_runtime_binary_path
@@ -1847,7 +1706,6 @@ class DockerRuntimeAdapter:
                     "OCI runtime registration is not installed authority",
                 )
             from .sandbox import _open_installed_regular
-
             descriptor = -1
             try:
                 descriptor = _open_installed_regular(authority_path)
@@ -1877,37 +1735,24 @@ class DockerRuntimeAdapter:
                 )
             observed_digest = binding.runtime_digest
         if observed_digest != authority_digest:
-            raise DockerAdapterError(
-                "runtime_preflight_failed",
-                "registered OCI runtime binary identity mismatch",
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "registered OCI runtime binary identity mismatch")
         if runtime.runtime_class.value == "hardened_gvisor" and (
             runtime.runsc_binary_path != authority_path
             or runtime.runsc_binary_digest != observed_digest
         ):
-            raise DockerAdapterError(
-                "runtime_unsupported", "runsc authority is contradictory"
-            )
+            raise DockerAdapterError("runtime_unsupported", "runsc authority is contradictory")
         image = await self._execute(
             (invocation.argv0, "image", "inspect", plan.image.image_digest),
-            timeout_ms=plan.limits.action_timeout_ms,
-            output_limit=output_limit,
+            timeout_ms=plan.limits.action_timeout_ms, output_limit=output_limit,
         )
         if not _image_identity_matches(image.stdout, plan.image.image_digest):
-            raise DockerAdapterError(
-                "runtime_preflight_failed", "immutable image identity mismatch"
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "immutable image identity mismatch")
         return DockerPreflightObservation(
-            docker_cli_digest=invocation.digest,
-            platform_version=platform_version,
-            runtime_name=runtime.oci_runtime_name,
-            advertised_path=advertised,
-            observed_oci_digest=observed_digest,
-            observed_oci_device=metadata.st_dev,
-            observed_oci_inode=metadata.st_ino,
-            version_payload=version.stdout,
-            info_payload=info.stdout,
-            image_payload=image.stdout,
+            docker_cli_digest=invocation.digest, platform_version=platform_version,
+            runtime_name=runtime.oci_runtime_name, advertised_path=advertised,
+            observed_oci_digest=observed_digest, observed_oci_device=metadata.st_dev,
+            observed_oci_inode=metadata.st_ino, version_payload=version.stdout,
+            info_payload=info.stdout, image_payload=image.stdout,
             daemon_binding=binding,
         )
 
@@ -1920,12 +1765,7 @@ class DockerRuntimeAdapter:
 
     @staticmethod
     def _is_not_found(result: DockerCommandResult, reference: str) -> bool:
-        if (
-            result.timed_out
-            or result.output_limited
-            or result.returncode == 0
-            or result.stdout.strip()
-        ):
+        if result.timed_out or result.output_limited or result.returncode == 0 or result.stdout.strip():
             return False
         stderr = result.stderr.strip()
         return stderr in {
@@ -1957,20 +1797,12 @@ class DockerRuntimeAdapter:
         except DockerAdapterError:
             return None, "stale_identity_uncertain"
 
-    async def prepare(
-        self,
-        plan: Any,
-        *,
-        lease_id: str,
-        workspace_id: str,
-        epoch: int,
-        role: str,
-        skeleton_path: Path,
-        mounts: Sequence[tuple[Path, str, bool]],
-        security_profile_path: Path,
-        security_profile_descriptor: int,
-        security_profile_metadata: os.stat_result,
-    ) -> tuple[str, str, tuple[str, ...]]:
+    async def prepare(self, plan: Any, *, lease_id: str, workspace_id: str, epoch: int,
+                      role: str, skeleton_path: Path,
+                      mounts: Sequence[tuple[Path, str, bool]],
+                      security_profile_path: Path,
+                      security_profile_descriptor: int,
+                      security_profile_metadata: os.stat_result) -> tuple[str, str, tuple[str, ...]]:
         self._pin(plan)
         profile = _bounded_regular_file_descriptor_bytes(
             security_profile_descriptor,
@@ -1982,9 +1814,7 @@ class DockerRuntimeAdapter:
             or "sha256:" + hashlib.sha256(profile).hexdigest()
             != plan.security_policy.seccomp_digest
         ):
-            raise DockerAdapterError(
-                "runtime_preflight_failed", "seccomp profile identity mismatch"
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "seccomp profile identity mismatch")
         argv = build_create_argv(
             plan,
             lease_id=lease_id,
@@ -2065,20 +1895,12 @@ class DockerRuntimeAdapter:
             code="runtime_launch_failed",
         )
 
-    async def create_start(
-        self,
-        plan: Any,
-        *,
-        lease_id: str,
-        workspace_id: str,
-        epoch: int,
-        role: str,
-        skeleton_path: Path,
-        mounts: Sequence[tuple[Path, str, bool]],
-        security_profile_path: Path,
-        security_profile_descriptor: int,
-        security_profile_metadata: os.stat_result,
-    ) -> tuple[str, str, tuple[str, ...]]:
+    async def create_start(self, plan: Any, *, lease_id: str, workspace_id: str, epoch: int,
+                           role: str, skeleton_path: Path,
+                           mounts: Sequence[tuple[Path, str, bool]],
+                           security_profile_path: Path,
+                           security_profile_descriptor: int,
+                           security_profile_metadata: os.stat_result) -> tuple[str, str, tuple[str, ...]]:
         prepared = await self.prepare(
             plan,
             lease_id=lease_id,
@@ -2127,7 +1949,9 @@ class DockerRuntimeAdapter:
     ) -> Mapping[str, Any]:
         self._pin(plan)
         captured_output_limit = (
-            plan.limits.observation_bytes if output_limit is None else output_limit
+            plan.limits.observation_bytes
+            if output_limit is None
+            else output_limit
         )
         raw_argv = (
             plan.runtime.executable_path,
@@ -2196,25 +2020,17 @@ class DockerRuntimeAdapter:
             return (identity,)
         attempted: list[tuple[str, DockerCommandResult]] = []
         for resource, argv in (
-            (
-                "runtime_stop",
-                (plan.runtime.executable_path, "stop", "--time", "5", bound_id),
-            ),
-            (
-                "runtime_remove",
-                (plan.runtime.executable_path, "rm", "--force", bound_id),
-            ),
+            ("runtime_stop", (plan.runtime.executable_path, "stop", "--time", "5", bound_id)),
+            ("runtime_remove", (plan.runtime.executable_path, "rm", "--force", bound_id)),
         ):
-            attempted.append(
-                (
-                    resource,
-                    await self._raw(
-                        argv,
-                        timeout_ms=plan.limits.action_timeout_ms,
-                        output_limit=plan.limits.observation_bytes,
-                    ),
-                )
-            )
+            attempted.append((
+                resource,
+                await self._raw(
+                    argv,
+                    timeout_ms=plan.limits.action_timeout_ms,
+                    output_limit=plan.limits.observation_bytes,
+                ),
+            ))
         final = await self._inspect_raw(plan, bound_id)
         if not self._is_not_found(final, bound_id):
             reason = (
@@ -2222,16 +2038,12 @@ class DockerRuntimeAdapter:
                 if not final.timed_out and not final.output_limited
                 else "stale_identity_uncertain"
             )
-            return tuple((resource, "failed", reason) for resource, _ in attempted) + (
-                ("runtime_absence", "failed", reason),
-            )
+            return tuple(
+                (resource, "failed", reason) for resource, _ in attempted
+            ) + (("runtime_absence", "failed", reason),)
         normalized: list[tuple[str, str, str]] = []
         for resource, result in attempted:
-            if (
-                not result.timed_out
-                and not result.output_limited
-                and result.returncode == 0
-            ):
+            if not result.timed_out and not result.output_limited and result.returncode == 0:
                 normalized.append((resource, "released", ""))
             elif self._is_not_found(result, bound_id):
                 normalized.append((resource, "already_released", ""))
@@ -2241,10 +2053,9 @@ class DockerRuntimeAdapter:
         return tuple(normalized)
 
 
+
 class DockerMeasurementProvider(Protocol):
-    async def measure(
-        self, plan: Any, container_name: str, inspect_payload: bytes
-    ) -> Mapping[str, Any]: ...
+    async def measure(self, plan: Any, container_name: str, inspect_payload: bytes) -> Mapping[str, Any]: ...
 
 
 def requested_measurement(
@@ -2261,8 +2072,7 @@ def requested_measurement(
         "capabilities": "drop_all",
         "no_new_privileges": plan.security_policy.no_new_privileges,
         "seccomp": plan.security_policy.seccomp_digest,
-        "lsm": plan.security_policy.apparmor_profile
-        or plan.security_policy.selinux_label,
+        "lsm": plan.security_policy.apparmor_profile or plan.security_policy.selinux_label,
         "read_only_root": plan.security_policy.read_only_root,
         "mounts": tuple(
             (destination, readonly)
@@ -2270,9 +2080,7 @@ def requested_measurement(
         ),
         "mount_sources": tuple(
             (str(source), destination, readonly)
-            for source, destination, readonly in sorted(
-                mounts, key=lambda item: item[1]
-            )
+            for source, destination, readonly in sorted(mounts, key=lambda item: item[1])
         ),
         "tmpfs": tuple(sorted(plan.security_policy.tmpfs_mounts)),
         "network": "none",
@@ -2282,9 +2090,7 @@ def requested_measurement(
         "memory_swap": plan.resources.memory_bytes,
         "pids": plan.resources.pids,
         "nofile": plan.resources.open_files,
-        "storage": plan.resources.storage_bytes
-        if storage_bytes is None
-        else storage_bytes,
+        "storage": plan.resources.storage_bytes if storage_bytes is None else storage_bytes,
         "output_limit": plan.limits.observation_bytes,
         "cgroups": ("", "private"),
         "namespaces": (
@@ -2300,12 +2106,8 @@ def requested_measurement(
     return measured
 
 
-def measurement_mismatches(
-    requested: Mapping[str, Any], measured: Mapping[str, Any]
-) -> tuple[str, ...]:
-    return tuple(
-        sorted(key for key, value in requested.items() if measured.get(key) != value)
-    )
+def measurement_mismatches(requested: Mapping[str, Any], measured: Mapping[str, Any]) -> tuple[str, ...]:
+    return tuple(sorted(key for key, value in requested.items() if measured.get(key) != value))
 
 
 class InspectDockerMeasurementProvider:
@@ -2350,7 +2152,6 @@ class DockerRuntimeHandle:
 
     def _record_terminal_cleanup(self, receipts: tuple[Any, ...]) -> None:
         from .materialization import CleanupState
-
         states = {item.state for item in receipts}
         if states <= {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}:
             self._closed = True
@@ -2380,10 +2181,7 @@ class DockerRuntimeHandle:
         except BaseException as exc:
             indeterminate = not isinstance(exc, DockerAdapterError) or (
                 exc.code == "output_limit_exceeded"
-                or (
-                    exc.code == "runtime_launch_failed"
-                    and "returncode" not in exc.details
-                )
+                or (exc.code == "runtime_launch_failed" and "returncode" not in exc.details)
             )
             if indeterminate:
                 self._fenced = True
@@ -2444,9 +2242,7 @@ class DockerRuntimeHandle:
         ceiling: int,
     ) -> Mapping[str, Any]:
         if type(offset) is not int or offset < 0:
-            raise DockerAdapterError(
-                "runtime_preflight_failed", "read offset is invalid"
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "read offset is invalid")
         if limit is not None and (
             type(limit) is not int or limit < 0 or limit > ceiling
         ):
@@ -2507,14 +2303,10 @@ class DockerRuntimeHandle:
 
     async def write_text(self, path: str, content: str) -> Mapping[str, Any]:
         if type(content) is not str:
-            raise DockerAdapterError(
-                "runtime_preflight_failed", "write content is invalid"
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "write content is invalid")
         payload = content.encode("utf-8")
         if len(payload) > self.plan.limits.artifact_bytes_each:
-            raise DockerAdapterError(
-                "output_limit_exceeded", "write exceeds admitted ceiling"
-            )
+            raise DockerAdapterError("output_limit_exceeded", "write exceeds admitted ceiling")
         result = await self._run(
             _workspace_python_argv(
                 "write",
@@ -2529,14 +2321,8 @@ class DockerRuntimeHandle:
         return {"path": path, "bytes": len(payload)}
 
     async def list_files(self, path: str, *, depth: int) -> Mapping[str, Any]:
-        if (
-            type(depth) is not int
-            or depth < 0
-            or depth > self.plan.security_policy.snapshot_max_depth
-        ):
-            raise DockerAdapterError(
-                "output_limit_exceeded", "list depth exceeds admitted ceiling"
-            )
+        if type(depth) is not int or depth < 0 or depth > self.plan.security_policy.snapshot_max_depth:
+            raise DockerAdapterError("output_limit_exceeded", "list depth exceeds admitted ceiling")
         result = await self._run(
             _workspace_python_argv(
                 "list",
@@ -2638,7 +2424,9 @@ class DockerRuntimeHandle:
                 "runtime_preflight_failed",
                 "workspace diff requires exactly one repository mount",
             )
-        repository_root = _container_workspace_path(repositories[0].target_logical_path)
+        repository_root = _container_workspace_path(
+            repositories[0].target_logical_path
+        )
         result = await self._run(
             ("git", "-C", repository_root, "diff", "--no-ext-diff", "--binary"),
             timeout_ms=self.plan.limits.action_timeout_ms,
@@ -2652,7 +2440,6 @@ class DockerRuntimeHandle:
 
     async def _terminate_bound(self) -> tuple[Any, ...]:
         from .materialization import CleanupState, CleanupStepReceipt
-
         try:
             reference = self.container_id or self.container_name
             raw = await self.adapter.cleanup(
@@ -2677,8 +2464,7 @@ class DockerRuntimeHandle:
             "quarantined": CleanupState.QUARANTINED,
         }
         return tuple(
-            CleanupStepReceipt(name, states[state], detail)
-            for name, state, detail in raw
+            CleanupStepReceipt(name, states[state], detail) for name, state, detail in raw
         )
 
     async def _retry_cleanup(self) -> tuple[Any, ...]:
@@ -2774,7 +2560,6 @@ class DockerRuntimeHandle:
 
     async def terminate(self) -> tuple[Any, ...]:
         from .materialization import CleanupState, CleanupStepReceipt
-
         if self._terminal_cleanup is not None:
             return self._terminal_cleanup
         if self._closed:
@@ -2783,31 +2568,20 @@ class DockerRuntimeHandle:
 
 
 class DockerSandboxBackend:
-    def __init__(
-        self,
-        *,
-        adapter: DockerRuntimeAdapter,
-        measurement_provider: DockerMeasurementProvider,
-        security_profile_root: str | Path,
-        mount_stager: DockerDescriptorMountStager | None = None,
-        skeleton_path: str | Path | None = None,
-    ) -> None:
+    def __init__(self, *, adapter: DockerRuntimeAdapter, measurement_provider: DockerMeasurementProvider,
+                 security_profile_root: str | Path,
+                 mount_stager: DockerDescriptorMountStager | None = None,
+                 skeleton_path: str | Path | None = None) -> None:
         self.adapter = adapter
         self.measurement_provider = measurement_provider
         self.mount_stager = mount_stager
         self.security_profile_root = Path(security_profile_root)
-        if not self.security_profile_root.is_absolute() or os.path.normpath(
-            self.security_profile_root
-        ) != str(self.security_profile_root):
-            raise ValueError(
-                "Docker security profile root must be absolute and normalized"
-            )
-        flags = (
-            os.O_RDONLY
-            | getattr(os, "O_DIRECTORY", 0)
-            | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
-        )
+        if (
+            not self.security_profile_root.is_absolute()
+            or os.path.normpath(self.security_profile_root) != str(self.security_profile_root)
+        ):
+            raise ValueError("Docker security profile root must be absolute and normalized")
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
         self._security_root_fd = os.open(self.security_profile_root, flags)
         self._quarantined_fds: list[int] = []
         self._quarantined_handles: list[DockerRuntimeHandle] = []
@@ -2816,6 +2590,7 @@ class DockerSandboxBackend:
     @property
     def cleanup_pending(self) -> bool:
         return bool(self._quarantined_handles or self._quarantined_stages)
+
 
     def close(self) -> None:
         if self._quarantined_handles or self._quarantined_stages:
@@ -2885,9 +2660,7 @@ class DockerSandboxBackend:
         def read_installed() -> bytes:
             descriptor = os.open(
                 name,
-                os.O_RDONLY
-                | getattr(os, "O_CLOEXEC", 0)
-                | getattr(os, "O_NOFOLLOW", 0),
+                os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
                 dir_fd=self._security_root_fd,
             )
             try:
@@ -2934,7 +2707,9 @@ class DockerSandboxBackend:
                 os.fsync(descriptor)
                 os.close(descriptor)
                 descriptor = -1
-                os.replace(temporary, name, src_dir_fd=directory, dst_dir_fd=directory)
+                os.replace(
+                    temporary, name, src_dir_fd=directory, dst_dir_fd=directory
+                )
                 os.fsync(directory)
             finally:
                 if descriptor >= 0:
@@ -2954,22 +2729,14 @@ class DockerSandboxBackend:
             or "sha256:" + hashlib.sha256(current).hexdigest()
             != plan.security_policy.seccomp_digest
         ):
-            raise DockerAdapterError(
-                "runtime_preflight_failed", "installed seccomp profile is tampered"
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "installed seccomp profile is tampered")
         return Path(name)
 
     @staticmethod
     def _validate_context(plan: Any, context: Any) -> None:
         from .sandbox import RuntimeLaunchContext, WorkspaceStorageIdentity
-
-        if (
-            type(context) is not RuntimeLaunchContext
-            or type(context.storage) is not WorkspaceStorageIdentity
-        ):
-            raise DockerAdapterError(
-                "runtime_preflight_failed", "exact runtime launch context required"
-            )
+        if type(context) is not RuntimeLaunchContext or type(context.storage) is not WorkspaceStorageIdentity:
+            raise DockerAdapterError("runtime_preflight_failed", "exact runtime launch context required")
         storage = context.storage
         if (
             type(storage.authority_id) is not str
@@ -2980,9 +2747,7 @@ class DockerSandboxBackend:
             or type(storage.owner_uid) is not int
             or type(storage.owner_gid) is not int
         ):
-            raise DockerAdapterError(
-                "runtime_preflight_failed", "workspace quota authority is not enforced"
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "workspace quota authority is not enforced")
         if context.role == "primary":
             valid = (
                 context.snapshot_relative_path is None
@@ -2999,24 +2764,14 @@ class DockerSandboxBackend:
         else:
             valid = False
         if not valid:
-            raise DockerAdapterError(
-                "runtime_preflight_failed", "runtime launch context is contradictory"
-            )
+            raise DockerAdapterError("runtime_preflight_failed", "runtime launch context is contradictory")
 
     @staticmethod
     def _mount_specs(plan: Any, context: Any) -> tuple[tuple[str, str, bool], ...]:
         if context.role == "verifier":
             return (
-                (
-                    context.snapshot_relative_path,
-                    f"{CONTAINER_WORKSPACE_ROOT}/snapshot",
-                    True,
-                ),
-                (
-                    context.result_relative_path,
-                    f"{CONTAINER_WORKSPACE_ROOT}/result",
-                    False,
-                ),
+                (context.snapshot_relative_path, f"{CONTAINER_WORKSPACE_ROOT}/snapshot", True),
+                (context.result_relative_path, f"{CONTAINER_WORKSPACE_ROOT}/result", False),
             )
         return tuple(
             (
@@ -3026,7 +2781,6 @@ class DockerSandboxBackend:
             )
             for entry in plan.materialization_plan.entries
         )
-
     async def launch(
         self, plan: Any, workspace: Path, *, context: Any
     ) -> tuple[DockerRuntimeHandle, Any]:
@@ -3039,7 +2793,9 @@ class DockerSandboxBackend:
         workspace_fd = getattr(context, "workspace_fd", None)
         workspace_identity = getattr(context, "workspace_identity", None)
         held_fds = (
-            [workspace_fd] if type(workspace_fd) is int and workspace_fd >= 0 else []
+            [workspace_fd]
+            if type(workspace_fd) is int and workspace_fd >= 0
+            else []
         )
         creation_attempted = False
         container_id: str | None = None
@@ -3111,9 +2867,7 @@ class DockerSandboxBackend:
                 expected_identity=workspace_identity,
             )
             admitted_mounts: list[tuple[int, str, bool, os.stat_result]] = []
-            for relative_path, destination, readonly in self._mount_specs(
-                plan, context
-            ):
+            for relative_path, destination, readonly in self._mount_specs(plan, context):
                 child_fd = _openat2_beneath(workspace_fd, relative_path)
                 held_fds.append(child_fd)
                 child_metadata = _validate_mount_descriptor(
@@ -3160,13 +2914,9 @@ class DockerSandboxBackend:
             )
             held_fds.append(profile_fd)
             profile_metadata = os.fstat(profile_fd)
-            if (
-                not stat.S_ISREG(profile_metadata.st_mode)
-                or profile_metadata.st_nlink != 1
-            ):
+            if not stat.S_ISREG(profile_metadata.st_mode) or profile_metadata.st_nlink != 1:
                 raise DockerAdapterError(
-                    "runtime_preflight_failed",
-                    "seccomp profile descriptor is not immutable authority",
+                    "runtime_preflight_failed", "seccomp profile descriptor is not immutable authority"
                 )
             profile_stage = await self.mount_stager.stage(
                 profile_fd,
@@ -3189,14 +2939,9 @@ class DockerSandboxBackend:
                 await self.mount_stager.validate(staged, descriptor)
             creation_attempted = True
             container_id, container_name, _ = await self.adapter.prepare(
-                plan,
-                lease_id=context.lease_id,
-                workspace_id=context.workspace_id,
-                epoch=context.epoch,
-                role=context.role,
-                skeleton_path=workspace_source,
-                mounts=tuple(descriptor_mounts),
-                security_profile_path=profile_source,
+                plan, lease_id=context.lease_id, workspace_id=context.workspace_id,
+                epoch=context.epoch, role=context.role, skeleton_path=workspace_source,
+                mounts=tuple(descriptor_mounts), security_profile_path=profile_source,
                 security_profile_descriptor=profile_fd,
                 security_profile_metadata=profile_metadata,
             )
@@ -3224,22 +2969,16 @@ class DockerSandboxBackend:
                 staged.validate_descriptor(descriptor)
                 await self.mount_stager.validate(staged, descriptor)
             measured = decode_docker_inspect(
-                inspect_payload,
-                plan,
-                container_id=container_id,
-                container_name=container_name,
-                labels=labels,
-                skeleton_path=workspace_source,
-                mounts=tuple(descriptor_mounts),
+                inspect_payload, plan, container_id=container_id,
+                container_name=container_name, labels=labels,
+                skeleton_path=workspace_source, mounts=tuple(descriptor_mounts),
                 security_profile_path=profile_source,
                 storage_bytes=context.storage.quota_bytes,
             )
             effective = dict(measured)
-            external = dict(
-                await self.measurement_provider.measure(
-                    plan, container_name, inspect_payload
-                )
-            )
+            external = dict(await self.measurement_provider.measure(
+                plan, container_name, inspect_payload
+            ))
             unknown = set(external) - set(measured)
             if unknown:
                 raise DockerAdapterError(
@@ -3250,10 +2989,8 @@ class DockerSandboxBackend:
             measured.update(external)
             identity = (container_id, container_name, identity_labels)
             requested = requested_measurement(
-                plan,
-                tuple(descriptor_mounts),
-                storage_bytes=context.storage.quota_bytes,
-                identity=identity,
+                plan, tuple(descriptor_mounts),
+                storage_bytes=context.storage.quota_bytes, identity=identity,
             )
             storage_identity = (
                 context.storage.authority_id,
@@ -3267,14 +3004,9 @@ class DockerSandboxBackend:
             measured["storage_identity"] = storage_identity
             effective["storage_identity"] = storage_identity
             handle = DockerRuntimeHandle(
-                adapter=self.adapter,
-                plan=plan,
-                container_id=container_id,
-                container_name=container_name,
-                labels=labels,
-                held_fds=held_fds,
-                mount_stager=self.mount_stager,
-                staged_mounts=staged_mounts,
+                adapter=self.adapter, plan=plan, container_id=container_id,
+                container_name=container_name, labels=labels, held_fds=held_fds,
+                mount_stager=self.mount_stager, staged_mounts=staged_mounts,
                 lease_id=context.lease_id,
             )
             repository_base_commit = await handle.measure_repository_base_commit()
@@ -3282,14 +3014,10 @@ class DockerSandboxBackend:
                 requested["workspace_base_commit"] = repository_base_commit
                 effective["workspace_base_commit"] = repository_base_commit
                 measured["workspace_base_commit"] = repository_base_commit
-            mismatch = tuple(
-                sorted(
-                    {
-                        *measurement_mismatches(requested, effective),
-                        *measurement_mismatches(requested, measured),
-                    }
-                )
-            )
+            mismatch = tuple(sorted({
+                *measurement_mismatches(requested, effective),
+                *measurement_mismatches(requested, measured),
+            }))
             if mismatch:
                 raise DockerAdapterError(
                     "runtime_measurement_mismatch",
@@ -3299,20 +3027,15 @@ class DockerSandboxBackend:
             held_fds = []
             return handle, SandboxMeasurement(
                 effective_plan_digest=plan.effective_plan_digest,
-                lease_id=context.lease_id,
-                workspace_id=context.workspace_id,
+                lease_id=context.lease_id, workspace_id=context.workspace_id,
                 runtime_id=plan.runtime.runtime_id,
                 runtime_class=plan.runtime.runtime_class.value,
                 driver_binary_digest=plan.runtime.measured_binary_digest,
-                image_digest=plan.image.image_digest,
-                requested=requested,
-                effective=effective,
-                measured=measured,
-                runtime_resource_id=container_id,
-                mismatch=(),
+                image_digest=plan.image.image_digest, requested=requested,
+                effective=effective, measured=measured,
+                runtime_resource_id=container_id, mismatch=(),
                 isolation_disposition=IsolationDisposition.ISOLATED,
-                isolated=True,
-                reward_eligible=True,
+                isolated=True, reward_eligible=True,
             )
         except BaseException as primary:
             if isinstance(primary, DockerAdapterError):
@@ -3323,34 +3046,31 @@ class DockerSandboxBackend:
                 ):
                     container_id = candidate
                 reported_cleanup = primary.details.get("cleanup")
-                if type(reported_cleanup) in {list, tuple} and all(
-                    type(item) in {list, tuple}
-                    and len(item) == 3
-                    and all(type(value) is str for value in item)
-                    for item in reported_cleanup
+                if (
+                    type(reported_cleanup) in {list, tuple}
+                    and all(
+                        type(item) in {list, tuple}
+                        and len(item) == 3
+                        and all(type(value) is str for value in item)
+                        for item in reported_cleanup
+                    )
                 ):
                     cleanup = tuple(tuple(item) for item in reported_cleanup)
             if container_id is not None:
                 try:
                     cleanup = await self.adapter.cleanup(
-                        plan,
-                        container_id,
-                        expected_id=container_id,
-                        expected_name=container_name,
-                        labels=labels,
+                        plan, container_id, expected_id=container_id,
+                        expected_name=container_name, labels=labels,
                     )
                 except BaseException as cleanup_error:
                     cleanup = (
-                        (
-                            "runtime_identity",
-                            "quarantined",
-                            type(cleanup_error).__name__,
-                        ),
+                        ("runtime_identity", "quarantined", type(cleanup_error).__name__),
                     )
                 if isinstance(primary, DockerAdapterError):
                     primary.details["cleanup"] = cleanup
             absence = any(
-                name == "runtime_absence" and state in {"released", "already_released"}
+                name == "runtime_absence"
+                and state in {"released", "already_released"}
                 for name, state, _ in cleanup
             )
             runtime_cleanup_pending = creation_attempted and not absence
@@ -3436,9 +3156,9 @@ class DockerSandboxBackend:
             while held_fds:
                 os.close(held_fds.pop())
 
+
     async def reconcile(self, record: Mapping[str, Any]) -> tuple[Any, ...]:
         from .materialization import CleanupState, CleanupStepReceipt
-
         # Legacy records contain only pathname/digest observations.  They do not
         # carry a durable daemon binding proving which OCI executable dockerd
         # consumed, so executing any CLI command could invoke unadmitted code.
@@ -3451,24 +3171,11 @@ class DockerSandboxBackend:
         )
 
 
-__all__ = [
-    "DockerAdapterError",
-    "DockerCliExecutor",
-    "SubprocessDockerCliExecutor",
-    "DockerCommandResult",
-    "ExecutableInvocation",
-    "DockerPreflightObservation",
-    "PrivateDockerDaemonBinding",
-    "StagedDockerDescriptorMount",
-    "DockerDescriptorMountStager",
-    "DockerRuntimeAdapter",
-    "DockerMeasurementProvider",
-    "InspectDockerMeasurementProvider",
-    "DockerRuntimeHandle",
-    "DockerSandboxBackend",
-    "build_create_argv",
-    "decode_docker_inspect",
-    "observe_binary_digest",
-    "measurement_mismatches",
-    "requested_measurement",
-]
+__all__ = ["DockerAdapterError", "DockerCliExecutor", "SubprocessDockerCliExecutor", "DockerCommandResult", "ExecutableInvocation",
+           "DockerPreflightObservation", "PrivateDockerDaemonBinding",
+           "StagedDockerDescriptorMount", "DockerDescriptorMountStager",
+           "DockerRuntimeAdapter",
+           "DockerMeasurementProvider", "InspectDockerMeasurementProvider",
+           "DockerRuntimeHandle", "DockerSandboxBackend",
+           "build_create_argv", "decode_docker_inspect", "observe_binary_digest",
+           "measurement_mismatches", "requested_measurement"]

--- a/breadboard/rl/harness/service.py
+++ b/breadboard/rl/harness/service.py
@@ -1902,12 +1902,8 @@ class BreadBoardV2EpisodeService:
             raw_workspace_diff = coordinator.lease.sealed_workspace_diff()
             if raw_workspace_diff is not None:
                 expected_keys = {
-                    "returncode",
-                    "stdout",
-                    "stderr",
-                    "base_commit",
-                    "git_executable_digest",
-                    "patch_digest",
+                    "returncode", "stdout", "stderr", "base_commit",
+                    "git_executable_digest", "patch_digest",
                     "snapshot_root_digest",
                 }
                 patch_bytes = raw_workspace_diff.get("stdout", "").encode("utf-8")
@@ -1922,8 +1918,7 @@ class BreadBoardV2EpisodeService:
                     or type(raw_workspace_diff["snapshot_root_digest"]) is not str
                     or raw_workspace_diff["returncode"] != 0
                     or raw_workspace_diff["stderr"] != ""
-                    or raw_workspace_diff["snapshot_root_digest"]
-                    != snapshot.root_digest
+                    or raw_workspace_diff["snapshot_root_digest"] != snapshot.root_digest
                     or raw_workspace_diff["patch_digest"]
                     != "sha256:" + hashlib.sha256(patch_bytes).hexdigest()
                 ):

--- a/breadboard/rl/harness/service.py
+++ b/breadboard/rl/harness/service.py
@@ -443,6 +443,7 @@ class V2RunResult:
     primary_measurement_digest: str | None = None
     verifier_measurement_digest: str | None = None
     verifier_result_digest: str | None = None
+    workspace_diff: Mapping[str, Any] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -570,6 +571,7 @@ class _V2EpisodeCoordinator:
     verifier_lease_id: str | None = None
     verifier_snapshot: VerifierSnapshotReceipt | None = None
     verifier_result: Mapping[str, Any] | None = None
+    workspace_diff: Mapping[str, Any] | None = None
     runner_event_refs: list[ArtifactRef] = field(default_factory=list)
     fault_injection: V2FaultInjectionAdmission | None = None
     fault_injection_consumed: bool = False
@@ -1512,8 +1514,7 @@ class BreadBoardV2EpisodeService:
                 coordinator.primary_lease_id = lease.lease_id
                 if (
                     coordinator.cancel_event.is_set()
-                    or coordinator.state
-                    is not EpisodeLifecycleState.ALLOCATING
+                    or coordinator.state is not EpisodeLifecycleState.ALLOCATING
                 ):
                     post_open_cancelled = True
                 else:
@@ -1896,6 +1897,24 @@ class BreadBoardV2EpisodeService:
         verifier: VerifierWorkspaceLease | None = None
         verification_error: BaseException | None = None
         try:
+            raw_workspace_diff = (
+                await coordinator.lease.runner_workspace.workspace_diff()
+            )
+            if (
+                set(raw_workspace_diff) != {"returncode", "stdout", "stderr"}
+                or type(raw_workspace_diff["returncode"]) is not int
+                or type(raw_workspace_diff["stdout"]) is not str
+                or type(raw_workspace_diff["stderr"]) is not str
+                or raw_workspace_diff["returncode"] != 0
+            ):
+                raise RuntimeError("canonical workspace diff failed")
+            coordinator.workspace_diff = MappingProxyType(
+                {
+                    "returncode": raw_workspace_diff["returncode"],
+                    "stdout": raw_workspace_diff["stdout"],
+                    "stderr": raw_workspace_diff["stderr"],
+                }
+            )
             snapshot = await coordinator.lease.seal_for_verifier()
             coordinator.verifier_snapshot = snapshot
             probe.raise_if_cancelled("before_verifier_open")
@@ -1912,10 +1931,7 @@ class BreadBoardV2EpisodeService:
                 if coordinator.verifier_cleanup_task is None:
                     coordinator.verifier_cleanup_task = asyncio.create_task(
                         verifier.close(),
-                        name=(
-                            "bb-v2-verifier-close:"
-                            f"{coordinator.request.episode_id}"
-                        ),
+                        name=(f"bb-v2-verifier-close:{coordinator.request.episode_id}"),
                     )
                 (
                     receipt,
@@ -1928,10 +1944,7 @@ class BreadBoardV2EpisodeService:
                     coordinator.verifier_cleanup_failure = _failure_from_exception(
                         close_error, "verifier_cleanup"
                     )
-                if (
-                    cleanup_cancellation is not None
-                    and verification_error is None
-                ):
+                if cleanup_cancellation is not None and verification_error is None:
                     verification_error = cleanup_cancellation
         verifier_receipt = coordinator.verifier_cleanup_receipt
         verifier_cleanup_lease_mismatch = (
@@ -2075,6 +2088,7 @@ class BreadBoardV2EpisodeService:
             primary_measurement_digest=completed.primary_measurement_digest,
             verifier_measurement_digest=completed.verifier_measurement_digest,
             verifier_result_digest=completed.verifier_result_digest,
+            workspace_diff=coordinator.workspace_diff,
         )
         coordinator.run_result = result
         return result
@@ -2362,9 +2376,7 @@ class BreadBoardV2EpisodeService:
                 except BaseException as exc:
                     errors.append(exc)
             else:
-                errors.extend(
-                    await self._coordinator_operation_failures(coordinator)
-                )
+                errors.extend(await self._coordinator_operation_failures(coordinator))
         errors.extend(await self._drain_operation_tasks())
         try:
             sandbox_receipts = await self._dependencies.sandbox_runtime.close()
@@ -2375,9 +2387,8 @@ class BreadBoardV2EpisodeService:
                     (),
                 )
                 for receipt in sandbox_receipts
-                if receipt.state not in {
-                    CleanupState.RELEASED, CleanupState.ALREADY_RELEASED
-                }
+                if receipt.state
+                not in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
             )
         except BaseException as exc:
             errors.append(exc)
@@ -2628,8 +2639,7 @@ class BreadBoardV2EpisodeService:
                 task = asyncio.create_task(
                     session.close(),
                     name=(
-                        "bb-v2-runner-session-close:"
-                        f"{coordinator.request.episode_id}"
+                        f"bb-v2-runner-session-close:{coordinator.request.episode_id}"
                     ),
                 )
                 coordinator.session_close_task = task
@@ -2643,7 +2653,6 @@ class BreadBoardV2EpisodeService:
                         close_error, "session_close"
                     )
         return cancellation, close_error
-
 
     async def _close_unowned_binding(
         self, coordinator: _V2EpisodeCoordinator
@@ -3138,6 +3147,7 @@ class BreadBoardV2EpisodeService:
             "response": dict(result.response),
             "termination": result.termination.value,
             "turn_count": result.turn_count,
+            "workspace_diff": dict(coordinator.workspace_diff or {}),
             "reward": verifier_result.get("reward"),
             "reward_components": dict(verifier_result.get("reward_components", {})),
         }
@@ -3446,6 +3456,11 @@ class BreadBoardV2EpisodeService:
                 primary_measurement_digest=recovered.primary_measurement_digest,
                 verifier_measurement_digest=recovered.verifier_measurement_digest,
                 verifier_result_digest=recovered.verifier_result_digest,
+                workspace_diff=(
+                    MappingProxyType(dict(run_payload["workspace_diff"]))
+                    if run_payload.get("workspace_diff")
+                    else None
+                ),
             )
         except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
             raise V2EpisodeQuarantined(
@@ -3494,6 +3509,7 @@ class BreadBoardV2EpisodeService:
             run_fingerprint=tombstone.run_fingerprint,
             primary_lease_id=recovered.primary_lease_id,
             primary_disposition=run_result.primary_disposition,
+            workspace_diff=run_result.workspace_diff,
             cleanup_disposition=EpisodeCleanupDisposition.RELEASED
             if recovered.closed_tombstone is not None
             else EpisodeCleanupDisposition.PENDING,

--- a/breadboard/rl/harness/service.py
+++ b/breadboard/rl/harness/service.py
@@ -1897,9 +1897,7 @@ class BreadBoardV2EpisodeService:
         verifier: VerifierWorkspaceLease | None = None
         verification_error: BaseException | None = None
         try:
-            raw_workspace_diff = (
-                await coordinator.lease.runner_workspace.workspace_diff()
-            )
+            raw_workspace_diff = await coordinator.lease.workspace_diff()
             if (
                 set(raw_workspace_diff) != {"returncode", "stdout", "stderr"}
                 or type(raw_workspace_diff["returncode"]) is not int

--- a/breadboard/rl/harness/service.py
+++ b/breadboard/rl/harness/service.py
@@ -1897,24 +1897,38 @@ class BreadBoardV2EpisodeService:
         verifier: VerifierWorkspaceLease | None = None
         verification_error: BaseException | None = None
         try:
-            raw_workspace_diff = await coordinator.lease.workspace_diff()
-            if (
-                set(raw_workspace_diff) != {"returncode", "stdout", "stderr"}
-                or type(raw_workspace_diff["returncode"]) is not int
-                or type(raw_workspace_diff["stdout"]) is not str
-                or type(raw_workspace_diff["stderr"]) is not str
-                or raw_workspace_diff["returncode"] != 0
-            ):
-                raise RuntimeError("canonical workspace diff failed")
-            coordinator.workspace_diff = MappingProxyType(
-                {
-                    "returncode": raw_workspace_diff["returncode"],
-                    "stdout": raw_workspace_diff["stdout"],
-                    "stderr": raw_workspace_diff["stderr"],
-                }
-            )
             snapshot = await coordinator.lease.seal_for_verifier()
             coordinator.verifier_snapshot = snapshot
+            raw_workspace_diff = coordinator.lease.sealed_workspace_diff()
+            if raw_workspace_diff is not None:
+                expected_keys = {
+                    "returncode",
+                    "stdout",
+                    "stderr",
+                    "base_commit",
+                    "git_executable_digest",
+                    "patch_digest",
+                    "snapshot_root_digest",
+                }
+                patch_bytes = raw_workspace_diff.get("stdout", "").encode("utf-8")
+                if (
+                    set(raw_workspace_diff) != expected_keys
+                    or type(raw_workspace_diff["returncode"]) is not int
+                    or type(raw_workspace_diff["stdout"]) is not str
+                    or type(raw_workspace_diff["stderr"]) is not str
+                    or type(raw_workspace_diff["base_commit"]) is not str
+                    or type(raw_workspace_diff["git_executable_digest"]) is not str
+                    or type(raw_workspace_diff["patch_digest"]) is not str
+                    or type(raw_workspace_diff["snapshot_root_digest"]) is not str
+                    or raw_workspace_diff["returncode"] != 0
+                    or raw_workspace_diff["stderr"] != ""
+                    or raw_workspace_diff["snapshot_root_digest"]
+                    != snapshot.root_digest
+                    or raw_workspace_diff["patch_digest"]
+                    != "sha256:" + hashlib.sha256(patch_bytes).hexdigest()
+                ):
+                    raise RuntimeError("canonical sealed workspace diff failed")
+                coordinator.workspace_diff = MappingProxyType(dict(raw_workspace_diff))
             probe.raise_if_cancelled("before_verifier_open")
             verifier = await self._dependencies.sandbox_runtime.open_verifier(
                 coordinator.lease, snapshot

--- a/docs/contracts/policies/acr/ACR-20260829-rl-sandbox-runtime.md
+++ b/docs/contracts/policies/acr/ACR-20260829-rl-sandbox-runtime.md
@@ -43,7 +43,7 @@ The RL harness needs one production sandbox contract and one installed headless 
 - Docker may be marked ready only after the Linux official SWE image canary proves `/testbed`, base commit, diff, cancellation, and resource absence.
 - Installed fake-policy validation must bind both E4 targets, an exact loopback route/model authority, one sampled request with retries disabled, semantic replay, result/event/patch digests, canonical patch bytes published through a distinct atomic destination, and terminal cleanup.
 - Trusted-process Linux integration covers leader exit, closed inherited descriptors, exact process-group/session/cgroup continuity, PID-reuse rejection, and descendant termination; detached sessions remain outside this explicitly non-isolating development adapter.
-- Canonical patch evidence is generated inside the verifier-seal boundary: terminate the primary runtime, use a sealed host-Git executable and private index bound to the launcher-measured base commit, include ignored and untracked files, then snapshot the same quiesced workspace and bind the patch digest to that snapshot root.
+- Canonical patch evidence is generated inside the verifier-seal boundary: terminate the primary runtime, snapshot the quiesced workspace, then use a sealed host-Git executable with a private repository, trusted attributes, private index, and launcher-measured base commit to derive a binary-safe patch from that immutable snapshot, including ignored and untracked files; bind its digest to the same snapshot root.
 - Exact-head correctness, security, automated review, danger-zone ACR guard, and full CI are required before merge.
 
 ## 6) Rollout Plan

--- a/docs/contracts/policies/acr/ACR-20260829-rl-sandbox-runtime.md
+++ b/docs/contracts/policies/acr/ACR-20260829-rl-sandbox-runtime.md
@@ -16,7 +16,7 @@ The RL harness needs one production sandbox contract and one installed headless 
 - Persistent Docker execution rooted at `/testbed`, including bounded command and file operations.
 - Explicit isolation and support status for Docker, gVisor, Firecracker, and process adapters.
 - Historical process factories restricted to explicit development use.
-- Installed headless request/result entrypoint with exact E4 target, provider route/model, secret handle, sandbox, limit, event, and cleanup authority.
+- Installed headless request/result entrypoint with exact E4 target, provider route/model, secret handle, sandbox, limit, event, canonical workspace-patch export, and cleanup authority.
 - Versioned semantic message/tool-call/tool-result replay interface; sampled-token and training fields remain external UAL authority.
 - Trusted-process runtime remains non-isolating and development-only; the installed headless entrypoint rejects it before loading provider credentials.
 - Danger-zone: yes.
@@ -41,7 +41,7 @@ The RL harness needs one production sandbox contract and one installed headless 
 - Docker security plan assertions: immutable digest, no implicit pull, explicit UID/GID, network selection, CPU/memory/PID/output bounds, ownership labels, and exact-resource cleanup.
 - Packaged `SANDBOX_CAPABILITY_MATRIX.json` must load from a clean installed wheel.
 - Docker may be marked ready only after the Linux official SWE image canary proves `/testbed`, base commit, diff, cancellation, and resource absence.
-- Installed fake-policy validation must bind both E4 targets, an exact loopback route/model authority, one sampled request with retries disabled, semantic replay, result/event digests, and terminal cleanup.
+- Installed fake-policy validation must bind both E4 targets, an exact loopback route/model authority, one sampled request with retries disabled, semantic replay, result/event/patch digests, canonical patch bytes published through a distinct atomic destination, and terminal cleanup.
 - Trusted-process Linux integration covers leader exit, closed inherited descriptors, exact process-group/session/cgroup continuity, PID-reuse rejection, and descendant termination; detached sessions remain outside this explicitly non-isolating development adapter.
 - Exact-head correctness, security, automated review, danger-zone ACR guard, and full CI are required before merge.
 

--- a/docs/contracts/policies/acr/ACR-20260829-rl-sandbox-runtime.md
+++ b/docs/contracts/policies/acr/ACR-20260829-rl-sandbox-runtime.md
@@ -43,6 +43,7 @@ The RL harness needs one production sandbox contract and one installed headless 
 - Docker may be marked ready only after the Linux official SWE image canary proves `/testbed`, base commit, diff, cancellation, and resource absence.
 - Installed fake-policy validation must bind both E4 targets, an exact loopback route/model authority, one sampled request with retries disabled, semantic replay, result/event/patch digests, canonical patch bytes published through a distinct atomic destination, and terminal cleanup.
 - Trusted-process Linux integration covers leader exit, closed inherited descriptors, exact process-group/session/cgroup continuity, PID-reuse rejection, and descendant termination; detached sessions remain outside this explicitly non-isolating development adapter.
+- Canonical patch evidence is generated inside the verifier-seal boundary: terminate the primary runtime, use a sealed host-Git executable and private index bound to the launcher-measured base commit, include ignored and untracked files, then snapshot the same quiesced workspace and bind the patch digest to that snapshot root.
 - Exact-head correctness, security, automated review, danger-zone ACR guard, and full CI are required before merge.
 
 ## 6) Rollout Plan

--- a/tests/rl/harness/test_headless_runner.py
+++ b/tests/rl/harness/test_headless_runner.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import sys
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -18,6 +20,7 @@ from breadboard.rl.harness.headless import (
     HeadlessRunRequest,
     HeadlessWorkspaceInput,
     _atomic_write,
+    _project_headless_run,
     _validate_repository_base_commit_binding,
     run_headless_request,
 )
@@ -94,6 +97,97 @@ def test_atomic_result_publication_refuses_existing_destination(
     assert list(tmp_path.iterdir()) == [destination]
 
 
+def test_headless_projection_exports_the_exact_workspace_patch() -> None:
+    patch = b"diff --git a/a.py b/a.py\n"
+    events = b'{"event":"done"}\n'
+
+    class CAS:
+        def __init__(self) -> None:
+            self.payloads = {
+                "manifest": json.dumps(
+                    {
+                        "runner_ledger_ref": self.ref("events", events),
+                        "artifact_manifest_ref": self.ref(
+                            "artifacts",
+                            json.dumps(
+                                {
+                                    "objects": [
+                                        {
+                                            "role": "workspace_patch",
+                                            "artifact_ref": self.ref("patch", patch),
+                                        }
+                                    ]
+                                },
+                                sort_keys=True,
+                            ).encode(),
+                        ),
+                    },
+                    sort_keys=True,
+                ).encode(),
+                "events": events,
+                "patch": patch,
+            }
+            self.payloads["artifacts"] = json.dumps(
+                {
+                    "objects": [
+                        {
+                            "role": "workspace_patch",
+                            "artifact_ref": self.ref("patch", patch),
+                        }
+                    ]
+                },
+                sort_keys=True,
+            ).encode()
+
+        @staticmethod
+        def ref(artifact_id: str, payload: bytes) -> dict[str, str]:
+            return {
+                "artifact_id": artifact_id,
+                "sha256": "sha256:" + hashlib.sha256(payload).hexdigest(),
+            }
+
+        def get_ref(self, artifact_id: str) -> SimpleNamespace:
+            payload = self.payloads[artifact_id]
+            projection = self.ref(artifact_id, payload)
+            return SimpleNamespace(**projection, to_dict=lambda: projection)
+
+        def get_bytes(self, ref: SimpleNamespace, *, max_bytes: int) -> bytes:
+            payload = self.payloads[ref.artifact_id]
+            assert len(payload) <= max_bytes
+            return payload
+
+    cas = CAS()
+    composition = SimpleNamespace(
+        authority_graph=SimpleNamespace(cas=cas),
+    )
+    run = SimpleNamespace(
+        primary_disposition=SimpleNamespace(value="succeeded"),
+        termination="completed",
+        turn_count=1,
+        response={"answer": "done"},
+        completed_envelope_ref=None,
+        closed_envelope_ref=None,
+        result_ref=None,
+        evidence_manifest_ref=cas.get_ref("manifest"),
+        evidence_root="sha256:" + "0" * 64,
+        artifact_manifest_ref=None,
+        primary_measurement_digest="sha256:" + "1" * 64,
+        verifier_measurement_digest="sha256:" + "2" * 64,
+        verifier_result_digest="sha256:" + "3" * 64,
+        reward=0.0,
+        reward_components={},
+    )
+    result: dict[str, Any] = {}
+
+    event_bytes, patch_bytes = _project_headless_run(result, run, composition)
+
+    assert event_bytes == events
+    assert patch_bytes == patch
+    assert result["workspace_evidence"]["patch_digest"] == (
+        "sha256:" + hashlib.sha256(patch).hexdigest()
+    )
+
+
 @pytest.mark.parametrize(
     "base_url",
     (
@@ -110,6 +204,7 @@ def test_provider_requires_usable_literal_loopback_authority(base_url: str) -> N
             base_url=base_url,
             policy_observation_digest="sha256:" + "0" * 64,
         )
+
 
 @pytest.mark.asyncio
 async def test_target_semantics_reject_changed_tool_parameter_schema(
@@ -152,7 +247,6 @@ async def test_target_semantics_reject_changed_tool_parameter_schema(
             )
     finally:
         await composition.close()
-
 
 
 @pytest.mark.skipif(
@@ -269,9 +363,7 @@ async def test_headless_runner_rejects_development_trusted_process(
         workspace=HeadlessWorkspaceInput(
             repository_snapshot_digest=plan.task.repository_snapshot_digest,
             base_commit=(
-                None
-                if plan.task.repository_snapshot_digest is None
-                else "0" * 40
+                None if plan.task.repository_snapshot_digest is None else "0" * 40
             ),
             task_image_digest=plan.sandbox.image_digest,
         ),

--- a/tests/rl/harness/test_headless_runner.py
+++ b/tests/rl/harness/test_headless_runner.py
@@ -103,41 +103,24 @@ def test_headless_projection_exports_the_exact_workspace_patch() -> None:
 
     class CAS:
         def __init__(self) -> None:
+            artifact_manifest = json.dumps(
+                {"objects": [{"role": "patch", "payload": "runner-result-json"}]},
+                sort_keys=True,
+            ).encode()
             self.payloads = {
                 "manifest": json.dumps(
                     {
                         "runner_ledger_ref": self.ref("events", events),
                         "artifact_manifest_ref": self.ref(
                             "artifacts",
-                            json.dumps(
-                                {
-                                    "objects": [
-                                        {
-                                            "role": "workspace_patch",
-                                            "artifact_ref": self.ref("patch", patch),
-                                        }
-                                    ]
-                                },
-                                sort_keys=True,
-                            ).encode(),
+                            artifact_manifest,
                         ),
                     },
                     sort_keys=True,
                 ).encode(),
                 "events": events,
-                "patch": patch,
+                "artifacts": artifact_manifest,
             }
-            self.payloads["artifacts"] = json.dumps(
-                {
-                    "objects": [
-                        {
-                            "role": "workspace_patch",
-                            "artifact_ref": self.ref("patch", patch),
-                        }
-                    ]
-                },
-                sort_keys=True,
-            ).encode()
 
         @staticmethod
         def ref(artifact_id: str, payload: bytes) -> dict[str, str]:
@@ -176,6 +159,11 @@ def test_headless_projection_exports_the_exact_workspace_patch() -> None:
         verifier_result_digest="sha256:" + "3" * 64,
         reward=0.0,
         reward_components={},
+        workspace_diff={
+            "returncode": 0,
+            "stdout": patch.decode(),
+            "stderr": "",
+        },
     )
     result: dict[str, Any] = {}
 
@@ -389,6 +377,7 @@ async def test_headless_runner_rejects_development_trusted_process(
         ),
         result_path=str(result_path),
         event_log_path=str(event_path),
+        patch_path=str(tmp_path / "workspace.patch"),
     )
     assert str(credential) not in request.model_dump_json()
     assert all(
@@ -446,6 +435,13 @@ async def test_headless_runner_rejects_development_trusted_process(
     assert rejected.value.result["terminal"]["failure"] == {
         "code": "ValueError",
         "category": "ValueError",
+    }
+    assert rejected.value.result["patch"] == {
+        "requested": True,
+        "destination": str(tmp_path / "workspace.patch"),
+        "digest": None,
+        "size_bytes": None,
+        "available": False,
     }
     assert json.loads(result_path.read_bytes()) == rejected.value.result
     assert not event_path.exists()

--- a/tests/rl/harness/test_headless_runner.py
+++ b/tests/rl/harness/test_headless_runner.py
@@ -171,7 +171,13 @@ def test_headless_projection_exports_the_exact_workspace_patch() -> None:
     )
     result: dict[str, Any] = {}
 
-    event_bytes, patch_bytes = _project_headless_run(result, run, composition)
+    with pytest.raises(ValueError, match="base commit mismatch"):
+        _project_headless_run(
+            {}, run, composition, expected_base_commit="1" * 40
+        )
+    event_bytes, patch_bytes = _project_headless_run(
+        result, run, composition, expected_base_commit="0" * 40
+    )
 
     assert event_bytes == events
     assert patch_bytes == patch

--- a/tests/rl/harness/test_headless_runner.py
+++ b/tests/rl/harness/test_headless_runner.py
@@ -163,6 +163,10 @@ def test_headless_projection_exports_the_exact_workspace_patch() -> None:
             "returncode": 0,
             "stdout": patch.decode(),
             "stderr": "",
+            "base_commit": "0" * 40,
+            "git_executable_digest": "sha256:" + "4" * 64,
+            "patch_digest": "sha256:" + hashlib.sha256(patch).hexdigest(),
+            "snapshot_root_digest": "sha256:" + "5" * 64,
         },
     )
     result: dict[str, Any] = {}

--- a/tests/rl/harness/test_headless_runner.py
+++ b/tests/rl/harness/test_headless_runner.py
@@ -360,9 +360,7 @@ async def test_headless_runner_rejects_development_trusted_process(
         context={"campaign": "e4"},
         workspace=HeadlessWorkspaceInput(
             repository_snapshot_digest=plan.task.repository_snapshot_digest,
-            base_commit=(
-                None if plan.task.repository_snapshot_digest is None else "0" * 40
-            ),
+            base_commit="0" * 40,
             task_image_digest=plan.sandbox.image_digest,
         ),
         expected_resources=plan.effective_capabilities.resources,
@@ -412,6 +410,14 @@ async def test_headless_runner_rejects_development_trusted_process(
         alternate_route.identity_dict()["caller_headers_sha256"]
         != route.identity_dict()["caller_headers_sha256"]
     )
+
+    if request.workspace.repository_snapshot_digest is None:
+        with pytest.raises(ValueError, match="not bound"):
+            _validate_repository_base_commit_binding(request, {})
+        _validate_repository_base_commit_binding(
+            request,
+            {request.workspace.task_image_digest: request.workspace.base_commit},
+        )
 
     bound_digest = "sha256:" + "1" * 64
     bound_commit = "2" * 40

--- a/tests/rl/harness/test_sandbox_docker.py
+++ b/tests/rl/harness/test_sandbox_docker.py
@@ -804,6 +804,40 @@ async def test_runtime_handle_zero_byte_read_is_a_nonfencing_success(
 
 
 @pytest.mark.asyncio
+async def test_launch_measurement_error_leaves_cleanup_with_backend_owner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, _, handle = await _launch_docker_handle(tmp_path)
+    original_exec = handle.adapter.exec
+    original_cleanup = handle._retry_cleanup
+    cleanup_calls = 0
+
+    async def fail_measurement(*args: Any, **kwargs: Any) -> Any:
+        raise DockerAdapterError(
+            "output_limit_exceeded", "measurement output exceeded limit"
+        )
+
+    async def track_cleanup() -> tuple[Any, ...]:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        return await original_cleanup()
+
+    monkeypatch.setattr(handle.adapter, "exec", fail_measurement)
+    monkeypatch.setattr(handle, "_retry_cleanup", track_cleanup)
+    handle._launching = True
+
+    with pytest.raises(DockerAdapterError, match="measurement output"):
+        await handle.measure_repository_base_commit()
+
+    assert cleanup_calls == 0
+    assert handle._closed is False
+    monkeypatch.setattr(handle.adapter, "exec", original_exec)
+    monkeypatch.setattr(handle, "_retry_cleanup", original_cleanup)
+    handle.complete_launch()
+    await handle.terminate()
+
+
+@pytest.mark.asyncio
 async def test_runtime_handle_retries_only_failed_stages_after_releasing_all_others(
     tmp_path: Path,
 ) -> None:

--- a/tests/rl/harness/test_sandbox_process_integration.py
+++ b/tests/rl/harness/test_sandbox_process_integration.py
@@ -49,13 +49,11 @@ from tests.rl.harness.wp7_fixtures import (
     DeterministicRandom,
     make_runtime_fixture,
 )
-
 pytestmark = pytest.mark.local_process
 
 
 RUNTIME_ABI = TERMINAL_RUNTIME_ABI
 RUNNER_DIGEST = TERMINAL_IMPLEMENTATION_DIGEST
-
 
 def _sealed_execution_supported() -> bool:
     required_fcntl = (
@@ -82,8 +80,7 @@ requires_sealed_execution = pytest.mark.skipif(
 
 
 def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     repository = tmp_path / "source"
     git_path = shutil.which("git")
@@ -106,11 +103,7 @@ def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
 
     def git(*arguments: str, cwd: Path = repository) -> str:
         completed = subprocess.run(
-            ("git", *arguments),
-            cwd=cwd,
-            check=True,
-            capture_output=True,
-            text=True,
+            ("git", *arguments), cwd=cwd, check=True, capture_output=True, text=True
         )
         return completed.stdout.strip()
 
@@ -120,14 +113,9 @@ def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
     (repository / "tracked.txt").write_text("before\n", encoding="utf-8")
     git("add", ".")
     git(
-        "-c",
-        "user.name=BreadBoard",
-        "-c",
-        "user.email=breadboard@example.invalid",
-        "commit",
-        "--quiet",
-        "-m",
-        "base",
+        "-c", "user.name=BreadBoard",
+        "-c", "user.email=breadboard@example.invalid",
+        "commit", "--quiet", "-m", "base",
     )
     base_commit = git("rev-parse", "HEAD")
     git("config", "diff.hide.command", "/usr/bin/true")
@@ -136,38 +124,27 @@ def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
     binary = b"\x00\x01\xffbinary\n"
     (repository / "new.bin").write_bytes(binary)
     plan = type(
-        "SealedDiffPlan",
-        (),
+        "SealedDiffPlan", (),
         {
             "runtime": type(
-                "Runtime",
-                (),
-                {"fixed_environment": (("PATH", os.environ["PATH"]),)},
+                "Runtime", (), {"fixed_environment": (("PATH", os.environ["PATH"]),)}
             )(),
             "limits": type(
-                "Limits",
-                (),
+                "Limits", (),
                 {"action_timeout_ms": 10_000, "artifact_bytes_each": 1024 * 1024},
             )(),
         },
     )()
-
     result = _sealed_repository_diff(
-        repository=repository,
-        base_commit=base_commit,
-        plan=plan,
+        repository=repository, base_commit=base_commit, plan=plan
     )
-
     reconstruction = tmp_path / "reconstruction"
     subprocess.run(
-        ("git", "clone", "--quiet", str(repository), str(reconstruction)),
-        check=True,
+        ("git", "clone", "--quiet", str(repository), str(reconstruction)), check=True
     )
     subprocess.run(
-        ("git", "apply", "--binary", "-"),
-        cwd=reconstruction,
-        input=result["stdout"].encode(),
-        check=True,
+        ("git", "apply", "--binary", "-"), cwd=reconstruction,
+        input=result["stdout"].encode(), check=True,
     )
     assert (reconstruction / "tracked.txt").read_text(encoding="utf-8") == "after\n"
     assert (reconstruction / "ignored.txt").read_text(encoding="utf-8") == "included\n"
@@ -210,7 +187,9 @@ async def test_run_shell_delegates_pinned_descriptor_as_workload_argv() -> None:
     )
 
     assert result is expected
-    assert calls == [(("/proc/self/fd/71", "-lc", "printf delegated"), 1_234, 5_678)]
+    assert calls == [
+        (("/proc/self/fd/71", "-lc", "printf delegated"), 1_234, 5_678)
+    ]
 
 
 async def test_run_argv_executes_requested_command_through_pinned_shell() -> None:
@@ -347,9 +326,7 @@ async def test_unsupported_host_refuses_before_subprocess_recorder_or_workload_e
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     if _sealed_execution_supported():
-        pytest.skip(
-            "unsupported-host contract is exercised only without sealed execution"
-        )
+        pytest.skip("unsupported-host contract is exercised only without sealed execution")
     fixture = make_runtime_fixture(
         with_writable_mount=True, runtime_install_root=tmp_path
     )
@@ -378,7 +355,8 @@ async def test_unsupported_host_refuses_before_subprocess_recorder_or_workload_e
     assert captured.value.code == "runtime_unsupported"
     assert calls == []
     assert not any(
-        path.name == "workload-effect" for path in harness.workspace_root.rglob("*")
+        path.name == "workload-effect"
+        for path in harness.workspace_root.rglob("*")
     )
 
 
@@ -464,19 +442,14 @@ async def test_symlinked_runtime_ancestor_is_rejected_before_child_creation(
         if runtime.runtime_id == fixture.plan.sandbox.runtime_id
     )
     alias = tmp_path / "alias"
-    alias.symlink_to(
-        Path(real_runtime.executable_path).parent, target_is_directory=True
-    )
+    alias.symlink_to(Path(real_runtime.executable_path).parent, target_is_directory=True)
     aliased_runtime = replace(
-        real_runtime,
-        executable_path=str(alias / Path(real_runtime.executable_path).name),
+        real_runtime, executable_path=str(alias / Path(real_runtime.executable_path).name)
     )
     authorities = replace(
         fixture.authorities,
         runtimes=tuple(
-            aliased_runtime
-            if runtime.runtime_id == aliased_runtime.runtime_id
-            else runtime
+            aliased_runtime if runtime.runtime_id == aliased_runtime.runtime_id else runtime
             for runtime in fixture.authorities.runtimes
         ),
     )
@@ -524,9 +497,7 @@ async def test_catalog_argv0_and_proc_exe_bind_different_objects_at_private_barr
         pid = int(identity["process_pid"])
         observed["cmdline"] = Path(f"/proc/{pid}/cmdline").read_bytes().split(b"\0")
         observed["exe"] = os.readlink(f"/proc/{pid}/exe")
-        observed["state"] = (
-            Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()[0]
-        )
+        observed["state"] = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()[0]
         original(lease_id, resource_id, identity)
 
     monkeypatch.setattr(
@@ -574,7 +545,9 @@ async def test_cancellation_at_private_barrier_reaps_group_and_handle_remains_us
     assert len(attempted_groups) == 1
     with pytest.raises(ProcessLookupError):
         os.killpg(attempted_groups[0], 0)
-    assert not (primary._materialized.workspace_path / "work/forbidden-effect").exists()
+    assert not (
+        primary._materialized.workspace_path / "work/forbidden-effect"
+    ).exists()
 
     monkeypatch.setattr(harness.manager, "_record_process_identity", original)
     later = await primary._runtime.run_shell(
@@ -582,6 +555,10 @@ async def test_cancellation_at_private_barrier_reaps_group_and_handle_remains_us
     )
     assert later["stdout"] == "later"
     assert (await primary.close()).state is CleanupState.RELEASED
+
+
+
+
 
 
 @requires_sealed_execution
@@ -711,29 +688,19 @@ async def test_real_process_plan_runs_through_wp5_port_seals_snapshot_and_cleans
 
     assert result.termination is RunnerTermination.SUBMITTED
     assert result.effective_plan_digest == fixture.plan.canonical_digest()
-    assert (await primary.runner_workspace.read_text("work/copied.txt"))[
-        "content"
-    ] == "candidate"
-    assert (
-        primary.measurement.isolation_disposition
-        is IsolationDisposition.TRUSTED_PROCESS
-    )
+    assert (await primary.runner_workspace.read_text("work/copied.txt"))["content"] == "candidate"
+    assert primary.measurement.isolation_disposition is IsolationDisposition.TRUSTED_PROCESS
     assert primary.measurement.isolated is False
     assert primary.measurement.reward_eligible is False
     snapshot = await primary.seal_for_verifier()
-    immutable = (
-        harness.cache_root
-        / "snapshot-objects"
-        / snapshot.root_digest.removeprefix("sha256:")
+    immutable = harness.cache_root / "snapshot-objects" / snapshot.root_digest.removeprefix(
+        "sha256:"
     )
     assert (immutable / "work" / "candidate.txt").read_bytes() == b"candidate"
     assert (immutable / "work" / "copied.txt").read_bytes() == b"candidate"
 
     verifier = await harness.manager.open_verifier(primary, snapshot)
-    assert (
-        verifier.measurement.isolation_disposition
-        is IsolationDisposition.TRUSTED_PROCESS
-    )
+    assert verifier.measurement.isolation_disposition is IsolationDisposition.TRUSTED_PROCESS
     with pytest.raises(VerifierExecutionError) as captured:
         await verifier.execute()
     assert captured.value.code == "verifier_result_malformed"
@@ -747,6 +714,7 @@ async def test_real_process_plan_runs_through_wp5_port_seals_snapshot_and_cleans
     assert list(harness.lease_root.iterdir()) == []
 
 
+
 @requires_sealed_execution
 async def test_real_process_leader_exit_keeps_exact_descendant_cleanup_authority(
     tmp_path: Path,
@@ -758,8 +726,8 @@ async def test_real_process_leader_exit_keeps_exact_descendant_cleanup_authority
     descendant_command = (
         "for descriptor in /proc/self/fd/*; do "
         "descriptor=${descriptor##*/}; "
-        'case "$descriptor" in 0|1|2) ;; '
-        '*) eval "exec ${descriptor}>&-" ;; esac; '
+        "case \"$descriptor\" in 0|1|2) ;; "
+        "*) eval \"exec ${descriptor}>&-\" ;; esac; "
         "done; "
         "printf '%s' \"$$\" > work/.descendant.tmp && "
         "mv work/.descendant.tmp work/descendant.pid; "
@@ -773,7 +741,9 @@ async def test_real_process_leader_exit_keeps_exact_descendant_cleanup_authority
     descendant_pid: int | None = None
     try:
         await primary.runner_workspace.run_shell(command, timeout=2)
-        descendant = await primary.runner_workspace.read_text("work/descendant.pid")
+        descendant = await primary.runner_workspace.read_text(
+            "work/descendant.pid"
+        )
         descendant_pid = int(descendant["content"])
         async with asyncio.timeout(1):
             while True:
@@ -791,7 +761,6 @@ async def test_real_process_leader_exit_keeps_exact_descendant_cleanup_authority
                 os.kill(descendant_pid, signal.SIGKILL)
             except ProcessLookupError:
                 pass
-
 
 @requires_sealed_execution
 @pytest.mark.parametrize("mode", ["timeout", "cancel"])
@@ -824,7 +793,7 @@ async def test_real_process_closed_stream_timeout_or_cancellation_kills_descenda
         "mv work/.spawned.tmp work/spawned.pid; "
         f"printf ready > {quoted_ready}; "
         "exec 1>&- 2>&-; "
-        'wait "$descendant"'
+        "wait \"$descendant\""
     )
     descendant_pid: int | None = None
     receipt = None
@@ -924,9 +893,7 @@ async def test_trusted_process_handle_enforces_exact_500ms_deadline_and_cleans_d
     under_elapsed = loop.time() - under_started
     assert under["returncode"] == 0
     assert 0 <= under_elapsed < 0.75
-    assert (await primary.runner_workspace.read_text("work/under"))[
-        "content"
-    ] == "under"
+    assert (await primary.runner_workspace.read_text("work/under"))["content"] == "under"
 
     descendant_command = (
         "trap '' TERM; "
@@ -943,7 +910,7 @@ async def test_trusted_process_handle_enforces_exact_500ms_deadline_and_cleans_d
         "printf '%s' \"$child\" > work/.deadline-spawned.tmp && "
         "mv work/.deadline-spawned.tmp work/deadline-spawned.pid; "
         "exec 1>&- 2>&-; "
-        'wait "$child"'
+        "wait \"$child\""
     )
     over_started = loop.time()
     with pytest.raises(SandboxLaunchError) as captured:
@@ -1012,7 +979,9 @@ async def test_real_process_restart_never_signals_from_stale_lease_record(
         "exec 1>&- 2>&-; "
         "sleep 10"
     )
-    action = asyncio.create_task(primary.runner_workspace.run_shell(command, timeout=2))
+    action = asyncio.create_task(
+        primary.runner_workspace.run_shell(command, timeout=2)
+    )
     loop = asyncio.get_running_loop()
     ready: asyncio.Future[None] = loop.create_future()
 
@@ -1156,12 +1125,8 @@ async def test_concurrent_trusted_actions_persist_distinct_identities_and_reconc
                 identities = tuple(record.get("process_identities", ()))
                 if (
                     len(identities) == 2
-                    and (
-                        primary._materialized.workspace_path / "work/first-ready"
-                    ).exists()
-                    and (
-                        primary._materialized.workspace_path / "work/second-ready"
-                    ).exists()
+                    and (primary._materialized.workspace_path / "work/first-ready").exists()
+                    and (primary._materialized.workspace_path / "work/second-ready").exists()
                 ):
                     break
                 await asyncio.sleep(0.005)

--- a/tests/rl/harness/test_sandbox_process_integration.py
+++ b/tests/rl/harness/test_sandbox_process_integration.py
@@ -7,6 +7,8 @@ import json
 import os
 import shlex
 import signal
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -34,6 +36,7 @@ from breadboard.rl.harness.sandbox import (
     TrustedProcessHandle,
     VerifierExecutionError,
     WorkspaceStateError,
+    _sealed_repository_diff,
 )
 from tests.rl.harness.test_runner_terminal import (
     RecordingEventSink,
@@ -46,11 +49,13 @@ from tests.rl.harness.wp7_fixtures import (
     DeterministicRandom,
     make_runtime_fixture,
 )
+
 pytestmark = pytest.mark.local_process
 
 
 RUNTIME_ABI = TERMINAL_RUNTIME_ABI
 RUNNER_DIGEST = TERMINAL_IMPLEMENTATION_DIGEST
+
 
 def _sealed_execution_supported() -> bool:
     required_fcntl = (
@@ -74,6 +79,99 @@ requires_sealed_execution = pytest.mark.skipif(
     not _sealed_execution_supported(),
     reason="requires Linux sealed-memfd descriptor execution",
 )
+
+
+def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "source"
+    git_path = shutil.which("git")
+    assert git_path is not None
+    descriptor = os.open(git_path, os.O_RDONLY)
+
+    class PinnedGit:
+        fd = descriptor
+        proc_fd_path = git_path
+        digest = "sha256:" + "0" * 64
+
+        def close(self) -> None:
+            os.close(self.fd)
+
+    monkeypatch.setattr(
+        "breadboard.rl.harness.sandbox._snapshot_installed_executable",
+        lambda path, expected_digest: PinnedGit(),
+    )
+    repository.mkdir()
+
+    def git(*arguments: str, cwd: Path = repository) -> str:
+        completed = subprocess.run(
+            ("git", *arguments),
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return completed.stdout.strip()
+
+    git("init", "--quiet")
+    (repository / ".gitignore").write_text("ignored.txt\n", encoding="utf-8")
+    (repository / ".gitattributes").write_text("*.txt diff=hide\n", encoding="utf-8")
+    (repository / "tracked.txt").write_text("before\n", encoding="utf-8")
+    git("add", ".")
+    git(
+        "-c",
+        "user.name=BreadBoard",
+        "-c",
+        "user.email=breadboard@example.invalid",
+        "commit",
+        "--quiet",
+        "-m",
+        "base",
+    )
+    base_commit = git("rev-parse", "HEAD")
+    git("config", "diff.hide.command", "/usr/bin/true")
+    (repository / "tracked.txt").write_text("after\n", encoding="utf-8")
+    (repository / "ignored.txt").write_text("included\n", encoding="utf-8")
+    binary = b"\x00\x01\xffbinary\n"
+    (repository / "new.bin").write_bytes(binary)
+    plan = type(
+        "SealedDiffPlan",
+        (),
+        {
+            "runtime": type(
+                "Runtime",
+                (),
+                {"fixed_environment": (("PATH", os.environ["PATH"]),)},
+            )(),
+            "limits": type(
+                "Limits",
+                (),
+                {"action_timeout_ms": 10_000, "artifact_bytes_each": 1024 * 1024},
+            )(),
+        },
+    )()
+
+    result = _sealed_repository_diff(
+        repository=repository,
+        base_commit=base_commit,
+        plan=plan,
+    )
+
+    reconstruction = tmp_path / "reconstruction"
+    subprocess.run(
+        ("git", "clone", "--quiet", str(repository), str(reconstruction)),
+        check=True,
+    )
+    subprocess.run(
+        ("git", "apply", "--binary", "-"),
+        cwd=reconstruction,
+        input=result["stdout"].encode(),
+        check=True,
+    )
+    assert (reconstruction / "tracked.txt").read_text(encoding="utf-8") == "after\n"
+    assert (reconstruction / "ignored.txt").read_text(encoding="utf-8") == "included\n"
+    assert (reconstruction / "new.bin").read_bytes() == binary
 
 
 async def test_run_shell_delegates_pinned_descriptor_as_workload_argv() -> None:
@@ -112,9 +210,7 @@ async def test_run_shell_delegates_pinned_descriptor_as_workload_argv() -> None:
     )
 
     assert result is expected
-    assert calls == [
-        (("/proc/self/fd/71", "-lc", "printf delegated"), 1_234, 5_678)
-    ]
+    assert calls == [(("/proc/self/fd/71", "-lc", "printf delegated"), 1_234, 5_678)]
 
 
 async def test_run_argv_executes_requested_command_through_pinned_shell() -> None:
@@ -251,7 +347,9 @@ async def test_unsupported_host_refuses_before_subprocess_recorder_or_workload_e
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     if _sealed_execution_supported():
-        pytest.skip("unsupported-host contract is exercised only without sealed execution")
+        pytest.skip(
+            "unsupported-host contract is exercised only without sealed execution"
+        )
     fixture = make_runtime_fixture(
         with_writable_mount=True, runtime_install_root=tmp_path
     )
@@ -280,8 +378,7 @@ async def test_unsupported_host_refuses_before_subprocess_recorder_or_workload_e
     assert captured.value.code == "runtime_unsupported"
     assert calls == []
     assert not any(
-        path.name == "workload-effect"
-        for path in harness.workspace_root.rglob("*")
+        path.name == "workload-effect" for path in harness.workspace_root.rglob("*")
     )
 
 
@@ -367,14 +464,19 @@ async def test_symlinked_runtime_ancestor_is_rejected_before_child_creation(
         if runtime.runtime_id == fixture.plan.sandbox.runtime_id
     )
     alias = tmp_path / "alias"
-    alias.symlink_to(Path(real_runtime.executable_path).parent, target_is_directory=True)
+    alias.symlink_to(
+        Path(real_runtime.executable_path).parent, target_is_directory=True
+    )
     aliased_runtime = replace(
-        real_runtime, executable_path=str(alias / Path(real_runtime.executable_path).name)
+        real_runtime,
+        executable_path=str(alias / Path(real_runtime.executable_path).name),
     )
     authorities = replace(
         fixture.authorities,
         runtimes=tuple(
-            aliased_runtime if runtime.runtime_id == aliased_runtime.runtime_id else runtime
+            aliased_runtime
+            if runtime.runtime_id == aliased_runtime.runtime_id
+            else runtime
             for runtime in fixture.authorities.runtimes
         ),
     )
@@ -422,7 +524,9 @@ async def test_catalog_argv0_and_proc_exe_bind_different_objects_at_private_barr
         pid = int(identity["process_pid"])
         observed["cmdline"] = Path(f"/proc/{pid}/cmdline").read_bytes().split(b"\0")
         observed["exe"] = os.readlink(f"/proc/{pid}/exe")
-        observed["state"] = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()[0]
+        observed["state"] = (
+            Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()[0]
+        )
         original(lease_id, resource_id, identity)
 
     monkeypatch.setattr(
@@ -470,9 +574,7 @@ async def test_cancellation_at_private_barrier_reaps_group_and_handle_remains_us
     assert len(attempted_groups) == 1
     with pytest.raises(ProcessLookupError):
         os.killpg(attempted_groups[0], 0)
-    assert not (
-        primary._materialized.workspace_path / "work/forbidden-effect"
-    ).exists()
+    assert not (primary._materialized.workspace_path / "work/forbidden-effect").exists()
 
     monkeypatch.setattr(harness.manager, "_record_process_identity", original)
     later = await primary._runtime.run_shell(
@@ -480,10 +582,6 @@ async def test_cancellation_at_private_barrier_reaps_group_and_handle_remains_us
     )
     assert later["stdout"] == "later"
     assert (await primary.close()).state is CleanupState.RELEASED
-
-
-
-
 
 
 @requires_sealed_execution
@@ -613,19 +711,29 @@ async def test_real_process_plan_runs_through_wp5_port_seals_snapshot_and_cleans
 
     assert result.termination is RunnerTermination.SUBMITTED
     assert result.effective_plan_digest == fixture.plan.canonical_digest()
-    assert (await primary.runner_workspace.read_text("work/copied.txt"))["content"] == "candidate"
-    assert primary.measurement.isolation_disposition is IsolationDisposition.TRUSTED_PROCESS
+    assert (await primary.runner_workspace.read_text("work/copied.txt"))[
+        "content"
+    ] == "candidate"
+    assert (
+        primary.measurement.isolation_disposition
+        is IsolationDisposition.TRUSTED_PROCESS
+    )
     assert primary.measurement.isolated is False
     assert primary.measurement.reward_eligible is False
     snapshot = await primary.seal_for_verifier()
-    immutable = harness.cache_root / "snapshot-objects" / snapshot.root_digest.removeprefix(
-        "sha256:"
+    immutable = (
+        harness.cache_root
+        / "snapshot-objects"
+        / snapshot.root_digest.removeprefix("sha256:")
     )
     assert (immutable / "work" / "candidate.txt").read_bytes() == b"candidate"
     assert (immutable / "work" / "copied.txt").read_bytes() == b"candidate"
 
     verifier = await harness.manager.open_verifier(primary, snapshot)
-    assert verifier.measurement.isolation_disposition is IsolationDisposition.TRUSTED_PROCESS
+    assert (
+        verifier.measurement.isolation_disposition
+        is IsolationDisposition.TRUSTED_PROCESS
+    )
     with pytest.raises(VerifierExecutionError) as captured:
         await verifier.execute()
     assert captured.value.code == "verifier_result_malformed"
@@ -639,7 +747,6 @@ async def test_real_process_plan_runs_through_wp5_port_seals_snapshot_and_cleans
     assert list(harness.lease_root.iterdir()) == []
 
 
-
 @requires_sealed_execution
 async def test_real_process_leader_exit_keeps_exact_descendant_cleanup_authority(
     tmp_path: Path,
@@ -651,8 +758,8 @@ async def test_real_process_leader_exit_keeps_exact_descendant_cleanup_authority
     descendant_command = (
         "for descriptor in /proc/self/fd/*; do "
         "descriptor=${descriptor##*/}; "
-        "case \"$descriptor\" in 0|1|2) ;; "
-        "*) eval \"exec ${descriptor}>&-\" ;; esac; "
+        'case "$descriptor" in 0|1|2) ;; '
+        '*) eval "exec ${descriptor}>&-" ;; esac; '
         "done; "
         "printf '%s' \"$$\" > work/.descendant.tmp && "
         "mv work/.descendant.tmp work/descendant.pid; "
@@ -666,9 +773,7 @@ async def test_real_process_leader_exit_keeps_exact_descendant_cleanup_authority
     descendant_pid: int | None = None
     try:
         await primary.runner_workspace.run_shell(command, timeout=2)
-        descendant = await primary.runner_workspace.read_text(
-            "work/descendant.pid"
-        )
+        descendant = await primary.runner_workspace.read_text("work/descendant.pid")
         descendant_pid = int(descendant["content"])
         async with asyncio.timeout(1):
             while True:
@@ -686,6 +791,7 @@ async def test_real_process_leader_exit_keeps_exact_descendant_cleanup_authority
                 os.kill(descendant_pid, signal.SIGKILL)
             except ProcessLookupError:
                 pass
+
 
 @requires_sealed_execution
 @pytest.mark.parametrize("mode", ["timeout", "cancel"])
@@ -718,7 +824,7 @@ async def test_real_process_closed_stream_timeout_or_cancellation_kills_descenda
         "mv work/.spawned.tmp work/spawned.pid; "
         f"printf ready > {quoted_ready}; "
         "exec 1>&- 2>&-; "
-        "wait \"$descendant\""
+        'wait "$descendant"'
     )
     descendant_pid: int | None = None
     receipt = None
@@ -818,7 +924,9 @@ async def test_trusted_process_handle_enforces_exact_500ms_deadline_and_cleans_d
     under_elapsed = loop.time() - under_started
     assert under["returncode"] == 0
     assert 0 <= under_elapsed < 0.75
-    assert (await primary.runner_workspace.read_text("work/under"))["content"] == "under"
+    assert (await primary.runner_workspace.read_text("work/under"))[
+        "content"
+    ] == "under"
 
     descendant_command = (
         "trap '' TERM; "
@@ -835,7 +943,7 @@ async def test_trusted_process_handle_enforces_exact_500ms_deadline_and_cleans_d
         "printf '%s' \"$child\" > work/.deadline-spawned.tmp && "
         "mv work/.deadline-spawned.tmp work/deadline-spawned.pid; "
         "exec 1>&- 2>&-; "
-        "wait \"$child\""
+        'wait "$child"'
     )
     over_started = loop.time()
     with pytest.raises(SandboxLaunchError) as captured:
@@ -904,9 +1012,7 @@ async def test_real_process_restart_never_signals_from_stale_lease_record(
         "exec 1>&- 2>&-; "
         "sleep 10"
     )
-    action = asyncio.create_task(
-        primary.runner_workspace.run_shell(command, timeout=2)
-    )
+    action = asyncio.create_task(primary.runner_workspace.run_shell(command, timeout=2))
     loop = asyncio.get_running_loop()
     ready: asyncio.Future[None] = loop.create_future()
 
@@ -1050,8 +1156,12 @@ async def test_concurrent_trusted_actions_persist_distinct_identities_and_reconc
                 identities = tuple(record.get("process_identities", ()))
                 if (
                     len(identities) == 2
-                    and (primary._materialized.workspace_path / "work/first-ready").exists()
-                    and (primary._materialized.workspace_path / "work/second-ready").exists()
+                    and (
+                        primary._materialized.workspace_path / "work/first-ready"
+                    ).exists()
+                    and (
+                        primary._materialized.workspace_path / "work/second-ready"
+                    ).exists()
                 ):
                     break
                 await asyncio.sleep(0.005)

--- a/tests/rl/harness/test_sandbox_process_integration.py
+++ b/tests/rl/harness/test_sandbox_process_integration.py
@@ -31,12 +31,15 @@ from breadboard.rl.harness.runners.terminal import (
 )
 from breadboard.rl.harness.sandbox import (
     SandboxLaunchError,
+    RuntimeLaunchContext,
     SandboxRuntimeManager,
     TrustedProcessBackend,
     TrustedProcessHandle,
     VerifierExecutionError,
     VerifierSnapshotError,
     WorkspaceStateError,
+    WorkspaceStorageIdentity,
+    build_sandbox_execution_plan,
     _sealed_repository_diff,
 )
 from tests.rl.harness.test_runner_terminal import (
@@ -174,6 +177,78 @@ def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
         _sealed_repository_diff(
             repository=repository, base_commit=base_commit, plan=plan
         )
+
+async def test_process_backend_binds_identity_recorder_before_base_measurement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture = make_runtime_fixture(with_writable_mount=True)
+    plan = build_sandbox_execution_plan(
+        fixture.request, fixture.registries, fixture.authorities
+    )
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    workspace_fd = os.open(workspace, os.O_RDONLY | os.O_DIRECTORY)
+    workspace_identity = os.fstat(workspace_fd)
+    pinned_fd = os.open(os.devnull, os.O_RDONLY)
+
+    class PinnedExecutable:
+        source_path = plan.runtime.executable_path
+        proc_fd_path = plan.runtime.executable_path
+        digest = plan.runtime.measured_binary_digest
+        size = 0
+        fd = pinned_fd
+
+        def close(self) -> None:
+            os.close(self.fd)
+
+    monkeypatch.setattr(
+        "breadboard.rl.harness.sandbox._snapshot_installed_executable",
+        lambda path, expected_digest: PinnedExecutable(),
+    )
+    recorder_calls: list[tuple[str, object]] = []
+
+    def recorder(resource_id: str, identity: object) -> None:
+        recorder_calls.append((resource_id, identity))
+
+    async def measure(handle: TrustedProcessHandle) -> None:
+        assert handle._identity_recorder is recorder
+        return None
+
+    monkeypatch.setattr(
+        TrustedProcessHandle, "measure_repository_base_commit", measure
+    )
+
+    async def publish(_: object) -> None:
+        return None
+
+    context = RuntimeLaunchContext(
+        role="primary",
+        lease_id="lease-recorder-order",
+        workspace_id="workspace-recorder-order",
+        epoch=1,
+        storage=WorkspaceStorageIdentity(
+            authority_id="test-storage",
+            quota_enforced=False,
+            quota_bytes=plan.resources.storage_bytes,
+            owner_uid=os.getuid(),
+            owner_gid=os.getgid(),
+        ),
+        snapshot_relative_path=None,
+        result_relative_path=None,
+        publish_prepared_identity=publish,
+        workspace_fd=workspace_fd,
+        workspace_identity=(workspace_identity.st_dev, workspace_identity.st_ino),
+        owner_token="owner-token",
+        record_process_identity=recorder,
+    )
+    handle, _ = await TrustedProcessBackend().launch(
+        plan, workspace, context=context
+    )
+
+    assert handle._identity_recorder is recorder
+    assert recorder_calls == []
+    await handle.terminate()
+
 
 
 async def test_run_shell_delegates_pinned_descriptor_as_workload_argv() -> None:

--- a/tests/rl/harness/test_sandbox_process_integration.py
+++ b/tests/rl/harness/test_sandbox_process_integration.py
@@ -146,7 +146,10 @@ def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
         },
     )()
     result = _sealed_repository_diff(
-        repository=repository, base_commit=base_commit, plan=plan
+        repository=repository,
+        scratch_directory=tmp_path,
+        base_commit=base_commit,
+        plan=plan,
     )
     reconstruction = tmp_path / "reconstruction"
     subprocess.run(
@@ -165,7 +168,10 @@ def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
         VerifierSnapshotError, match="embedded Git repository"
     ):
         _sealed_repository_diff(
-            repository=repository, base_commit=base_commit, plan=plan
+            repository=repository,
+            scratch_directory=tmp_path,
+            base_commit=base_commit,
+            plan=plan,
         )
     shutil.rmtree(repository / "nested")
     alternates = repository / ".git" / "objects" / "info" / "alternates"
@@ -175,7 +181,10 @@ def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
         VerifierSnapshotError, match="external Git object authority"
     ):
         _sealed_repository_diff(
-            repository=repository, base_commit=base_commit, plan=plan
+            repository=repository,
+            scratch_directory=tmp_path,
+            base_commit=base_commit,
+            plan=plan,
         )
 
 async def test_process_backend_binds_identity_recorder_before_base_measurement(

--- a/tests/rl/harness/test_sandbox_process_integration.py
+++ b/tests/rl/harness/test_sandbox_process_integration.py
@@ -35,6 +35,7 @@ from breadboard.rl.harness.sandbox import (
     TrustedProcessBackend,
     TrustedProcessHandle,
     VerifierExecutionError,
+    VerifierSnapshotError,
     WorkspaceStateError,
     _sealed_repository_diff,
 )
@@ -85,12 +86,12 @@ def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
     repository = tmp_path / "source"
     git_path = shutil.which("git")
     assert git_path is not None
-    descriptor = os.open(git_path, os.O_RDONLY)
 
     class PinnedGit:
-        fd = descriptor
-        proc_fd_path = git_path
-        digest = "sha256:" + "0" * 64
+        def __init__(self) -> None:
+            self.fd = os.open(git_path, os.O_RDONLY)
+            self.proc_fd_path = git_path
+            self.digest = "sha256:" + "0" * 64
 
         def close(self) -> None:
             os.close(self.fd)
@@ -109,7 +110,9 @@ def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
 
     git("init", "--quiet")
     (repository / ".gitignore").write_text("ignored.txt\n", encoding="utf-8")
-    (repository / ".gitattributes").write_text("*.txt diff=hide\n", encoding="utf-8")
+    (repository / ".gitattributes").write_text(
+        "*.txt diff=hide filter=forge\n", encoding="utf-8"
+    )
     (repository / "tracked.txt").write_text("before\n", encoding="utf-8")
     git("add", ".")
     git(
@@ -119,10 +122,14 @@ def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
     )
     base_commit = git("rev-parse", "HEAD")
     git("config", "diff.hide.command", "/usr/bin/true")
+    git("config", "filter.forge.clean", "sed s/after/forged/")
+    git("config", "filter.forge.smudge", "cat")
     (repository / "tracked.txt").write_text("after\n", encoding="utf-8")
     (repository / "ignored.txt").write_text("included\n", encoding="utf-8")
     binary = b"\x00\x01\xffbinary\n"
     (repository / "new.bin").write_bytes(binary)
+    raw_binary = b"\xffnon-UTF-8-without-NUL\n"
+    (repository / "raw.bin").write_bytes(raw_binary)
     plan = type(
         "SealedDiffPlan", (),
         {
@@ -149,6 +156,24 @@ def test_sealed_repository_diff_includes_ignored_untracked_and_binary_files(
     assert (reconstruction / "tracked.txt").read_text(encoding="utf-8") == "after\n"
     assert (reconstruction / "ignored.txt").read_text(encoding="utf-8") == "included\n"
     assert (reconstruction / "new.bin").read_bytes() == binary
+    assert (reconstruction / "raw.bin").read_bytes() == raw_binary
+    (repository / "nested" / ".git" / "objects").mkdir(parents=True)
+    with pytest.raises(
+        VerifierSnapshotError, match="embedded Git repository"
+    ):
+        _sealed_repository_diff(
+            repository=repository, base_commit=base_commit, plan=plan
+        )
+    shutil.rmtree(repository / "nested")
+    alternates = repository / ".git" / "objects" / "info" / "alternates"
+    alternates.parent.mkdir(exist_ok=True)
+    alternates.write_text("/tmp/attacker-objects\n", encoding="utf-8")
+    with pytest.raises(
+        VerifierSnapshotError, match="external Git object authority"
+    ):
+        _sealed_repository_diff(
+            repository=repository, base_commit=base_commit, plan=plan
+        )
 
 
 async def test_run_shell_delegates_pinned_descriptor_as_workload_argv() -> None:

--- a/tests/rl/harness/test_verifier_snapshot.py
+++ b/tests/rl/harness/test_verifier_snapshot.py
@@ -99,11 +99,8 @@ async def _opened_snapshot(tmp_path: Path) -> tuple[RuntimeHarness, Any, Any]:
     await primary.runner_workspace.write_text("work/candidate.txt", "candidate")
     snapshot = await primary.seal_for_verifier()
     return harness, primary, snapshot
-
-
 async def test_seal_terminates_before_patch_and_binds_patch_to_snapshot(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     fixture = make_runtime_fixture(with_writable_mount=True)
     harness = RuntimeHarness(tmp_path, fixture)
@@ -131,14 +128,15 @@ async def test_seal_terminates_before_patch_and_binds_patch_to_snapshot(
 
     monkeypatch.setattr(sandbox_module, "_sealed_repository_diff", sealed_diff)
     monkeypatch.setattr(harness.store, "seal_snapshot", seal_snapshot)
-
     snapshot = await primary.seal_for_verifier()
     workspace_diff = primary.sealed_workspace_diff()
-
     assert order == ["patch", "snapshot"]
     assert workspace_diff is not None
     assert workspace_diff["snapshot_root_digest"] == snapshot.root_digest
-    assert workspace_diff["patch_digest"] == digest(workspace_diff["stdout"].encode())
+    assert workspace_diff["patch_digest"] == digest(
+        workspace_diff["stdout"].encode()
+    )
+
 
 
 def _isolated_verifier_fixture(runtime_class: c.RuntimeClass) -> Any:
@@ -282,10 +280,8 @@ async def test_snapshot_digest_independently_binds_every_path_byte_and_mode(
     tmp_path: Path,
 ) -> None:
     harness, primary, snapshot = await _opened_snapshot(tmp_path)
-    object_root = (
-        harness.cache_root
-        / "snapshot-objects"
-        / snapshot.root_digest.removeprefix("sha256:")
+    object_root = harness.cache_root / "snapshot-objects" / snapshot.root_digest.removeprefix(
+        "sha256:"
     )
     entries = _snapshot_entries(object_root)
 
@@ -310,9 +306,7 @@ async def test_snapshot_digest_independently_binds_every_path_byte_and_mode(
     await primary.close()
 
 
-@pytest.mark.parametrize(
-    "attack", ["symlink", "hardlink", "fifo", "depth", "files", "bytes"]
-)
+@pytest.mark.parametrize("attack", ["symlink", "hardlink", "fifo", "depth", "files", "bytes"])
 async def test_snapshot_rejects_links_special_files_and_budget_bombs_before_verifier(
     tmp_path: Path, attack: str
 ) -> None:
@@ -369,10 +363,7 @@ async def test_snapshot_requires_positive_runtime_quiescence_and_starts_no_verif
     assert captured.value.code == "snapshot_not_quiescent"
     assert primary.state is WorkspaceLeaseState.QUARANTINED
     assert len(harness.backend.launches) == 1
-    assert (
-        list((harness.cache_root / "snapshot-objects").glob("*/work/candidate.txt"))
-        == []
-    )
+    assert list((harness.cache_root / "snapshot-objects").glob("*/work/candidate.txt")) == []
     assert (await primary.close()).state is CleanupState.RELEASED
 
 
@@ -388,23 +379,12 @@ async def test_verifier_uses_distinct_runtime_workspace_and_read_only_snapshot(
     assert verifier.measurement.workspace_id != primary.measurement.workspace_id
     assert verifier.plan.runtime.runtime_id == "verifier-runtime"
     assert verifier.plan.image.image_digest == primary.plan.verifier.grant.image_digest
-    assert (
-        verifier.plan.security_policy.policy_digest
-        == primary.plan.verifier.security_policy_digest
-    )
-    assert (
-        verifier.plan.network_policy.policy_digest
-        == primary.plan.verifier.grant.network_policy_digest
-    )
-    assert (
-        verifier.workspace / "snapshot" / "work" / "candidate.txt"
-    ).read_bytes() == b"candidate"
-    assert (
-        stat.S_IMODE(
-            (verifier.workspace / "snapshot" / "work" / "candidate.txt").stat().st_mode
-        )
-        == 0o400
-    )
+    assert verifier.plan.security_policy.policy_digest == primary.plan.verifier.security_policy_digest
+    assert verifier.plan.network_policy.policy_digest == primary.plan.verifier.grant.network_policy_digest
+    assert (verifier.workspace / "snapshot" / "work" / "candidate.txt").read_bytes() == b"candidate"
+    assert stat.S_IMODE(
+        (verifier.workspace / "snapshot" / "work" / "candidate.txt").stat().st_mode
+    ) == 0o400
     assert stat.S_IMODE((verifier.workspace / "result").stat().st_mode) == 0o700
     assert len(harness.backend.launches) == 2
     assert primary.measurement.reward_eligible is False
@@ -412,9 +392,7 @@ async def test_verifier_uses_distinct_runtime_workspace_and_read_only_snapshot(
     assert verifier.measurement.reward_eligible is False
 
     payload = _valid_result(primary, snapshot)
-    result_path = (
-        verifier.workspace / "result" / verifier.plan.verifier.result_relative_path
-    )
+    result_path = verifier.workspace / "result" / verifier.plan.verifier.result_relative_path
     result_path.write_text(json.dumps(payload), encoding="utf-8")
     result = await verifier.execute()
     assert isinstance(result, MappingProxyType)
@@ -522,14 +500,10 @@ async def test_reward_eligible_primary_requires_equally_isolated_verifier_measur
         assert len(list(harness.lease_root.iterdir())) == 2
     else:
         verifier = await harness.manager.open_verifier(primary, snapshot)
-        assert (
-            primary.measurement.isolation_disposition is IsolationDisposition.ISOLATED
-        )
+        assert primary.measurement.isolation_disposition is IsolationDisposition.ISOLATED
         assert primary.measurement.isolated is True
         assert primary.measurement.reward_eligible is True
-        assert (
-            verifier.measurement.isolation_disposition is IsolationDisposition.ISOLATED
-        )
+        assert verifier.measurement.isolation_disposition is IsolationDisposition.ISOLATED
         assert verifier.measurement.isolated is True
         assert verifier.measurement.reward_eligible is True
         assert (await verifier.close()).state is CleanupState.RELEASED
@@ -567,9 +541,7 @@ async def test_malicious_verifier_results_are_typed_and_cleanup_is_authoritative
     harness, primary, snapshot = await _opened_snapshot(tmp_path)
     verifier = await harness.manager.open_verifier(primary, snapshot)
     handle = harness.backend.handles[1]
-    result_path = (
-        verifier.workspace / "result" / verifier.plan.verifier.result_relative_path
-    )
+    result_path = verifier.workspace / "result" / verifier.plan.verifier.result_relative_path
     payload = _valid_result(primary, snapshot)
     device_fd: int | None = None
     if case == "nonzero":
@@ -592,7 +564,9 @@ async def test_malicious_verifier_results_are_typed_and_cleanup_is_authoritative
         device_fd = os.open("/dev/null", os.O_RDONLY)
         original_open = os.open
 
-        def substitute_device(path: Any, flags: int, *args: Any, **kwargs: Any) -> int:
+        def substitute_device(
+            path: Any, flags: int, *args: Any, **kwargs: Any
+        ) -> int:
             if path == result_path.name and kwargs.get("dir_fd") is not None:
                 return os.dup(device_fd)
             return original_open(path, flags, *args, **kwargs)
@@ -745,7 +719,6 @@ async def test_snapshot_seal_cancellation_releases_completed_snapshot_worker(
     assert list(harness.workspace_root.iterdir()) == []
     assert list(harness.lease_root.iterdir()) == []
 
-
 async def test_identical_snapshot_seal_holds_reference_during_release(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -813,7 +786,9 @@ async def test_snapshot_copy_cancellation_waits_before_verifier_workspace_releas
         return original_copy(*args, **kwargs)
 
     monkeypatch.setattr(harness.store, "copy_snapshot", blocked_copy)
-    opening = asyncio.create_task(harness.manager.open_verifier(primary, snapshot))
+    opening = asyncio.create_task(
+        harness.manager.open_verifier(primary, snapshot)
+    )
     assert await asyncio.to_thread(entered.wait, 1)
 
     opening.cancel()
@@ -828,7 +803,8 @@ async def test_snapshot_copy_cancellation_waits_before_verifier_workspace_releas
         for path in harness.workspace_root.iterdir()
     )
     assert not any(
-        path.name.startswith("verifier-lease-") for path in harness.lease_root.iterdir()
+        path.name.startswith("verifier-lease-")
+        for path in harness.lease_root.iterdir()
     )
     assert (await primary.close()).state is CleanupState.RELEASED
     assert harness.manager._snapshots == {}
@@ -841,10 +817,8 @@ async def test_post_seal_snapshot_mutation_starts_no_verifier_and_cleans_primary
     tmp_path: Path,
 ) -> None:
     harness, primary, snapshot = await _opened_snapshot(tmp_path)
-    object_root = (
-        harness.cache_root
-        / "snapshot-objects"
-        / snapshot.root_digest.removeprefix("sha256:")
+    object_root = harness.cache_root / "snapshot-objects" / snapshot.root_digest.removeprefix(
+        "sha256:"
     )
     candidate = object_root / "work" / "candidate.txt"
     candidate.chmod(0o600)
@@ -877,7 +851,9 @@ async def test_open_verifier_reservation_precedes_parent_close_and_child_cleanup
     backend = harness.backend
     backend.launch_entered = asyncio.Event()
     backend.release_launch = asyncio.Event()
-    opening = asyncio.create_task(harness.manager.open_verifier(primary, snapshot))
+    opening = asyncio.create_task(
+        harness.manager.open_verifier(primary, snapshot)
+    )
 
     await asyncio.wait_for(backend.launch_entered.wait(), 1)
     assert len(backend.launches) == 2
@@ -966,8 +942,6 @@ async def test_primary_close_aggregates_failed_child_without_duplicate_resource(
     reconciled = await harness.manager.close()
     assert len(reconciled) == 1
     assert reconciled[0].state is CleanupState.RELEASED
-
-
 @pytest.mark.parametrize(
     "primary_case",
     ["fabricated", "subclass", "foreign-manager", "stale", "non-live"],
@@ -983,7 +957,6 @@ async def test_open_verifier_rejects_noncanonical_primary_before_effects(
 
     if primary_case in {"fabricated", "subclass"}:
         if primary_case == "subclass":
-
             class DerivedPrimary(SandboxWorkspaceLease):
                 pass
 
@@ -1016,7 +989,10 @@ async def test_open_verifier_rejects_noncanonical_primary_before_effects(
     before = (
         len(harness.backend.launches),
         tuple(sorted(path.name for path in harness.workspace_root.iterdir())),
-        {path.name: path.read_bytes() for path in sorted(harness.lease_root.iterdir())},
+        {
+            path.name: path.read_bytes()
+            for path in sorted(harness.lease_root.iterdir())
+        },
         dict(harness.manager._snapshots),
     )
     foreign_before = (
@@ -1036,7 +1012,10 @@ async def test_open_verifier_rejects_noncanonical_primary_before_effects(
     assert (
         len(harness.backend.launches),
         tuple(sorted(path.name for path in harness.workspace_root.iterdir())),
-        {path.name: path.read_bytes() for path in sorted(harness.lease_root.iterdir())},
+        {
+            path.name: path.read_bytes()
+            for path in sorted(harness.lease_root.iterdir())
+        },
         dict(harness.manager._snapshots),
     ) == before
     if foreign_harness is not None:
@@ -1074,7 +1053,6 @@ async def test_open_verifier_rejects_caller_substituted_authority_before_effects
             executable_digest=foreign_grant.executable_digest,
         )
     else:
-
         class DerivedVerifier(type(canonical)):
             pass
 
@@ -1094,7 +1072,10 @@ async def test_open_verifier_rejects_caller_substituted_authority_before_effects
     before = (
         len(harness.backend.launches),
         tuple(sorted(path.name for path in harness.workspace_root.iterdir())),
-        {path.name: path.read_bytes() for path in sorted(harness.lease_root.iterdir())},
+        {
+            path.name: path.read_bytes()
+            for path in sorted(harness.lease_root.iterdir())
+        },
         dict(harness.manager._snapshots),
     )
 
@@ -1108,10 +1089,15 @@ async def test_open_verifier_rejects_caller_substituted_authority_before_effects
     assert (
         len(harness.backend.launches),
         tuple(sorted(path.name for path in harness.workspace_root.iterdir())),
-        {path.name: path.read_bytes() for path in sorted(harness.lease_root.iterdir())},
+        {
+            path.name: path.read_bytes()
+            for path in sorted(harness.lease_root.iterdir())
+        },
         dict(harness.manager._snapshots),
     ) == before
     assert (await primary.close()).state is CleanupState.RELEASED
+
+
 
 
 class VerifierRestartBackend(RecordingBackend):
@@ -1156,7 +1142,9 @@ async def test_restart_reconciles_durable_verifier_child_before_parent(
     if phase == "allocating":
         harness.backend.launch_entered = asyncio.Event()
         harness.backend.release_launch = asyncio.Event()
-        opening = asyncio.create_task(harness.manager.open_verifier(primary, snapshot))
+        opening = asyncio.create_task(
+            harness.manager.open_verifier(primary, snapshot)
+        )
         await asyncio.wait_for(harness.backend.launch_entered.wait(), 1)
         verifier_lease_id = harness.backend.launches[-1][2].lease_id
     else:
@@ -1226,7 +1214,9 @@ async def test_restart_reconciles_durable_verifier_child_before_parent(
         CleanupStepReceipt("lease_record", CleanupState.RELEASED),
     )
     assert not verifier_record_path.exists()
-    assert not (harness.lease_root / f"{primary.lease_id}.json").exists()
+    assert not (
+        harness.lease_root / f"{primary.lease_id}.json"
+    ).exists()
     assert list(harness.workspace_root.iterdir()) == []
 
 
@@ -1253,6 +1243,7 @@ async def test_same_manager_reconcile_skips_live_primary_and_verifier_leases(
     assert (await primary.close()).state is CleanupState.RELEASED
     assert list(harness.workspace_root.iterdir()) == []
     assert list(harness.lease_root.iterdir()) == []
+
 
 
 @pytest.mark.parametrize(
@@ -1318,9 +1309,7 @@ async def test_verifier_open_record_failure_obeys_detailed_runtime_cleanup_proof
         assert captured.value.primary.args == (
             "verifier active record durability fault",
         )
-        assert (
-            captured.value.cleanup_receipt.steps[: len(runtime_steps)] == runtime_steps
-        )
+        assert captured.value.cleanup_receipt.steps[: len(runtime_steps)] == runtime_steps
 
     assert calls == 2
     assert harness.backend.handles[1].terminate_calls == 1
@@ -1330,7 +1319,6 @@ async def test_verifier_open_record_failure_obeys_detailed_runtime_cleanup_proof
     else:
         assert len(set(harness.workspace_root.iterdir()) - primary_workspaces) == 1
         assert len(set(harness.lease_root.iterdir()) - primary_records) == 2
-
 
 @pytest.mark.parametrize(
     "runtime_state",
@@ -1344,7 +1332,9 @@ async def test_verifier_close_retains_dependents_until_runtime_absence_is_proven
     handle = harness.backend.handles[1]
     handle.termination_states = [runtime_state, CleanupState.RELEASED]
     result_path = (
-        verifier.workspace / "result" / verifier.plan.verifier.result_relative_path
+        verifier.workspace
+        / "result"
+        / verifier.plan.verifier.result_relative_path
     )
     result_path.write_text("retained", encoding="utf-8")
     record_path = harness.lease_root / f"{verifier.lease_id}.json"
@@ -1398,6 +1388,8 @@ async def test_verifier_close_retains_dependents_until_runtime_absence_is_proven
     assert (await primary.close()).state is CleanupState.RELEASED
     assert list(harness.workspace_root.iterdir()) == []
     assert list(harness.lease_root.iterdir()) == []
+
+
 
 
 class BlockingVerifierHandle(RecordingHandle):

--- a/tests/rl/harness/test_verifier_snapshot.py
+++ b/tests/rl/harness/test_verifier_snapshot.py
@@ -99,7 +99,7 @@ async def _opened_snapshot(tmp_path: Path) -> tuple[RuntimeHarness, Any, Any]:
     await primary.runner_workspace.write_text("work/candidate.txt", "candidate")
     snapshot = await primary.seal_for_verifier()
     return harness, primary, snapshot
-async def test_seal_terminates_before_patch_and_binds_patch_to_snapshot(
+async def test_patch_uses_the_terminated_immutable_verifier_snapshot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     fixture = make_runtime_fixture(with_writable_mount=True)
@@ -113,6 +113,7 @@ async def test_seal_terminates_before_patch_and_binds_patch_to_snapshot(
 
     def sealed_diff(**kwargs: Any) -> Mapping[str, Any]:
         assert handle.terminate_calls == 1
+        assert kwargs["repository"] != primary._materialized.workspace_path / "work"
         order.append("patch")
         return {
             "returncode": 0,
@@ -130,7 +131,7 @@ async def test_seal_terminates_before_patch_and_binds_patch_to_snapshot(
     monkeypatch.setattr(harness.store, "seal_snapshot", seal_snapshot)
     snapshot = await primary.seal_for_verifier()
     workspace_diff = primary.sealed_workspace_diff()
-    assert order == ["patch", "snapshot"]
+    assert order == ["snapshot", "patch"]
     assert workspace_diff is not None
     assert workspace_diff["snapshot_root_digest"] == snapshot.root_digest
     assert workspace_diff["patch_digest"] == digest(

--- a/tests/rl/harness/test_verifier_snapshot.py
+++ b/tests/rl/harness/test_verifier_snapshot.py
@@ -100,6 +100,47 @@ async def _opened_snapshot(tmp_path: Path) -> tuple[RuntimeHarness, Any, Any]:
     snapshot = await primary.seal_for_verifier()
     return harness, primary, snapshot
 
+
+async def test_seal_terminates_before_patch_and_binds_patch_to_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = make_runtime_fixture(with_writable_mount=True)
+    harness = RuntimeHarness(tmp_path, fixture)
+    primary = await harness.manager.open(fixture.request)
+    handle = harness.backend.handles[0]
+    handle.repository_base_commit = "0" * 40
+    handle.repository_relative_path = "work"
+    order: list[str] = []
+    original_seal = harness.store.seal_snapshot
+
+    def sealed_diff(**kwargs: Any) -> Mapping[str, Any]:
+        assert handle.terminate_calls == 1
+        order.append("patch")
+        return {
+            "returncode": 0,
+            "stdout": "diff --git a/a.py b/a.py\n",
+            "stderr": "",
+            "base_commit": kwargs["base_commit"],
+            "git_executable_digest": digest(b"git"),
+        }
+
+    def seal_snapshot(*args: Any, **kwargs: Any) -> Any:
+        order.append("snapshot")
+        return original_seal(*args, **kwargs)
+
+    monkeypatch.setattr(sandbox_module, "_sealed_repository_diff", sealed_diff)
+    monkeypatch.setattr(harness.store, "seal_snapshot", seal_snapshot)
+
+    snapshot = await primary.seal_for_verifier()
+    workspace_diff = primary.sealed_workspace_diff()
+
+    assert order == ["patch", "snapshot"]
+    assert workspace_diff is not None
+    assert workspace_diff["snapshot_root_digest"] == snapshot.root_digest
+    assert workspace_diff["patch_digest"] == digest(workspace_diff["stdout"].encode())
+
+
 def _isolated_verifier_fixture(runtime_class: c.RuntimeClass) -> Any:
     fixture = make_runtime_fixture(
         runtime_class=runtime_class,
@@ -241,8 +282,10 @@ async def test_snapshot_digest_independently_binds_every_path_byte_and_mode(
     tmp_path: Path,
 ) -> None:
     harness, primary, snapshot = await _opened_snapshot(tmp_path)
-    object_root = harness.cache_root / "snapshot-objects" / snapshot.root_digest.removeprefix(
-        "sha256:"
+    object_root = (
+        harness.cache_root
+        / "snapshot-objects"
+        / snapshot.root_digest.removeprefix("sha256:")
     )
     entries = _snapshot_entries(object_root)
 
@@ -267,7 +310,9 @@ async def test_snapshot_digest_independently_binds_every_path_byte_and_mode(
     await primary.close()
 
 
-@pytest.mark.parametrize("attack", ["symlink", "hardlink", "fifo", "depth", "files", "bytes"])
+@pytest.mark.parametrize(
+    "attack", ["symlink", "hardlink", "fifo", "depth", "files", "bytes"]
+)
 async def test_snapshot_rejects_links_special_files_and_budget_bombs_before_verifier(
     tmp_path: Path, attack: str
 ) -> None:
@@ -324,7 +369,10 @@ async def test_snapshot_requires_positive_runtime_quiescence_and_starts_no_verif
     assert captured.value.code == "snapshot_not_quiescent"
     assert primary.state is WorkspaceLeaseState.QUARANTINED
     assert len(harness.backend.launches) == 1
-    assert list((harness.cache_root / "snapshot-objects").glob("*/work/candidate.txt")) == []
+    assert (
+        list((harness.cache_root / "snapshot-objects").glob("*/work/candidate.txt"))
+        == []
+    )
     assert (await primary.close()).state is CleanupState.RELEASED
 
 
@@ -340,12 +388,23 @@ async def test_verifier_uses_distinct_runtime_workspace_and_read_only_snapshot(
     assert verifier.measurement.workspace_id != primary.measurement.workspace_id
     assert verifier.plan.runtime.runtime_id == "verifier-runtime"
     assert verifier.plan.image.image_digest == primary.plan.verifier.grant.image_digest
-    assert verifier.plan.security_policy.policy_digest == primary.plan.verifier.security_policy_digest
-    assert verifier.plan.network_policy.policy_digest == primary.plan.verifier.grant.network_policy_digest
-    assert (verifier.workspace / "snapshot" / "work" / "candidate.txt").read_bytes() == b"candidate"
-    assert stat.S_IMODE(
-        (verifier.workspace / "snapshot" / "work" / "candidate.txt").stat().st_mode
-    ) == 0o400
+    assert (
+        verifier.plan.security_policy.policy_digest
+        == primary.plan.verifier.security_policy_digest
+    )
+    assert (
+        verifier.plan.network_policy.policy_digest
+        == primary.plan.verifier.grant.network_policy_digest
+    )
+    assert (
+        verifier.workspace / "snapshot" / "work" / "candidate.txt"
+    ).read_bytes() == b"candidate"
+    assert (
+        stat.S_IMODE(
+            (verifier.workspace / "snapshot" / "work" / "candidate.txt").stat().st_mode
+        )
+        == 0o400
+    )
     assert stat.S_IMODE((verifier.workspace / "result").stat().st_mode) == 0o700
     assert len(harness.backend.launches) == 2
     assert primary.measurement.reward_eligible is False
@@ -353,7 +412,9 @@ async def test_verifier_uses_distinct_runtime_workspace_and_read_only_snapshot(
     assert verifier.measurement.reward_eligible is False
 
     payload = _valid_result(primary, snapshot)
-    result_path = verifier.workspace / "result" / verifier.plan.verifier.result_relative_path
+    result_path = (
+        verifier.workspace / "result" / verifier.plan.verifier.result_relative_path
+    )
     result_path.write_text(json.dumps(payload), encoding="utf-8")
     result = await verifier.execute()
     assert isinstance(result, MappingProxyType)
@@ -461,10 +522,14 @@ async def test_reward_eligible_primary_requires_equally_isolated_verifier_measur
         assert len(list(harness.lease_root.iterdir())) == 2
     else:
         verifier = await harness.manager.open_verifier(primary, snapshot)
-        assert primary.measurement.isolation_disposition is IsolationDisposition.ISOLATED
+        assert (
+            primary.measurement.isolation_disposition is IsolationDisposition.ISOLATED
+        )
         assert primary.measurement.isolated is True
         assert primary.measurement.reward_eligible is True
-        assert verifier.measurement.isolation_disposition is IsolationDisposition.ISOLATED
+        assert (
+            verifier.measurement.isolation_disposition is IsolationDisposition.ISOLATED
+        )
         assert verifier.measurement.isolated is True
         assert verifier.measurement.reward_eligible is True
         assert (await verifier.close()).state is CleanupState.RELEASED
@@ -502,7 +567,9 @@ async def test_malicious_verifier_results_are_typed_and_cleanup_is_authoritative
     harness, primary, snapshot = await _opened_snapshot(tmp_path)
     verifier = await harness.manager.open_verifier(primary, snapshot)
     handle = harness.backend.handles[1]
-    result_path = verifier.workspace / "result" / verifier.plan.verifier.result_relative_path
+    result_path = (
+        verifier.workspace / "result" / verifier.plan.verifier.result_relative_path
+    )
     payload = _valid_result(primary, snapshot)
     device_fd: int | None = None
     if case == "nonzero":
@@ -525,9 +592,7 @@ async def test_malicious_verifier_results_are_typed_and_cleanup_is_authoritative
         device_fd = os.open("/dev/null", os.O_RDONLY)
         original_open = os.open
 
-        def substitute_device(
-            path: Any, flags: int, *args: Any, **kwargs: Any
-        ) -> int:
+        def substitute_device(path: Any, flags: int, *args: Any, **kwargs: Any) -> int:
             if path == result_path.name and kwargs.get("dir_fd") is not None:
                 return os.dup(device_fd)
             return original_open(path, flags, *args, **kwargs)
@@ -680,6 +745,7 @@ async def test_snapshot_seal_cancellation_releases_completed_snapshot_worker(
     assert list(harness.workspace_root.iterdir()) == []
     assert list(harness.lease_root.iterdir()) == []
 
+
 async def test_identical_snapshot_seal_holds_reference_during_release(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -747,9 +813,7 @@ async def test_snapshot_copy_cancellation_waits_before_verifier_workspace_releas
         return original_copy(*args, **kwargs)
 
     monkeypatch.setattr(harness.store, "copy_snapshot", blocked_copy)
-    opening = asyncio.create_task(
-        harness.manager.open_verifier(primary, snapshot)
-    )
+    opening = asyncio.create_task(harness.manager.open_verifier(primary, snapshot))
     assert await asyncio.to_thread(entered.wait, 1)
 
     opening.cancel()
@@ -764,8 +828,7 @@ async def test_snapshot_copy_cancellation_waits_before_verifier_workspace_releas
         for path in harness.workspace_root.iterdir()
     )
     assert not any(
-        path.name.startswith("verifier-lease-")
-        for path in harness.lease_root.iterdir()
+        path.name.startswith("verifier-lease-") for path in harness.lease_root.iterdir()
     )
     assert (await primary.close()).state is CleanupState.RELEASED
     assert harness.manager._snapshots == {}
@@ -778,8 +841,10 @@ async def test_post_seal_snapshot_mutation_starts_no_verifier_and_cleans_primary
     tmp_path: Path,
 ) -> None:
     harness, primary, snapshot = await _opened_snapshot(tmp_path)
-    object_root = harness.cache_root / "snapshot-objects" / snapshot.root_digest.removeprefix(
-        "sha256:"
+    object_root = (
+        harness.cache_root
+        / "snapshot-objects"
+        / snapshot.root_digest.removeprefix("sha256:")
     )
     candidate = object_root / "work" / "candidate.txt"
     candidate.chmod(0o600)
@@ -812,9 +877,7 @@ async def test_open_verifier_reservation_precedes_parent_close_and_child_cleanup
     backend = harness.backend
     backend.launch_entered = asyncio.Event()
     backend.release_launch = asyncio.Event()
-    opening = asyncio.create_task(
-        harness.manager.open_verifier(primary, snapshot)
-    )
+    opening = asyncio.create_task(harness.manager.open_verifier(primary, snapshot))
 
     await asyncio.wait_for(backend.launch_entered.wait(), 1)
     assert len(backend.launches) == 2
@@ -903,6 +966,8 @@ async def test_primary_close_aggregates_failed_child_without_duplicate_resource(
     reconciled = await harness.manager.close()
     assert len(reconciled) == 1
     assert reconciled[0].state is CleanupState.RELEASED
+
+
 @pytest.mark.parametrize(
     "primary_case",
     ["fabricated", "subclass", "foreign-manager", "stale", "non-live"],
@@ -918,6 +983,7 @@ async def test_open_verifier_rejects_noncanonical_primary_before_effects(
 
     if primary_case in {"fabricated", "subclass"}:
         if primary_case == "subclass":
+
             class DerivedPrimary(SandboxWorkspaceLease):
                 pass
 
@@ -950,10 +1016,7 @@ async def test_open_verifier_rejects_noncanonical_primary_before_effects(
     before = (
         len(harness.backend.launches),
         tuple(sorted(path.name for path in harness.workspace_root.iterdir())),
-        {
-            path.name: path.read_bytes()
-            for path in sorted(harness.lease_root.iterdir())
-        },
+        {path.name: path.read_bytes() for path in sorted(harness.lease_root.iterdir())},
         dict(harness.manager._snapshots),
     )
     foreign_before = (
@@ -973,10 +1036,7 @@ async def test_open_verifier_rejects_noncanonical_primary_before_effects(
     assert (
         len(harness.backend.launches),
         tuple(sorted(path.name for path in harness.workspace_root.iterdir())),
-        {
-            path.name: path.read_bytes()
-            for path in sorted(harness.lease_root.iterdir())
-        },
+        {path.name: path.read_bytes() for path in sorted(harness.lease_root.iterdir())},
         dict(harness.manager._snapshots),
     ) == before
     if foreign_harness is not None:
@@ -1014,6 +1074,7 @@ async def test_open_verifier_rejects_caller_substituted_authority_before_effects
             executable_digest=foreign_grant.executable_digest,
         )
     else:
+
         class DerivedVerifier(type(canonical)):
             pass
 
@@ -1033,10 +1094,7 @@ async def test_open_verifier_rejects_caller_substituted_authority_before_effects
     before = (
         len(harness.backend.launches),
         tuple(sorted(path.name for path in harness.workspace_root.iterdir())),
-        {
-            path.name: path.read_bytes()
-            for path in sorted(harness.lease_root.iterdir())
-        },
+        {path.name: path.read_bytes() for path in sorted(harness.lease_root.iterdir())},
         dict(harness.manager._snapshots),
     )
 
@@ -1050,15 +1108,10 @@ async def test_open_verifier_rejects_caller_substituted_authority_before_effects
     assert (
         len(harness.backend.launches),
         tuple(sorted(path.name for path in harness.workspace_root.iterdir())),
-        {
-            path.name: path.read_bytes()
-            for path in sorted(harness.lease_root.iterdir())
-        },
+        {path.name: path.read_bytes() for path in sorted(harness.lease_root.iterdir())},
         dict(harness.manager._snapshots),
     ) == before
     assert (await primary.close()).state is CleanupState.RELEASED
-
-
 
 
 class VerifierRestartBackend(RecordingBackend):
@@ -1103,9 +1156,7 @@ async def test_restart_reconciles_durable_verifier_child_before_parent(
     if phase == "allocating":
         harness.backend.launch_entered = asyncio.Event()
         harness.backend.release_launch = asyncio.Event()
-        opening = asyncio.create_task(
-            harness.manager.open_verifier(primary, snapshot)
-        )
+        opening = asyncio.create_task(harness.manager.open_verifier(primary, snapshot))
         await asyncio.wait_for(harness.backend.launch_entered.wait(), 1)
         verifier_lease_id = harness.backend.launches[-1][2].lease_id
     else:
@@ -1175,9 +1226,7 @@ async def test_restart_reconciles_durable_verifier_child_before_parent(
         CleanupStepReceipt("lease_record", CleanupState.RELEASED),
     )
     assert not verifier_record_path.exists()
-    assert not (
-        harness.lease_root / f"{primary.lease_id}.json"
-    ).exists()
+    assert not (harness.lease_root / f"{primary.lease_id}.json").exists()
     assert list(harness.workspace_root.iterdir()) == []
 
 
@@ -1204,7 +1253,6 @@ async def test_same_manager_reconcile_skips_live_primary_and_verifier_leases(
     assert (await primary.close()).state is CleanupState.RELEASED
     assert list(harness.workspace_root.iterdir()) == []
     assert list(harness.lease_root.iterdir()) == []
-
 
 
 @pytest.mark.parametrize(
@@ -1270,7 +1318,9 @@ async def test_verifier_open_record_failure_obeys_detailed_runtime_cleanup_proof
         assert captured.value.primary.args == (
             "verifier active record durability fault",
         )
-        assert captured.value.cleanup_receipt.steps[: len(runtime_steps)] == runtime_steps
+        assert (
+            captured.value.cleanup_receipt.steps[: len(runtime_steps)] == runtime_steps
+        )
 
     assert calls == 2
     assert harness.backend.handles[1].terminate_calls == 1
@@ -1280,6 +1330,7 @@ async def test_verifier_open_record_failure_obeys_detailed_runtime_cleanup_proof
     else:
         assert len(set(harness.workspace_root.iterdir()) - primary_workspaces) == 1
         assert len(set(harness.lease_root.iterdir()) - primary_records) == 2
+
 
 @pytest.mark.parametrize(
     "runtime_state",
@@ -1293,9 +1344,7 @@ async def test_verifier_close_retains_dependents_until_runtime_absence_is_proven
     handle = harness.backend.handles[1]
     handle.termination_states = [runtime_state, CleanupState.RELEASED]
     result_path = (
-        verifier.workspace
-        / "result"
-        / verifier.plan.verifier.result_relative_path
+        verifier.workspace / "result" / verifier.plan.verifier.result_relative_path
     )
     result_path.write_text("retained", encoding="utf-8")
     record_path = harness.lease_root / f"{verifier.lease_id}.json"
@@ -1349,8 +1398,6 @@ async def test_verifier_close_retains_dependents_until_runtime_absence_is_proven
     assert (await primary.close()).state is CleanupState.RELEASED
     assert list(harness.workspace_root.iterdir()) == []
     assert list(harness.lease_root.iterdir()) == []
-
-
 
 
 class BlockingVerifierHandle(RecordingHandle):

--- a/tests/rl/harness/v2_service_fixtures.py
+++ b/tests/rl/harness/v2_service_fixtures.py
@@ -458,18 +458,11 @@ class DeterministicLease:
         self.close_error: BaseException | None = None
         self.close_entered = asyncio.Event()
         self.close_release: asyncio.Event | None = None
-
-    async def workspace_diff(self) -> dict[str, Any]:
-        self.calls.append("workspace.diff")
-        return {
-            "returncode": 0,
-            "stdout": "diff --git a/a.py b/a.py\n",
-            "stderr": "",
-        }
+        self._sealed_workspace_diff: dict[str, Any] | None = None
 
     async def seal_for_verifier(self) -> VerifierSnapshotReceipt:
         self.calls.append("lease.seal")
-        return VerifierSnapshotReceipt(
+        receipt = VerifierSnapshotReceipt(
             snapshot_id="snapshot-deterministic",
             source_workspace_id="workspace-deterministic",
             source_lease_id=self.lease_id,
@@ -483,6 +476,21 @@ class DeterministicLease:
             byte_count=0,
             immutable_storage_object_id="cas/snapshot-deterministic",
         )
+        patch = "diff --git a/a.py b/a.py\n"
+        self._sealed_workspace_diff = {
+            "returncode": 0,
+            "stdout": patch,
+            "stderr": "",
+            "base_commit": "0" * 40,
+            "git_executable_digest": ref("workspace-diff-git").sha256,
+            "patch_digest": "sha256:" + hashlib.sha256(patch.encode()).hexdigest(),
+            "snapshot_root_digest": receipt.root_digest,
+        }
+        return receipt
+
+    def sealed_workspace_diff(self) -> dict[str, Any] | None:
+        self.calls.append("workspace.diff")
+        return self._sealed_workspace_diff
 
     async def close(self) -> SandboxCleanupReceipt:
         self.calls.append("lease.close")

--- a/tests/rl/harness/v2_service_fixtures.py
+++ b/tests/rl/harness/v2_service_fixtures.py
@@ -460,6 +460,7 @@ class DeterministicLease:
         self.close_release: asyncio.Event | None = None
         self._sealed_workspace_diff: dict[str, Any] | None = None
 
+
     async def seal_for_verifier(self) -> VerifierSnapshotReceipt:
         self.calls.append("lease.seal")
         receipt = VerifierSnapshotReceipt(

--- a/tests/rl/harness/v2_service_fixtures.py
+++ b/tests/rl/harness/v2_service_fixtures.py
@@ -60,7 +60,13 @@ def released_receipt(lease_id: str = "lease-deterministic") -> SandboxCleanupRec
         lease_id,
         tuple(
             CleanupStepReceipt(resource, CleanupState.RELEASED)
-            for resource in ("child_verifier", "runtime", "workspace", "cache_holder", "lease_record")
+            for resource in (
+                "child_verifier",
+                "runtime",
+                "workspace",
+                "cache_holder",
+                "lease_record",
+            )
         ),
     )
 
@@ -70,7 +76,9 @@ def failed_receipt(lease_id: str = "lease-deterministic") -> SandboxCleanupRecei
         lease_id,
         (
             CleanupStepReceipt("runtime", CleanupState.RELEASED),
-            CleanupStepReceipt("workspace", CleanupState.FAILED, "deterministic failure"),
+            CleanupStepReceipt(
+                "workspace", CleanupState.FAILED, "deterministic failure"
+            ),
             CleanupStepReceipt("cache_holder", CleanupState.RELEASED),
             CleanupStepReceipt("lease_record", CleanupState.RELEASED),
         ),
@@ -134,12 +142,8 @@ def deterministic_sandbox_plan() -> Any:
             measured_binary_digest=ref("runtime-binary").sha256,
         ),
         image=SimpleNamespace(image_digest=ref("runtime-image").sha256),
-        security_policy=SimpleNamespace(
-            policy_digest=ref("security-policy").sha256
-        ),
-        network_policy=SimpleNamespace(
-            policy_digest=ref("network-policy").sha256
-        ),
+        security_policy=SimpleNamespace(policy_digest=ref("security-policy").sha256),
+        network_policy=SimpleNamespace(policy_digest=ref("network-policy").sha256),
         verifier=SimpleNamespace(
             grant=SimpleNamespace(
                 implementation_digest=ref("verifier-implementation").sha256
@@ -159,6 +163,7 @@ def exact_wp4_case() -> tuple[Any, Any, Any]:
     resolved = fixture.runtime.resolve_episode(fixture.request)
     return fixture, fixture.request, resolved
 
+
 def conductor_compatible_case() -> tuple[Any, Any, Any, Any]:
     fixture, request, _ = exact_wp4_case()
     observation = _observation("v2")
@@ -168,11 +173,16 @@ def conductor_compatible_case() -> tuple[Any, Any, Any, Any]:
         implementation_digest=CONDUCTOR_IMPLEMENTATION_DIGEST,
     )
     binding = c.SelectionBinding(
-        owner_key="sha256:" + hashlib.sha256(canonical_json_bytes({
-            "schema_version": "bb.rl.selection-owner.v1",
-            "subject_digest": plan.subject_digest,
-            "episode_id": request.episode_id,
-        })).hexdigest(),
+        owner_key="sha256:"
+        + hashlib.sha256(
+            canonical_json_bytes(
+                {
+                    "schema_version": "bb.rl.selection-owner.v1",
+                    "subject_digest": plan.subject_digest,
+                    "episode_id": request.episode_id,
+                }
+            )
+        ).hexdigest(),
         request_digest=ref("selection-request").sha256,
         selection_record_digest=plan.selection_record_digest,
     )
@@ -273,7 +283,9 @@ class DeterministicPolicyResolver:
         self.entered: asyncio.Event | None = None
         self.release: asyncio.Event | None = None
 
-    async def resolve(self, policy_binding: Any, *, episode_id: str, effective_plan_digest: str) -> Any:
+    async def resolve(
+        self, policy_binding: Any, *, episode_id: str, effective_plan_digest: str
+    ) -> Any:
         self.calls.append("policy.resolve")
         if self.entered is not None:
             self.entered.set()
@@ -315,12 +327,23 @@ class DeterministicSession:
         result = RunnerResult(
             episode_id=self.request.episode_id,
             effective_plan_digest=self.request.effective_plan_digest,
-            original_request={"task_input": dict(request.task_input), "context": dict(request.context)},
+            original_request={
+                "task_input": dict(request.task_input),
+                "context": dict(request.context),
+            },
             response={"answer": "deterministic"},
             termination=termination,
             turn_count=1,
             turns=(RunnerTurn(1, ({"type": "submit", "value": "deterministic"},)),),
-            events=(RunnerTerminationEvent(0, self.request.episode_id, self.request.effective_plan_digest, 1, termination),),
+            events=(
+                RunnerTerminationEvent(
+                    0,
+                    self.request.episode_id,
+                    self.request.effective_plan_digest,
+                    1,
+                    termination,
+                ),
+            ),
         )
         if self.events is not None and self.emit_result_events:
             for event in result.events:
@@ -355,7 +378,15 @@ class DeterministicRunner:
         self.session_events: tuple[Any, ...] = ()
         self.emit_result_events = False
 
-    async def open(self, request: Any, *, policy: Any, workspace: Any, cancellation: Any, events: Any) -> Any:
+    async def open(
+        self,
+        request: Any,
+        *,
+        policy: Any,
+        workspace: Any,
+        cancellation: Any,
+        events: Any,
+    ) -> Any:
         self.calls.append("runner.open")
         self.open_arguments.append((request, policy, workspace, cancellation, events))
         if self.open_error is not None:
@@ -413,12 +444,27 @@ class DeterministicVerifier:
         return self.close_receipt
 
 
+class DeterministicRunnerWorkspace:
+    tool_bindings: tuple[Any, ...] = ()
+
+    def __init__(self, calls: list[str]) -> None:
+        self.calls = calls
+
+    async def workspace_diff(self) -> dict[str, Any]:
+        self.calls.append("workspace.diff")
+        return {
+            "returncode": 0,
+            "stdout": "diff --git a/a.py b/a.py\n",
+            "stderr": "",
+        }
+
+
 class DeterministicLease:
     def __init__(self, calls: list[str], effective_plan_digest: str) -> None:
         self.calls = calls
         self.effective_plan_digest = effective_plan_digest
         self.lease_id = "lease-deterministic"
-        self.runner_workspace = SimpleNamespace(tool_bindings=())
+        self.runner_workspace = DeterministicRunnerWorkspace(calls)
         self.measurement = {"measurement": ref("primary-measurement").sha256}
         self._materialized = SimpleNamespace(
             receipt={"receipt": ref("materialized").sha256}
@@ -460,7 +506,9 @@ class DeterministicEvidenceAuthority(V2EvidenceAuthority):
         super().__init__(())
         self.calls = calls
 
-    def validate_plan(self, effective_plan: Any, evidence_policy: Any, retention_policy: Any) -> Any:
+    def validate_plan(
+        self, effective_plan: Any, evidence_policy: Any, retention_policy: Any
+    ) -> Any:
         self.calls.append("evidence.validate_plan")
         return super().validate_plan(effective_plan, evidence_policy, retention_policy)
 
@@ -622,9 +670,7 @@ class DeterministicEvidenceRepository:
             raise ValueError("deterministic runner event sequence is not contiguous")
         events.append(event)
         event_digest = canonical_digest(event)
-        event_ref = ref(
-            f"runner-event-{episode_id}-{event.sequence}-{event_digest}"
-        )
+        event_ref = ref(f"runner-event-{episode_id}-{event.sequence}-{event_digest}")
         self.runner_event_refs.setdefault(episode_id, []).append(event_ref)
         return SimpleNamespace(
             event_ref=event_ref,
@@ -664,8 +710,7 @@ class DeterministicEvidenceRepository:
         self.calls.append("repo.publish_completed")
         if (
             inputs.verifier_cleanup_receipt is not None
-            and inputs.verifier_cleanup_receipt.lease_id
-            != inputs.verifier_lease_id
+            and inputs.verifier_cleanup_receipt.lease_id != inputs.verifier_lease_id
         ):
             raise EvidenceValidationError("cleanup receipt lease mismatch")
         self.completed_inputs.append(inputs)
@@ -715,9 +760,7 @@ class DeterministicEvidenceRepository:
                     "absent cleanup receipt cannot claim cleanup resources"
                 )
         else:
-            resources = tuple(
-                step.resource for step in inputs.cleanup_receipt.steps
-            )
+            resources = tuple(step.resource for step in inputs.cleanup_receipt.steps)
             released = {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
             if (
                 tuple(inputs.cleanup_required_resources) != required_resources
@@ -725,8 +768,7 @@ class DeterministicEvidenceRepository:
                 or set(resources) != set(required_resources)
                 or inputs.cleanup_receipt.state not in released
                 or any(
-                    step.state not in released
-                    for step in inputs.cleanup_receipt.steps
+                    step.state not in released for step in inputs.cleanup_receipt.steps
                 )
             ):
                 raise EvidenceValidationError(
@@ -798,6 +840,7 @@ def service_case() -> DeterministicServiceCase:
         evidence_authority=evidence_authority,
     )
 
+
 def canonical_create_response_bytes(response: Any) -> bytes:
     return canonical_json_bytes(
         {
@@ -805,7 +848,9 @@ def canonical_create_response_bytes(response: Any) -> bytes:
             "create_fingerprint": response.create_fingerprint,
             "state": response.state.value,
             "effective_plan_digest": response.effective_plan_digest,
-            "selection_record_ref": response.selection_record_ref.model_dump(mode="json"),
+            "selection_record_ref": response.selection_record_ref.model_dump(
+                mode="json"
+            ),
             "effective_plan_ref": response.effective_plan_ref.model_dump(mode="json"),
             "policy_binding_digest": response.policy_binding_digest,
             "selection_commit": response.selection_commit.model_dump(mode="json"),

--- a/tests/rl/harness/v2_service_fixtures.py
+++ b/tests/rl/harness/v2_service_fixtures.py
@@ -444,27 +444,12 @@ class DeterministicVerifier:
         return self.close_receipt
 
 
-class DeterministicRunnerWorkspace:
-    tool_bindings: tuple[Any, ...] = ()
-
-    def __init__(self, calls: list[str]) -> None:
-        self.calls = calls
-
-    async def workspace_diff(self) -> dict[str, Any]:
-        self.calls.append("workspace.diff")
-        return {
-            "returncode": 0,
-            "stdout": "diff --git a/a.py b/a.py\n",
-            "stderr": "",
-        }
-
-
 class DeterministicLease:
     def __init__(self, calls: list[str], effective_plan_digest: str) -> None:
         self.calls = calls
         self.effective_plan_digest = effective_plan_digest
         self.lease_id = "lease-deterministic"
-        self.runner_workspace = DeterministicRunnerWorkspace(calls)
+        self.runner_workspace = SimpleNamespace(tool_bindings=())
         self.measurement = {"measurement": ref("primary-measurement").sha256}
         self._materialized = SimpleNamespace(
             receipt={"receipt": ref("materialized").sha256}
@@ -473,6 +458,14 @@ class DeterministicLease:
         self.close_error: BaseException | None = None
         self.close_entered = asyncio.Event()
         self.close_release: asyncio.Event | None = None
+
+    async def workspace_diff(self) -> dict[str, Any]:
+        self.calls.append("workspace.diff")
+        return {
+            "returncode": 0,
+            "stdout": "diff --git a/a.py b/a.py\n",
+            "stderr": "",
+        }
 
     async def seal_for_verifier(self) -> VerifierSnapshotReceipt:
         self.calls.append("lease.seal")


### PR DESCRIPTION
## Scope

- add an optional normalized `patch_path` to the installed headless request
- load the exact workspace patch artifact from the canonical evidence CAS before cleanup
- publish patch bytes atomically to a distinct caller destination
- bind patch digest, size, availability, and publication failures in the versioned result
- fail closed when a requested run produces no canonical patch

## Evidence

- focused headless tests: 6 passed, 1 skipped
- ruff E9/F821: pass
- exact source commit before ACR-only update: `e9fc4be13d576e6a9a12908a32e2daec006540e3`
- final head: `092cabccdac989ea02921da66c0de8d44537522a`

Required by the installed SWE evaluator path so official scoring cannot consume a patch detached from the executed workspace.