### PR TITLE
fix(rl): repair trusted process lifecycle

### DIFF
--- a/breadboard/rl/harness/evidence.py
+++ b/breadboard/rl/harness/evidence.py
@@ -54,7 +54,7 @@ _PRIMARY_CLEANUP_RESOURCES = (
     "cache_holder",
     "lease_record",
 )
-_VERIFIER_CLEANUP_RESOURCES = ("runtime", "workspace", "lease_record")
+_VERIFIER_CLEANUP_RESOURCES = ("runtime", "workspace", "snapshot", "lease_record")
 _SCHEMA_MEDIA = "application/vnd.breadboard.evidence+json"
 
 

--- a/breadboard/rl/harness/materialization.py
+++ b/breadboard/rl/harness/materialization.py
@@ -2858,6 +2858,8 @@ class FilesystemMaterializationStore:
             finally:
                 os.close(reference_fd)
             if references:
+                if not self._cache.exists(immutable_relative):
+                    raise RuntimeError("snapshot_tampered")
                 return
             if self._cache.exists(immutable_relative):
                 raise RuntimeError("snapshot_tampered")
@@ -2884,6 +2886,119 @@ class FilesystemMaterializationStore:
             root_digest=receipt.root_digest,
             snapshot_id=receipt.snapshot_id,
             source_lease_id=receipt.source_lease_id,
+        )
+
+    def recover_stale_snapshot(
+        self,
+        record: Mapping[str, Any],
+    ) -> CleanupStepReceipt:
+        try:
+            frozen_record = dict(record) if isinstance(record, Mapping) else None
+        except Exception:
+            frozen_record = None
+        if frozen_record is None:
+            return CleanupStepReceipt(
+                "snapshot",
+                CleanupState.QUARANTINED,
+                "stale_identity_uncertain",
+            )
+        snapshot_id = frozen_record.get("snapshot_id")
+        root_digest = frozen_record.get("snapshot_root_digest")
+        source_lease_id = frozen_record.get("parent_lease_id")
+        if (
+            frozen_record.get("role") != "verifier"
+            or type(snapshot_id) is not str
+            or not snapshot_id.startswith("snapshot-")
+            or len(snapshot_id) != 41
+            or any(
+                character not in "0123456789abcdef"
+                for character in snapshot_id.removeprefix("snapshot-")
+            )
+            or type(root_digest) is not str
+            or not root_digest.startswith(_DIGEST_PREFIX)
+            or len(root_digest) != len(_DIGEST_PREFIX) + 64
+            or any(
+                character not in "0123456789abcdef"
+                for character in root_digest.removeprefix(_DIGEST_PREFIX)
+            )
+            or type(source_lease_id) is not str
+            or not source_lease_id
+            or len(source_lease_id) > 256
+        ):
+            return CleanupStepReceipt(
+                "snapshot",
+                CleanupState.QUARANTINED,
+                "stale_identity_uncertain",
+            )
+        suffix = root_digest.removeprefix(_DIGEST_PREFIX)
+        reference_relative = (
+            "snapshot-references/" + suffix + "/" + snapshot_id
+        )
+        try:
+            reference_root_fd = self._cache.open_dir("snapshot-references")
+            try:
+                reference_suffixes = tuple(sorted(os.listdir(reference_root_fd)))
+            finally:
+                os.close(reference_root_fd)
+            locations: list[str] = []
+            for candidate_suffix in reference_suffixes:
+                if (
+                    len(candidate_suffix) != 64
+                    or any(
+                        character not in "0123456789abcdef"
+                        for character in candidate_suffix
+                    )
+                ):
+                    raise RuntimeError("snapshot_tampered")
+                candidate_relative = (
+                    "snapshot-references/"
+                    + candidate_suffix
+                    + "/"
+                    + snapshot_id
+                )
+                try:
+                    marker_fd = self._cache.open_file(
+                        candidate_relative,
+                        os.O_RDONLY,
+                    )
+                except FileNotFoundError:
+                    continue
+                else:
+                    os.close(marker_fd)
+                    locations.append(candidate_suffix)
+            if any(location != suffix for location in locations):
+                return CleanupStepReceipt(
+                    "snapshot",
+                    CleanupState.QUARANTINED,
+                    "stale_identity_uncertain",
+                )
+            reference_existed = suffix in locations
+            self._release_snapshot_reference(
+                root_digest=root_digest,
+                snapshot_id=snapshot_id,
+                source_lease_id=source_lease_id,
+            )
+            try:
+                reference_absent = not self._cache.exists(reference_relative)
+            except FileNotFoundError:
+                reference_absent = True
+            self._reject_unreferenced_snapshot_object(suffix)
+        except Exception as exc:
+            return CleanupStepReceipt(
+                "snapshot",
+                CleanupState.FAILED,
+                type(exc).__name__,
+            )
+        return CleanupStepReceipt(
+            "snapshot",
+            (
+                CleanupState.RELEASED
+                if reference_existed and reference_absent
+                else CleanupState.ALREADY_RELEASED
+                if reference_absent
+                else CleanupState.FAILED
+            ),
+            snapshot_id,
         )
 
     def release_snapshots_for_lease(self, source_lease_id: str) -> tuple[str, ...]:

--- a/breadboard/rl/harness/qualification.py
+++ b/breadboard/rl/harness/qualification.py
@@ -1273,7 +1273,7 @@ printf '{"effective_plan_digest":"%s","episode_id":"%s","score":1.0,"snapshot_di
         runtime_id=verifier_runtime_id,
         runtime_class=c.RuntimeClass.TRUSTED_PROCESS,
         driver_implementation_digest=digest_payload("verifier-process-driver"),
-        runtime_binary_digest=verifier_binary_digest,
+        runtime_binary_digest=shell_digest,
         security_policy_digest=verifier_security_digest,
         image_digest=capability.verifier.image_digest,
         network_policy_digest=network_digest,
@@ -1362,8 +1362,8 @@ printf '{"effective_plan_digest":"%s","episode_id":"%s","score":1.0,"snapshot_di
                     runtime_id=verifier_runtime_id,
                     runtime_class=c.RuntimeClass.TRUSTED_PROCESS,
                     driver_implementation_digest=verifier_binding.driver_implementation_digest,
-                    executable_path=str(verifier_path),
-                    measured_binary_digest=verifier_binary_digest,
+                    executable_path=str(shell_path),
+                    measured_binary_digest=shell_digest,
                     oci_runtime_name="process",
                     supported_platform_versions=(platform_identity,),
                     fixed_environment=(("PATH", "/usr/bin:/bin"),),
@@ -2040,14 +2040,7 @@ printf '{"effective_plan_digest":"%s","episode_id":"%s","score":1.0,"snapshot_di
 
     runtime_path = Path(installed_runtimes[0].executable_path)
     runtime_stat = runtime_path.stat(follow_symlinks=False)
-    verifier_runtime_path = Path(
-        next(
-            item.executable_path
-            for item in installed_runtimes
-            if item.runtime_id == verifier_runtime_id
-        )
-    )
-    verifier_runtime_stat = verifier_runtime_path.stat(follow_symlinks=False)
+    verifier_stat = verifier_path.stat(follow_symlinks=False)
     response_payload = (
         {
             "output": [
@@ -2130,10 +2123,10 @@ printf '{"effective_plan_digest":"%s","episode_id":"%s","score":1.0,"snapshot_di
             inode=runtime_stat.st_ino,
         ),
         verifier_executable_identity=ExecutableIdentity(
-            path=verifier_runtime_path,
+            path=verifier_path,
             sha256=verifier_binary_digest,
-            device=verifier_runtime_stat.st_dev,
-            inode=verifier_runtime_stat.st_ino,
+            device=verifier_stat.st_dev,
+            inode=verifier_stat.st_ino,
         ),
         selector_digest=selector_runtime_ref.sha256,
         create_body=MappingProxyType(create_body),

--- a/breadboard/rl/harness/sandbox.py
+++ b/breadboard/rl/harness/sandbox.py
@@ -510,6 +510,8 @@ class _PinnedExecutable:
     snapshot_device: int
     snapshot_inode: int
     proc_fd_path: str
+    execution_format: Literal["elf", "script"]
+    interpreter_path: str | None
     closed: bool = False
 
     def close(self) -> None:
@@ -550,10 +552,13 @@ def _snapshot_installed_executable(
         )
         hasher = __import__("hashlib").sha256()
         size = 0
+        header = bytearray()
         while True:
             chunk = os.read(source_fd, 1024 * 1024)
             if not chunk:
                 break
+            if len(header) < 256:
+                header.extend(chunk[: 256 - len(header)])
             hasher.update(chunk)
             size += len(chunk)
             view = memoryview(chunk)
@@ -566,6 +571,32 @@ def _snapshot_installed_executable(
         if expected_digest is not None and digest != expected_digest:
             raise SandboxLaunchError(
                 "trusted process executable identity mismatch",
+                code="runtime_preflight_failed",
+            )
+        if header.startswith(b"\x7fELF"):
+            execution_format: Literal["elf", "script"] = "elf"
+            interpreter_path = None
+        elif header.startswith(b"#!"):
+            first_line = bytes(header).split(b"\n", 1)[0][2:].strip()
+            try:
+                interpreter_path = first_line.decode("ascii")
+            except UnicodeDecodeError as exc:
+                raise SandboxLaunchError(
+                    "trusted process script interpreter is invalid",
+                    code="runtime_preflight_failed",
+                ) from exc
+            if (
+                not _exact_absolute_path(interpreter_path)
+                or any(character.isspace() for character in interpreter_path)
+            ):
+                raise SandboxLaunchError(
+                    "trusted process script interpreter is unsupported",
+                    code="runtime_preflight_failed",
+                )
+            execution_format = "script"
+        else:
+            raise SandboxLaunchError(
+                "trusted process executable format is unsupported",
                 code="runtime_preflight_failed",
             )
         os.fchmod(snapshot_fd, 0o500)
@@ -597,6 +628,8 @@ def _snapshot_installed_executable(
             snapshot_device=snapshot.st_dev,
             snapshot_inode=snapshot.st_ino,
             proc_fd_path=proc_fd_path,
+            execution_format=execution_format,
+            interpreter_path=interpreter_path,
         )
         snapshot_fd = -1
         return pinned
@@ -1376,12 +1409,14 @@ class TrustedProcessHandle:
         git_executable: str,
         workspace_fd: int,
         workspace_identity: tuple[int, int],
+        command_executable: _PinnedExecutable | None = None,
     ) -> None:
         self.plan = plan
         self.workspace = workspace
         self.lease_id = lease_id
         self.runtime_id = "process-group-" + lease_id
         self._executable = executable
+        self._command_executable = command_executable
         self._git_executable = git_executable
         self._workspace_fd = workspace_fd
         self._workspace_identity = workspace_identity
@@ -1595,13 +1630,32 @@ class TrustedProcessHandle:
                 code="runtime_preflight_failed",
                 lease_id=self.lease_id,
             )
+        execution_argv = tuple(argv)
+        if self._command_executable is not None:
+            if execution_argv[0] != self._command_executable.source_path:
+                raise SandboxLaunchError(
+                    "fixed argv executable is not the pinned authority",
+                    code="runtime_preflight_failed",
+                    lease_id=self.lease_id,
+                )
+            if self._command_executable.execution_format == "script":
+                execution_argv = (
+                    self._executable.proc_fd_path,
+                    self._command_executable.proc_fd_path,
+                    *execution_argv[1:],
+                )
+            else:
+                execution_argv = (
+                    self._command_executable.proc_fd_path,
+                    *execution_argv[1:],
+                )
         return await self._run_pinned_argv(
             (
                 self._executable.proc_fd_path,
                 "-lc",
                 'exec "$@"',
                 "breadboard-execute",
-                *argv,
+                *execution_argv,
             ),
             timeout_ms=timeout_ms,
             output_limit=output_limit,
@@ -1616,7 +1670,6 @@ class TrustedProcessHandle:
                 code="runtime_preflight_failed",
                 lease_id=self.lease_id,
             )
-        read_fd = write_fd = -1
         process: asyncio.subprocess.Process | None = None
         identity_published = False
         try:
@@ -1634,12 +1687,7 @@ class TrustedProcessHandle:
                         code="workspace_authority_mismatch",
                         lease_id=self.lease_id,
                     )
-                read_fd, write_fd = os.pipe()
-                os.set_inheritable(write_fd, True)
-                bootstrap = (
-                    f"printf B >&{write_fd}; "
-                    'kill -STOP $$; exec "$@"'
-                )
+                bootstrap = 'printf B; kill -STOP $$; exec "$@"'
                 process = await asyncio.create_subprocess_exec(
                     self._executable.proc_fd_path,
                     "-c",
@@ -1647,23 +1695,34 @@ class TrustedProcessHandle:
                     "breadboard-bootstrap",
                     *argv,
                     executable=self._executable.proc_fd_path,
-                    pass_fds=(
-                        self._executable.fd,
-                        self._workspace_fd,
-                        write_fd,
-                    ),
+                    pass_fds=tuple(
+                        executable.fd
+                        for executable in (
+                            self._executable,
+                            self._command_executable,
+                        )
+                        if executable is not None
+                    )
+                    + (self._workspace_fd,),
                     preexec_fn=lambda: os.fchdir(self._workspace_fd),
                     env=dict(self.plan.runtime.fixed_environment),
                     start_new_session=True,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
-                os.close(write_fd)
-                write_fd = -1
-                if os.read(read_fd, 1) != b"B":
-                    raise RuntimeError("trusted process bootstrap failed")
+                if process.stdout is None:
+                    raise RuntimeError("trusted process bootstrap pipe is unavailable")
                 loop = asyncio.get_running_loop()
                 deadline = loop.time() + timeout_ms / 1000
+                try:
+                    marker = await asyncio.wait_for(
+                        process.stdout.readexactly(1),
+                        min(timeout_ms / 1000, 1.0),
+                    )
+                except (asyncio.IncompleteReadError, asyncio.TimeoutError):
+                    raise RuntimeError("trusted process bootstrap failed") from None
+                if marker != b"B":
+                    raise RuntimeError("trusted process bootstrap failed")
                 stop_deadline = min(deadline, loop.time() + 0.25)
                 while True:
                     fields = self._proc_fields(process.pid)
@@ -1691,11 +1750,6 @@ class TrustedProcessHandle:
                     process, clear_identity=identity_published
                 )
             raise
-        finally:
-            if read_fd >= 0:
-                os.close(read_fd)
-            if write_fd >= 0:
-                os.close(write_fd)
 
         total = 0
         count_lock = asyncio.Lock()
@@ -1859,6 +1913,8 @@ class TrustedProcessHandle:
         async with self._launch_lock:
             if not failed and not self._groups:
                 self._executable.close()
+                if self._command_executable is not None:
+                    self._command_executable.close()
                 if self._workspace_fd >= 0:
                     os.close(self._workspace_fd)
                     self._workspace_fd = -1
@@ -1895,14 +1951,41 @@ class TrustedProcessBackend:
                 lease_id=lease_id,
             )
         executable: _PinnedExecutable | None = None
+        command_executable: _PinnedExecutable | None = None
         try:
             executable = _snapshot_installed_executable(
                 plan.runtime.executable_path,
                 plan.runtime.measured_binary_digest,
             )
+            if context.role == "verifier":
+                if (
+                    plan.verifier.runtime_id != plan.runtime.runtime_id
+                    or not plan.verifier.argv
+                ):
+                    raise SandboxLaunchError(
+                        "verifier executable authority is incomplete",
+                        code="runtime_preflight_failed",
+                        lease_id=lease_id,
+                    )
+                command_executable = _snapshot_installed_executable(
+                    plan.verifier.argv[0],
+                    plan.verifier.executable_digest,
+                )
+                if command_executable.execution_format == "script":
+                    interpreter = _snapshot_installed_executable(
+                        os.path.realpath(command_executable.interpreter_path or ""),
+                        plan.runtime.measured_binary_digest,
+                    )
+                    interpreter.close()
             handle = TrustedProcessHandle(
-                plan, workspace, lease_id, executable, git_executable,
-                context.workspace_fd, context.workspace_identity,
+                plan,
+                workspace,
+                lease_id,
+                executable,
+                git_executable,
+                context.workspace_fd,
+                context.workspace_identity,
+                command_executable,
             )
             if context.record_process_identity is None:
                 raise SandboxLaunchError(
@@ -1925,6 +2008,15 @@ class TrustedProcessBackend:
                 "size": executable.size,
                 "execution": "linux-sealed-memfd",
             }
+            if command_executable is not None:
+                effective["trusted_command_executable"] = {
+                    "source_path": command_executable.source_path,
+                    "digest": command_executable.digest,
+                    "size": command_executable.size,
+                    "execution": "linux-sealed-memfd",
+                    "format": command_executable.execution_format,
+                    "interpreter_path": command_executable.interpreter_path,
+                }
             effective["workspace_diff_git_path"] = git_executable
             if repository_base_commit is not None:
                 effective["workspace_base_commit"] = repository_base_commit
@@ -1947,6 +2039,8 @@ class TrustedProcessBackend:
                 False,
             )
         except BaseException:
+            if command_executable is not None:
+                command_executable.close()
             if executable is not None:
                 executable.close()
             os.close(context.workspace_fd)
@@ -3174,6 +3268,23 @@ class SandboxRuntimeManager:
             ",".join(released),
         )
 
+    async def _release_recorded_verifier_snapshot(
+        self,
+        record: Mapping[str, Any],
+    ) -> CleanupStepReceipt:
+        receipt = await asyncio.to_thread(
+            self.materialization_store.recover_stale_snapshot,
+            record,
+        )
+        snapshot_id = record.get("snapshot_id")
+        if (
+            type(snapshot_id) is str
+            and receipt.state
+            in {CleanupState.RELEASED, CleanupState.ALREADY_RELEASED}
+        ):
+            self._snapshots.pop(snapshot_id, None)
+        return receipt
+
 
     async def open(self, request: WorkspaceOpenRequest) -> SandboxWorkspaceLease:
         plan = build_sandbox_execution_plan(request, self.registries, self.installed_authorities)
@@ -3598,11 +3709,6 @@ class SandboxRuntimeManager:
                 launched, measurement = await backend.launch(
                     verifier_plan, workspace, context=context
                 )
-                if isinstance(launched, TrustedProcessHandle):
-                    launched.bind_identity_recorder(
-                        lambda resource_id, identity, lease_id=lease_id:
-                            self._record_process_identity(lease_id, resource_id, identity)
-                    )
                 if measurement.mismatch:
                     raise SandboxAttestationError("verifier runtime measurement mismatch", code="runtime_measurement_mismatch",
                                                   lease_id=lease_id)
@@ -4165,6 +4271,10 @@ class SandboxRuntimeManager:
                         CleanupState.QUARANTINED,
                         "dependent verifier cleanup incomplete",
                     )
+            elif role == "verifier":
+                snapshot_step = (
+                    await self._release_recorded_verifier_snapshot(record)
+                )
             reconciliation_prefix = tuple(
                 step
                 for step in (child_step, snapshot_step)
@@ -4223,6 +4333,7 @@ class SandboxRuntimeManager:
                     }
                     if role == "primary"
                     else {
+                        *(("snapshot",) if snapshot_step is not None else ()),
                         "runtime",
                         "workspace",
                         "cache_holder",

--- a/breadboard/rl/harness/service.py
+++ b/breadboard/rl/harness/service.py
@@ -1963,7 +1963,7 @@ class BreadBoardV2EpisodeService:
             or verifier_cleanup_lease_mismatch
             or not _cleanup_released(
                 verifier_receipt,
-                required={"runtime", "workspace", "lease_record"},
+                required={"runtime", "workspace", "snapshot", "lease_record"},
             )
         )
         if verifier_cleanup_bad and coordinator.verifier_cleanup_failure is None:
@@ -2872,7 +2872,7 @@ class BreadBoardV2EpisodeService:
             != coordinator.verifier_lease_id
             or not _cleanup_released(
                 coordinator.verifier_cleanup_receipt,
-                required={"runtime", "workspace", "lease_record"},
+                required={"runtime", "workspace", "snapshot", "lease_record"},
             )
         ):
             failure = coordinator.verifier_cleanup_failure or _v2_failure(
@@ -2982,7 +2982,12 @@ class BreadBoardV2EpisodeService:
                         if coordinator.verifier_cleanup_receipt is not None
                         and _cleanup_released(
                             coordinator.verifier_cleanup_receipt,
-                            required={"runtime", "workspace", "lease_record"},
+                            required={
+                                "runtime",
+                                "workspace",
+                                "snapshot",
+                                "lease_record",
+                            },
                         )
                         else None
                     ),
@@ -2991,16 +2996,26 @@ class BreadBoardV2EpisodeService:
                         if coordinator.verifier_cleanup_receipt is not None
                         and _cleanup_released(
                             coordinator.verifier_cleanup_receipt,
-                            required={"runtime", "workspace", "lease_record"},
+                            required={
+                                "runtime",
+                                "workspace",
+                                "snapshot",
+                                "lease_record",
+                            },
                         )
                         else None
                     ),
                     verifier_cleanup_required_resources=(
-                        ("runtime", "workspace", "lease_record")
+                        ("runtime", "workspace", "snapshot", "lease_record")
                         if coordinator.verifier_cleanup_receipt is not None
                         and _cleanup_released(
                             coordinator.verifier_cleanup_receipt,
-                            required={"runtime", "workspace", "lease_record"},
+                            required={
+                                "runtime",
+                                "workspace",
+                                "snapshot",
+                                "lease_record",
+                            },
                         )
                         else ()
                     ),

--- a/docs/contracts/policies/acr/ACR-20260901-trusted-process-lifecycle-repair.md
+++ b/docs/contracts/policies/acr/ACR-20260901-trusted-process-lifecycle-repair.md
@@ -1,0 +1,60 @@
+# ACR-20260901-trusted-process-lifecycle-repair
+
+- `acr_id`: `ACR-20260901-trusted-process-lifecycle-repair`
+- `title`: Repair trusted-process admission and verifier cleanup lifecycle
+- `author`: Codex (engine stop-and-PR closure)
+- `date`: 2026-09-01
+- `status`: implemented
+
+## 1) Problem Statement
+
+The clean Linux installed-artifact journey exposed four defects in the trusted-process lifecycle: dash rejected a multi-digit inherited marker descriptor, verifier identity recording was bound twice, production qualification treated the verifier script as the shell bootstrap runtime, and verifier cleanup evidence did not consistently require the sealed snapshot. These defects prevented the installed lifecycle from reaching a successful, evidence-published terminal state.
+
+## 2) Scope and Surfaces
+
+- Trusted process bootstrap admission in `breadboard.rl.harness.sandbox`.
+- Production verifier runtime and executable identities in `breadboard.rl.harness.qualification`.
+- Verifier cleanup resource validation in the service and evidence repository.
+- Linux process integration and deterministic lifecycle fixtures.
+- Danger-zone: yes.
+- Outside scope: new sandbox capabilities, stronger isolation claims, compatibility fallbacks, provider behavior, or TUI changes.
+
+## 3) Coupling and Generalization Impact
+
+- Core to extension dependency introduced: no.
+- Coupling and generalization impact: positive. One process bootstrap mechanism now works independently of inherited descriptor number, and one cleanup resource set is enforced across service and evidence boundaries.
+- Generalization risk assessment: low. The stdout marker is consumed before application output is delegated; verifier execution remains bound to the existing pinned-shell contract.
+- Coupling risk: medium because admission ordering, executable identity, and cleanup evidence cross sandbox, qualification, service, and repository boundaries.
+
+## 4) Change Classification
+
+- Classification: `internal`.
+- Compatibility: no public request, response, or SDK contract changes.
+- Runtime behavior: corrective; previously rejected valid Linux process layouts and valid released cleanup receipts now complete.
+
+## 5) Evidence and Validation Plan
+
+- Local focused lifecycle/evidence/composition/process suite must pass.
+- Linux sealed-process regressions must cover a descriptor number above 9, verifier execution, cleanup, and the public lifecycle.
+- A clean installed wheel must execute inspect, create, run, verify, publish completed and closed envelopes, and release episode cleanup.
+- Exact-head independent review, danger-zone guard, and required CI must pass before merge.
+
+## 6) Rollout Plan
+
+1. Merge only after exact-head review and required CI.
+2. Rebuild all frozen SDK, Darwin, and Linux artifacts from the resulting merge identity.
+3. Repeat the Linux installed journey and official Docker canary against that identity.
+
+No new capability or promotion claim is created by this repair.
+
+## 7) Rollback Plan
+
+- Revert the repair merge as one unit if admission ordering, output integrity, verifier identity, or cleanup publication regresses.
+- Invalidate artifacts and handoffs bound to the reverted identity.
+- Do not restore the inherited shell descriptor marker or omit snapshot cleanup; fail the lifecycle closed until a replacement repair is reviewed.
+
+## 8) Approvals
+
+- Owner decision: the engine stop-and-PR request authorizes this bounded corrective PR and non-squash merge after evidence gates.
+- Independent exact-head correctness review: required.
+- Final decision: merge only after required CI passes with zero unresolved review threads.

--- a/tests/rl/harness/test_evidence.py
+++ b/tests/rl/harness/test_evidence.py
@@ -523,7 +523,7 @@ def _verifier_released_receipt() -> SandboxCleanupReceipt:
         "verifier-lease-7",
         tuple(
             CleanupStepReceipt(resource, CleanupState.RELEASED)
-            for resource in ("runtime", "workspace", "lease_record")
+            for resource in ("runtime", "workspace", "snapshot", "lease_record")
         ),
     )
 
@@ -660,6 +660,7 @@ def _publish_closed(
             verifier_cleanup_required_resources=(
                 "runtime",
                 "workspace",
+                "snapshot",
                 "lease_record",
             ),
             export_authorization_refs=authorization_refs,
@@ -1984,6 +1985,7 @@ def test_caller_cannot_narrow_authoritative_cleanup_required_resources() -> None
                 verifier_cleanup_required_resources=(
                     "runtime",
                     "workspace",
+                    "snapshot",
                     "lease_record",
                 ),
             )
@@ -2186,7 +2188,7 @@ def test_failed_verifier_evidence_is_unadmitted_until_released_cleanup_proof() -
                 ),
                 failed_cleanup,
                 "verifier-lease-7",
-                ("runtime", "workspace", "lease_record"),
+                ("runtime", "workspace", "snapshot", "lease_record"),
             )
         )
 
@@ -2305,7 +2307,7 @@ def test_foreign_completed_aggregate_with_victim_tombstone_ref_is_rejected() -> 
                 ),
                 _verifier_released_receipt(),
                 "verifier-lease-7",
-                ("runtime", "workspace", "lease_record"),
+                ("runtime", "workspace", "snapshot", "lease_record"),
             )
         )
     assert locators.get(EPISODE) == locator_before
@@ -2550,7 +2552,7 @@ def test_close_requires_the_canonical_lifecycle_primary_lease(
                 ),
                 _verifier_released_receipt(),
                 "verifier-lease-7",
-                ("runtime", "workspace", "lease_record"),
+                ("runtime", "workspace", "snapshot", "lease_record"),
             )
         )
     assert locators.get(EPISODE) == locator_before
@@ -2692,7 +2694,7 @@ def test_close_rejects_verifier_cleanup_lease_claim_that_differs_from_persisted_
                 ),
                 _verifier_released_receipt(),
                 "wrong-verifier-lease",
-                ("runtime", "workspace", "lease_record"),
+                ("runtime", "workspace", "snapshot", "lease_record"),
             )
         )
     assert locators.get(EPISODE) == locator_before
@@ -2755,7 +2757,7 @@ def test_malformed_or_foreign_export_pins_fail_closed_with_typed_errors(
                 ),
                 _verifier_released_receipt(),
                 "verifier-lease-7",
-                ("runtime", "workspace", "lease_record"),
+                ("runtime", "workspace", "snapshot", "lease_record"),
                 **pins,
             )
         )
@@ -3548,7 +3550,12 @@ def test_atomic_close_failure_never_claims_closed(
         ),
         verifier_cleanup_receipt=_verifier_released_receipt(),
         verifier_cleanup_lease_id="verifier-lease-7",
-        verifier_cleanup_required_resources=("runtime", "workspace", "lease_record"),
+        verifier_cleanup_required_resources=(
+            "runtime",
+            "workspace",
+            "snapshot",
+            "lease_record",
+        ),
         export_authorization_refs=pins.authorization_refs,
         redaction_decision_refs=pins.redaction_decision_refs,
     )

--- a/tests/rl/harness/test_materialization.py
+++ b/tests/rl/harness/test_materialization.py
@@ -1347,6 +1347,72 @@ def test_snapshot_references_coordinate_across_store_instances(
     second_store.close()
     store.close()
 
+def test_stale_snapshot_recovery_is_idempotent_with_shared_object(
+    tmp_path: Path,
+) -> None:
+    store, workspace, cache_root, workspace_root = _empty_materialized_workspace(
+        tmp_path
+    )
+    (workspace.workspace_path / "answer.txt").write_bytes(b"shared")
+    second_store = FilesystemMaterializationStore(
+        cache_root=cache_root,
+        workspace_root=workspace_root,
+        source_reader=store.source_reader,
+        clock=store.clock,
+        lease_ttl=store.lease_ttl,
+        storage_backend=directory_storage(),
+        random_bytes=DeterministicRandom(91_000),
+    )
+    limits = {
+        "max_depth": 0,
+        "max_files": 1,
+        "max_inodes": 1,
+        "max_bytes": 6,
+    }
+    stale_receipt, object_path = _seal_snapshot(store, workspace, **limits)
+    live_receipt, live_path = _seal_snapshot(
+        second_store,
+        workspace,
+        **limits,
+    )
+    record = {
+        "role": "verifier",
+        "snapshot_id": stale_receipt.snapshot_id,
+        "snapshot_root_digest": stale_receipt.root_digest,
+        "parent_lease_id": stale_receipt.source_lease_id,
+    }
+
+    assert store.recover_stale_snapshot(record) == CleanupStepReceipt(
+        "snapshot",
+        CleanupState.RELEASED,
+        stale_receipt.snapshot_id,
+    )
+    assert object_path.is_dir()
+    assert store.recover_stale_snapshot(record) == CleanupStepReceipt(
+        "snapshot",
+        CleanupState.ALREADY_RELEASED,
+        stale_receipt.snapshot_id,
+    )
+    second_store.verify_snapshot(live_receipt, live_path, **limits)
+    suffix = live_receipt.root_digest.removeprefix("sha256:")
+    store._cache.remove_tree("snapshot-objects/" + suffix)
+    assert store.recover_stale_snapshot(record) == CleanupStepReceipt(
+        "snapshot",
+        CleanupState.FAILED,
+        "RuntimeError",
+    )
+    assert (
+        cache_root
+        / "snapshot-references"
+        / suffix
+        / live_receipt.snapshot_id
+    ).is_file()
+    assert second_store.release_snapshot(live_receipt, live_path)
+    assert not object_path.exists()
+    workspace.close()
+    second_store.close()
+    store.close()
+
 
 def test_snapshot_staging_recovery_waits_for_record_publication(
     tmp_path: Path,

--- a/tests/rl/harness/test_sandbox_process_integration.py
+++ b/tests/rl/harness/test_sandbox_process_integration.py
@@ -41,6 +41,7 @@ from breadboard.rl.harness.sandbox import (
     WorkspaceStorageIdentity,
     build_sandbox_execution_plan,
     _sealed_repository_diff,
+    _snapshot_installed_executable,
 )
 from tests.rl.harness.test_runner_terminal import (
     RecordingEventSink,
@@ -308,6 +309,7 @@ async def test_run_argv_executes_requested_command_through_pinned_shell() -> Non
         (),
         {"proc_fd_path": "/proc/self/fd/71"},
     )()
+    handle._command_executable = None
     calls: list[tuple[tuple[str, ...], int, int]] = []
     expected = {"returncode": 0, "stdout": "ok\n", "stderr": ""}
 
@@ -521,6 +523,111 @@ async def test_pinned_shell_executes_admitted_bytes_after_source_mutation(
     assert result["returncode"] == 0
     assert result["stdout"] == "admitted-snapshot"
     assert (await primary.close()).state is CleanupState.RELEASED
+
+
+@requires_sealed_execution
+async def test_pinned_shell_bootstrap_does_not_require_inherited_marker_fd(
+    tmp_path: Path,
+) -> None:
+    held_descriptors: list[int] = []
+    try:
+        while not held_descriptors or held_descriptors[-1] < 32:
+            held_descriptors.append(os.open("/dev/null", os.O_RDONLY))
+        fixture = make_runtime_fixture(
+            with_writable_mount=True,
+            runtime_install_root=tmp_path / "runtime",
+        )
+        (tmp_path / "harness").mkdir()
+        harness = RuntimeHarness(tmp_path / "harness", fixture)
+        harness.manager.process_backend = TrustedProcessBackend()
+        primary = await harness.manager.open(fixture.request)
+        try:
+            result = await primary._runtime.run_shell(
+                "printf high-descriptor-bootstrap",
+                timeout_ms=1_000,
+                output_limit=4_096,
+            )
+        finally:
+            cleanup = await primary.close()
+    finally:
+        for descriptor in held_descriptors:
+            os.close(descriptor)
+
+    assert result["returncode"] == 0
+    assert result["stdout"] == "high-descriptor-bootstrap"
+    assert cleanup.state is CleanupState.RELEASED
+
+@requires_sealed_execution
+async def test_pinned_verifier_executes_admitted_bytes_after_source_replacement(
+    tmp_path: Path,
+) -> None:
+    fixture = make_runtime_fixture(
+        with_writable_mount=True,
+        runtime_install_root=tmp_path / "runtime",
+    )
+    (tmp_path / "harness").mkdir()
+    harness = RuntimeHarness(tmp_path / "harness", fixture)
+    harness.manager.process_backend = TrustedProcessBackend()
+    primary = await harness.manager.open(fixture.request)
+    verifier_path = tmp_path / "verifier"
+    verifier_path.write_bytes(b"#!/bin/sh\nprintf admitted-verifier\n")
+    verifier_path.chmod(0o500)
+    verifier_digest = "sha256:" + __import__("hashlib").sha256(
+        verifier_path.read_bytes()
+    ).hexdigest()
+    pinned = _snapshot_installed_executable(str(verifier_path), verifier_digest)
+    primary._runtime._command_executable = pinned
+    replacement = tmp_path / "replacement-verifier"
+    replacement.write_bytes(b"#!/bin/sh\nprintf attacker-controlled\n")
+    replacement.chmod(0o500)
+    os.replace(replacement, verifier_path)
+
+    result = await primary._runtime.run_argv(
+        (str(verifier_path),),
+        timeout_ms=1_000,
+        output_limit=4_096,
+    )
+
+    assert result["returncode"] == 0
+    assert result["stdout"] == "admitted-verifier"
+    assert (await primary.close()).state is CleanupState.RELEASED
+    assert pinned.closed is True
+
+@requires_sealed_execution
+async def test_pinned_binary_verifier_preserves_direct_execution(
+    tmp_path: Path,
+) -> None:
+    fixture = make_runtime_fixture(
+        with_writable_mount=True,
+        runtime_install_root=tmp_path / "runtime",
+    )
+    (tmp_path / "harness").mkdir()
+    harness = RuntimeHarness(tmp_path / "harness", fixture)
+    harness.manager.process_backend = TrustedProcessBackend()
+    primary = await harness.manager.open(fixture.request)
+    verifier_path = tmp_path / "binary-verifier"
+    shutil.copyfile(Path(os.path.realpath("/bin/sh")), verifier_path)
+    verifier_path.chmod(0o500)
+    verifier_digest = "sha256:" + __import__("hashlib").sha256(
+        verifier_path.read_bytes()
+    ).hexdigest()
+    pinned = _snapshot_installed_executable(str(verifier_path), verifier_digest)
+    primary._runtime._command_executable = pinned
+    replacement = tmp_path / "replacement-binary-verifier"
+    replacement.write_bytes(b"#!/bin/sh\nprintf attacker-controlled\n")
+    replacement.chmod(0o500)
+    os.replace(replacement, verifier_path)
+
+    result = await primary._runtime.run_argv(
+        (str(verifier_path), "-c", "printf admitted-binary"),
+        timeout_ms=1_000,
+        output_limit=4_096,
+    )
+
+    assert result["returncode"] == 0
+    assert result["stdout"] == "admitted-binary"
+    assert (await primary.close()).state is CleanupState.RELEASED
+    assert pinned.closed is True
 
 
 @requires_sealed_execution

--- a/tests/rl/harness/test_verifier_snapshot.py
+++ b/tests/rl/harness/test_verifier_snapshot.py
@@ -398,14 +398,9 @@ async def test_verifier_uses_distinct_runtime_workspace_and_read_only_snapshot(
     result = await verifier.execute()
     assert isinstance(result, MappingProxyType)
     assert dict(result) == payload
-    verifier_executable = next(
-        runtime.executable_path
-        for runtime in harness.fixture.authorities.runtimes
-        if runtime.runtime_id == verifier.plan.runtime.runtime_id
-    )
     assert harness.backend.handles[1].argv_actions == [
         (
-            (verifier_executable, "-c", "printf verifier"),
+            verifier.plan.verifier.argv,
             primary.plan.limits.verifier_timeout_ms,
             primary.plan.limits.observation_bytes,
         )
@@ -1139,6 +1134,12 @@ async def test_restart_reconciles_durable_verifier_child_before_parent(
     tmp_path: Path, phase: str
 ) -> None:
     harness, primary, snapshot = await _opened_snapshot(tmp_path)
+    snapshot_object = (
+        harness.cache_root
+        / "snapshot-objects"
+        / snapshot.root_digest.removeprefix("sha256:")
+    )
+    assert snapshot_object.exists()
     opening: asyncio.Task[Any] | None = None
     if phase == "allocating":
         harness.backend.launch_entered = asyncio.Event()
@@ -1194,6 +1195,11 @@ async def test_restart_reconciles_durable_verifier_child_before_parent(
         else CleanupState.RELEASED
     )
     assert verifier_receipt.steps == (
+        CleanupStepReceipt(
+            "snapshot",
+            CleanupState.RELEASED,
+            snapshot.snapshot_id,
+        ),
         CleanupStepReceipt("runtime", expected_runtime_state),
         CleanupStepReceipt("workspace", CleanupState.RELEASED),
         CleanupStepReceipt("cache_holder", CleanupState.ALREADY_RELEASED),
@@ -1203,11 +1209,6 @@ async def test_restart_reconciles_durable_verifier_child_before_parent(
         CleanupStepReceipt(
             "child_verifier",
             CleanupState.ALREADY_RELEASED,
-        ),
-        CleanupStepReceipt(
-            "snapshot",
-            CleanupState.RELEASED,
-            snapshot.snapshot_id,
         ),
         CleanupStepReceipt("runtime", CleanupState.RELEASED),
         CleanupStepReceipt("workspace", CleanupState.RELEASED),
@@ -1219,6 +1220,42 @@ async def test_restart_reconciles_durable_verifier_child_before_parent(
         harness.lease_root / f"{primary.lease_id}.json"
     ).exists()
     assert list(harness.workspace_root.iterdir()) == []
+    assert not snapshot_object.exists()
+
+@pytest.mark.parametrize("mutation", ["root", "parent", "role"])
+async def test_recorded_verifier_snapshot_rejects_mismatched_identity(
+    tmp_path: Path,
+    mutation: str,
+) -> None:
+    harness, primary, snapshot = await _opened_snapshot(tmp_path)
+    object_path = (
+        harness.cache_root
+        / "snapshot-objects"
+        / snapshot.root_digest.removeprefix("sha256:")
+    )
+    record = {
+        "role": "verifier",
+        "snapshot_id": snapshot.snapshot_id,
+        "snapshot_root_digest": snapshot.root_digest,
+        "parent_lease_id": primary.lease_id,
+    }
+    if mutation == "root":
+        record["snapshot_root_digest"] = "sha256:" + "0" * 64
+    elif mutation == "parent":
+        record["parent_lease_id"] = "lease-" + "f" * 32
+    else:
+        record["role"] = "primary"
+
+    receipt = await harness.manager._release_recorded_verifier_snapshot(
+        record
+    )
+
+    assert receipt.resource == "snapshot"
+    assert receipt.state in {CleanupState.FAILED, CleanupState.QUARANTINED}
+    assert snapshot.snapshot_id in harness.manager._snapshots
+    assert object_path.is_dir()
+    assert (await primary.close()).state is CleanupState.RELEASED
+    assert not object_path.exists()
 
 
 async def test_same_manager_reconcile_skips_live_primary_and_verifier_leases(

--- a/tests/rl/harness/test_wp7_source_guards.py
+++ b/tests/rl/harness/test_wp7_source_guards.py
@@ -455,10 +455,11 @@ def test_trusted_process_launch_uses_pinned_fd_and_cannot_resume_before_recordin
     keywords = {keyword.arg: keyword.value for keyword in creator.keywords}
     assert {"executable", "pass_fds"} <= keywords.keys()
     assert _qualified_name(keywords["executable"]) == "self._executable.proc_fd_path"
-    assert isinstance(keywords["pass_fds"], ast.Tuple)
-    assert {
-        _qualified_name(item) for item in keywords["pass_fds"].elts
-    } == {"self._executable.fd", "self._workspace_fd", "write_fd"}
+    pass_fds = ast.unparse(keywords["pass_fds"])
+    assert "self._executable" in pass_fds
+    assert "self._command_executable" in pass_fds
+    assert "self._workspace_fd" in pass_fds
+    assert "write_fd" not in pass_fds
     assert _qualified_name(keywords["executable"]) != "self.plan.runtime.executable_path"
 
     calls = [
@@ -469,7 +470,9 @@ def test_trusted_process_launch_uses_pinned_fd_and_cannot_resume_before_recordin
     create_line = min(
         line for line, name in calls if name == "asyncio.create_subprocess_exec"
     )
-    barrier_line = min(line for line, name in calls if name == "os.read")
+    barrier_line = min(
+        line for line, name in calls if name == "process.stdout.readexactly"
+    )
     stopped_line = min(line for line, name in calls if name == "self._proc_fields")
     recorder_line = min(line for line, name in calls if name == "recorder")
     resume_line = min(line for line, name in calls if name == "os.kill")
@@ -480,15 +483,17 @@ def test_trusted_process_launch_uses_pinned_fd_and_cannot_resume_before_recordin
     assert create_line < drain_line
 
     bootstrap = next(
-        node.value
+        node.value.value
         for node in ast.walk(run)
         if isinstance(node, ast.Assign)
-        and any(isinstance(target, ast.Name) and target.id == "bootstrap" for target in node.targets)
-        and isinstance(node.value, ast.JoinedStr)
+        and any(
+            isinstance(target, ast.Name) and target.id == "bootstrap"
+            for target in node.targets
+        )
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
     )
-    literals = "".join(
-        item.value for item in bootstrap.values if isinstance(item, ast.Constant)
-    )
+    literals = bootstrap
     assert "printf B" in literals
     assert "kill -STOP $$" in literals
     assert 'exec "$@"' in literals

--- a/tests/rl/harness/v2_service_fixtures.py
+++ b/tests/rl/harness/v2_service_fixtures.py
@@ -426,6 +426,7 @@ class DeterministicVerifier:
         self.close_receipt = receipt_from_resources(
             "runtime",
             "workspace",
+            "snapshot",
             "lease_record",
             lease_id="verifier-lease",
         )

--- a/tests/rl/harness/wp7_fixtures.py
+++ b/tests/rl/harness/wp7_fixtures.py
@@ -74,6 +74,7 @@ def make_effective_plan(
     network_policy_digest: str | None = None,
     verifier_network_policy_digest: str | None = None,
     runtime_binary_digest: str | None = None,
+    verifier_executable_digest: str | None = None,
     runner_adapter_id: str = "terminal-responses",
     runner_runtime_abi: str = "responses-v1",
     runner_implementation_digest: str | None = None,
@@ -132,7 +133,8 @@ def make_effective_plan(
         verifier_id="verifier",
         implementation_digest=digest("verifier-implementation"),
         image_digest=digest("verifier-image"),
-        executable_digest=digest("verifier-executable"),
+        executable_digest=verifier_executable_digest
+        or digest("verifier-executable"),
         code_digest=digest("verifier-code"),
         input_schema_digest=digest("verifier-input-schema"),
         result_schema_digest=digest("verifier-result-schema"),
@@ -443,26 +445,34 @@ def _registry_snapshot(**records: tuple[Any, ...]) -> c.RegistrySnapshotSet:
 
 
 @lru_cache(maxsize=1)
-def _shared_private_shell_binary() -> str:
+def _shared_private_runtime_executables() -> tuple[str, str]:
     installation = Path(
         tempfile.mkdtemp(prefix="breadboard-wp7-runtime-")
     ).resolve(strict=True)
-    return _install_private_shell_binary(installation)
+    return _install_private_runtime_executables(installation)
 
 
-def _install_private_shell_binary(installation: Path) -> str:
+def _install_private_runtime_executables(
+    installation: Path,
+) -> tuple[str, str]:
     source = Path(os.path.realpath("/bin/sh"))
     if not source.is_absolute() or not source.is_file() or source.is_symlink():
         raise RuntimeError("canonical test shell must be an absolute regular file")
     installation.mkdir(mode=0o700, parents=True, exist_ok=True)
     canonical_installation = installation.resolve(strict=True)
-    target = canonical_installation / "shell"
-    shutil.copyfile(source, target)
-    target.chmod(0o500)
-    canonical_target = target.resolve(strict=True)
-    if canonical_target != target or canonical_target.is_symlink():
+    shell = canonical_installation / "shell"
+    shutil.copyfile(source, shell)
+    shell.chmod(0o500)
+    canonical_shell = shell.resolve(strict=True)
+    if canonical_shell != shell or canonical_shell.is_symlink():
         raise RuntimeError("private test shell must not contain a symlink")
-    return str(canonical_target)
+    verifier = canonical_installation / "verifier"
+    verifier.write_bytes(b"#!/bin/sh\nprintf verifier\n")
+    verifier.chmod(0o500)
+    canonical_verifier = verifier.resolve(strict=True)
+    if canonical_verifier != verifier or canonical_verifier.is_symlink():
+        raise RuntimeError("private test verifier must not contain a symlink")
+    return str(canonical_shell), str(canonical_verifier)
 
 
 def make_runtime_fixture(
@@ -523,12 +533,15 @@ def make_runtime_fixture(
     primary_security_digest = SandboxSecurityPolicy.derive_digest(primary_security_projection)
     verifier_security_digest = SandboxSecurityPolicy.derive_digest(verifier_security_projection)
     network_digest = SandboxNetworkPolicy.derive_digest(network_projection)
-    shell_path = (
-        _install_private_shell_binary(runtime_install_root / "runtime-install")
+    shell_path, verifier_path = (
+        _install_private_runtime_executables(
+            runtime_install_root / "runtime-install"
+        )
         if runtime_install_root is not None
-        else _shared_private_shell_binary()
+        else _shared_private_runtime_executables()
     )
     shell_binary_digest = digest(Path(shell_path).read_bytes())
+    verifier_binary_digest = digest(Path(verifier_path).read_bytes())
     plan = make_effective_plan(
         runtime_id=runtime_id,
         runtime_class=runtime_class,
@@ -538,6 +551,7 @@ def make_runtime_fixture(
         network_policy_digest=network_digest,
         verifier_network_policy_digest=network_digest,
         runtime_binary_digest=shell_binary_digest,
+        verifier_executable_digest=verifier_binary_digest,
         runner_adapter_id=runner_adapter_id,
         runner_runtime_abi=runner_runtime_abi,
         runner_implementation_digest=runner_implementation_digest,
@@ -680,7 +694,7 @@ def make_runtime_fixture(
         runtime_id=verifier_runtime_id,
         runtime_class=c.RuntimeClass.TRUSTED_PROCESS,
         security_policy_digest=verifier_security_digest,
-        argv=(shell_path, "-c", "printf verifier"),
+        argv=(verifier_path,),
         result_relative_path="result.json",
         executable_digest=plan.verifier.executable_digest,
         code_digest=plan.verifier.code_digest,


### PR DESCRIPTION
## Problem and originating item
Final Linux artifact qualification for `ENGINE_STOP_AND_PR_8-27_REQUEST.md` / `RL-PACKAGE-1` exposed four trusted-process lifecycle defects:
1. dash cannot reliably parse inherited multi-digit marker descriptors in the bootstrap redirection;
2. verifier process identity recording was bound twice;
3. production qualification bound the verifier script as the trusted bootstrap runtime instead of the pinned shell;
4. verifier cleanup evidence omitted the sealed snapshot from the required released resource set.

## Observable behavior
Before: a clean Linux installed wheel failed during trusted-process admission, verifier opening, verifier execution, or completed-envelope publication depending on how far the preceding defect was repaired.

After: a high-FD trusted process admits without inherited marker-descriptor syntax; both shebang-script and ELF verifiers execute admitted, sealed bytes after source-path replacement; and service/evidence cleanup contracts accept only the complete released set `runtime, workspace, snapshot, lease_record`.

## Scope and non-goals
Scope: trusted-process bootstrap admission, verifier runtime/executable identity, script/ELF verifier execution, verifier cleanup projections, deterministic fixtures, Linux regressions, and the required danger-zone ACR.

Non-goals: new sandbox capability, stronger process-isolation claims, compatibility fallback, provider/TUI behavior, package publication, or unrelated cleanup.

## Commit map and source lineage
- `1f3cc69a781b9d7869d162e0479a19735105b9fb` (tree `0e77c44012b1e0c02fe0f033ec7549fd032b3b61`) — `fix(rl): repair trusted process lifecycle`
- base/frozen predecessor: `e176bd76b38accdc6f4973926c91634698a070e9`
- work window: 2026-08-31 through 2026-09-01; reconstructed corrective commit uses the current author/committer date.
- originating installed-artifact defects and job evidence remain under the engine custody root; no source custody state was rewritten or deleted.

## Contract, packaging, and migration effects
- Public request/response/SDK schemas: unchanged.
- Generated output and dependency locks: unchanged.
- Runtime: corrective Linux trusted-process behavior; the bootstrap shell and verifier executable are independently digest-checked and sealed. Admitted scripts run through the sealed shell after interpreter-byte equivalence validation; admitted ELF binaries execute directly from their sealed descriptor.
- Evidence invariant: verifier cleanup projection now requires the sealed snapshot everywhere; stale recovery authenticates the exact durable snapshot marker before release and preserves live shared references.
- Packaging: source changes require rebuilding all frozen artifacts after merge.
- Migration: none.

## Exact validation
Local:
```text
/opt/homebrew/bin/python3.11 -m pytest -q \
  tests/rl/harness/test_v2_service.py \
  tests/rl/harness/test_evidence.py \
  tests/rl/harness/test_production_composition_fixture_generator.py \
  tests/rl/harness/test_sandbox_process_integration.py \
  tests/rl/harness/test_wp7_source_guards.py \
  tests/rl/harness/test_verifier_snapshot.py \
  tests/rl/harness/test_sandbox_runtime.py \
  tests/rl/harness/test_materialization.py
566 passed, 23 skipped in 13.67s
```

Linux x86_64 source regressions on Slurm job 11530:
```text
11 passed in 2.86s
```
Coverage includes high-FD bootstrap, admitted script and ELF source replacement, real sealed lifecycle, allocating/active stale verifier reconciliation, root/parent/role mismatch rejection, shared-object idempotence, missing-object tamper, and public restart/reconcile/double-close.

Clean installed candidate wheel on Linux x86_64, Slurm job 11531:
- wheel SHA256 `44d7649f0b045fe3d0821dd29f4007179f06fd9cd9f64220db6870b4051c104a`;
- source commit/tree `1f3cc69a781b9d7869d162e0479a19735105b9fb` / `0e77c44012b1e0c02fe0f033ec7549fd032b3b61`;
- public inspect entrypoint passed;
- primary disposition `succeeded`;
- completed and closed envelopes published;
- terminal state `closed`, episode cleanup `released`;
- installed Pi 0.57.1 and Oh My Pi 16.2.13 target assets hash-verified;
- installed module origins were under `/tmp/venv/lib/python3.11/site-packages`.

Danger-zone ACR checker: `ok: true`, classification `internal`, no missing fields.

## Risks, unsupported paths, and rollback
Risk: stdout is now both the admission-marker channel and eventual application-output channel. The parent consumes exactly one marker byte before the existing output consumer starts; the Linux regression defends output integrity and high-FD admission.

The trusted process remains explicitly non-isolating. gVisor/Firecracker readiness is unchanged.

Rollback unit: revert this PR's merge commit and invalidate every SDK/runtime/Linux receipt built from it. Do not restore partial artifacts as ready.

## Dependencies and merge order
Depends on merged PR #89 / main `e176bd76`. This is the last runtime-affecting repair before the final freeze and artifact rebuild. Non-squash merge required.

## Independent review
Exact-head correctness review accepted `1f3cc69a781b9d7869d162e0479a19735105b9fb` / tree `0e77c44012b1e0c02fe0f033ec7549fd032b3b61` at confidence 0.94 with no findings. Exact-head security review accepted the same commit/tree at high confidence with no findings and explicit closure of r3900792324, r3900891448, r3900906249, r3900969049, and BB-STALE-SNAPSHOT-CROSS-LEASE-001. Required CI passes. Merge remains blocked only until unresolved review threads are zero.

## Omitted source changes
None. All branch changes are in this PR. Artifact probes, Slurm logs, candidate wheels, and custody receipts are evidence-only and intentionally remain outside product source.
