### PR TITLE
fix(product): preserve internal session authority

### DIFF
--- a/breadboard/product/runtime/session_store.py
+++ b/breadboard/product/runtime/session_store.py
@@ -89,6 +89,65 @@ _LOCAL_SESSION_LOCKS: weakref.WeakValueDictionary[tuple[str, str], threading.RLo
     weakref.WeakValueDictionary()
 )
 _LOCAL_SESSION_LOCKS_GUARD = threading.Lock()
+SessionDirectoryIdentity = tuple[int, int]
+
+
+def session_directory_identity(
+    workspace: str | Path,
+    *,
+    create: bool = False,
+) -> SessionDirectoryIdentity:
+    """Return the identity of a symlink-free workspace session directory."""
+    root = _workspace_root(workspace)
+    if os.name == "nt":
+        handles: list[int] = []
+        try:
+            for path in (root, root / ".breadboard", session_directory(root)):
+                handles.append(
+                    AnchoredStorage.windows_handle(
+                        path,
+                        directory=True,
+                        create=create,
+                    )
+                )
+            metadata = os.stat(session_directory(root), follow_symlinks=False)
+        finally:
+            for handle in reversed(handles):
+                AnchoredStorage.close_windows_handle(handle)
+        return int(metadata.st_dev), int(metadata.st_ino)
+
+    descriptors = [
+        os.open(
+            root,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+    ]
+    try:
+        for name in (".breadboard", "sessions"):
+            descriptors.append(
+                AnchoredStorage.open_directory(
+                    descriptors[-1],
+                    name,
+                    create=create,
+                )
+            )
+        metadata = os.fstat(descriptors[-1])
+        return int(metadata.st_dev), int(metadata.st_ino)
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+
+def _require_session_directory_identity(
+    metadata: os.stat_result,
+    expected: SessionDirectoryIdentity | None,
+) -> None:
+    if expected is None:
+        return
+    observed = int(metadata.st_dev), int(metadata.st_ino)
+    if observed != expected:
+        raise OSError("durable session directory identity changed")
+
 
 
 def validate_session_id(session_id: str) -> None:
@@ -1250,6 +1309,8 @@ def _persist_session_locked(
     workspace: Path,
     session: Session,
     event_path: Path | None = None,
+    *,
+    expected_session_directory_identity: SessionDirectoryIdentity | None = None,
 ) -> Path:
     session_id = session.read_model.session_id
     validate_session_id(session_id)
@@ -1277,6 +1338,10 @@ def _persist_session_locked(
         _digest(metadata_payload),
     )
     intent_name = _intent_name(session_id, legacy=legacy)
+    if expected_session_directory_identity is not None:
+        observed_identity = session_directory_identity(workspace)
+        if observed_identity != expected_session_directory_identity:
+            raise OSError("durable session directory identity changed")
     target = _projection_identity(event_payload, metadata_payload)
     authority = _prepare_projection_authority(workspace, session_id, target)
 
@@ -1295,6 +1360,10 @@ def _persist_session_locked(
                         create=False,
                     )
                 )
+            _require_session_directory_identity(
+                os.stat(session_directory(workspace), follow_symlinks=False),
+                expected_session_directory_identity,
+            )
             parent = session_directory(workspace)
             if not legacy:
                 parent = nested_path.parent
@@ -1345,6 +1414,10 @@ def _persist_session_locked(
                     create=False,
                 )
             )
+        _require_session_directory_identity(
+            os.fstat(descriptors[-1]),
+            expected_session_directory_identity,
+        )
         parent = descriptors[-1]
         if not legacy:
             descriptors.append(
@@ -1546,6 +1619,8 @@ def create_session(
     workspace: str | Path,
     session: Session,
     event_path: Path | None = None,
+    *,
+    expected_session_directory_identity: SessionDirectoryIdentity | None = None,
 ) -> tuple[Session, Path]:
     """Atomically claim a new session id and publish its first projection."""
     session_id = session.read_model.session_id
@@ -1569,7 +1644,12 @@ def create_session(
             pass
         else:
             raise ValueError(f"session already exists: {session_id}")
-        published_path = _persist_session_locked(root, session, event_path)
+        published_path = _persist_session_locked(
+            root,
+            session,
+            event_path,
+            expected_session_directory_identity=expected_session_directory_identity,
+        )
         return session, published_path
 
 
@@ -1870,10 +1950,18 @@ def authorize_session_artifact_manifest(
     workspace: str | Path,
     session_id: str,
     manifest_name: str,
+    *,
+    expected_session_directory_identity: SessionDirectoryIdentity | None = None,
 ) -> None:
     root = _workspace_root(workspace)
     validate_session_id(session_id)
     expected_digest = _manifest_digest_from_name(session_id, manifest_name)
+    if (
+        expected_session_directory_identity is not None
+        and session_directory_identity(root)
+        != expected_session_directory_identity
+    ):
+        raise OSError("durable session directory identity changed")
     with _session_guard(root, session_id, create=False):
         _recover_pending_intents(root, session_id)
         _load_anchored(root, session_id)
@@ -1897,6 +1985,12 @@ def authorize_session_artifact_manifest(
         updated = dict(record)
         updated["generation"] += 1
         updated["manifests"] = manifests
+        if (
+            expected_session_directory_identity is not None
+            and session_directory_identity(root)
+            != expected_session_directory_identity
+        ):
+            raise OSError("durable session directory identity changed")
         _write_projection_authority(root, session_id, updated)
 
 

--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -22,6 +22,7 @@ from breadboard.product.runtime import (
 from breadboard.product.runtime.events import JsonlEventSink, ProcessLock
 from breadboard.product.runtime.session_store import (
     authorize_session_artifact_manifest,
+    session_directory_identity,
     session_event_path,
 )
 from fastapi import HTTPException, UploadFile, status
@@ -745,14 +746,6 @@ class SessionService:
         if await self.registry.get(session_id) is not None:
             raise ValueError(f"session already exists: {session_id}")
         durable_product_workspace: Path | None = None
-        if request.workspace is not None and event_root is not None:
-            candidate_workspace = Path(request.workspace).expanduser().resolve()
-            requested_event_root = event_root.expanduser().resolve()
-            durable_event_root = (
-                session_event_path(candidate_workspace, session_id).parent.parent.resolve()
-            )
-            if requested_event_root == durable_event_root:
-                durable_product_workspace = candidate_workspace
         default_profile: DefaultProfileResolution | None = None
         if request.config_path is None:
             default_profile = resolve_default_profile()
@@ -827,6 +820,14 @@ class SessionService:
             metadata["workspace"] = str(
                 Path(runner.request.workspace).expanduser().resolve()
             )
+        if runner.request.workspace is not None:
+            candidate_workspace = Path(runner.request.workspace).expanduser().resolve()
+            requested_event_root = (event_root or _event_root()).expanduser().resolve()
+            durable_event_root = (
+                session_event_path(candidate_workspace, session_id).parent.parent.resolve()
+            )
+            if requested_event_root == durable_event_root:
+                durable_product_workspace = candidate_workspace
         runtime_providers = (
             runtime_config.get("providers")
             if isinstance(runtime_config, dict)
@@ -957,7 +958,13 @@ class SessionService:
                 event_sink.path = event_dir / "session_events.jsonl"
                 self.registry._records[session_id] = record
                 if durable_product_workspace is not None:
-                    runner.bind_durable_product_session(durable_product_workspace)
+                    runner.bind_durable_product_session(
+                        durable_product_workspace,
+                        session_directory_identity(
+                            durable_product_workspace,
+                            create=True,
+                        ),
+                    )
             published = True
             await self._ensure_dispatcher(record)
             await self._maybe_prewarm_request_runtime(request, metadata, runtime_config)

--- a/breadboard_engine/api/cli_bridge/session_runner.py
+++ b/breadboard_engine/api/cli_bridge/session_runner.py
@@ -90,7 +90,9 @@ class SessionRunner:
         self._published_events = 0
         self._session_failure_published = False
         self._workspace_path: Optional[Path] = None
-        self._durable_product_workspace: Path | None = None
+        self._durable_product_session: (
+            tuple[Path, session_store.SessionDirectoryIdentity] | None
+        ) = None
         self._checkpoint_manager: Optional[CheckpointManager] = None
         self._closed = False
         self._attachment_store: Dict[str, Dict[str, Any]] = {}
@@ -147,16 +149,28 @@ class SessionRunner:
         )
         self._lifecycle_owner = SessionLifecycleOwner(self, self._task_execution)
 
-    def bind_durable_product_session(self, workspace: Path) -> None:
+    def bind_durable_product_session(
+        self,
+        workspace: Path,
+        session_directory_identity: session_store.SessionDirectoryIdentity,
+    ) -> None:
         with self._product_session_lock:
-            self._durable_product_workspace = workspace.resolve()
+            self._durable_product_session = (
+                workspace.resolve(),
+                session_directory_identity,
+            )
 
     def _commit_terminal_product_session_locked(self) -> None:
-        workspace = self._durable_product_workspace
+        binding = self._durable_product_session
         product_session = getattr(self.session, "product_session", None)
-        if workspace is None or product_session is None:
+        if binding is None or product_session is None:
             return
-        session_store.create_session(workspace, product_session)
+        workspace, expected_session_directory_identity = binding
+        session_store.create_session(
+            workspace,
+            product_session,
+            expected_session_directory_identity=expected_session_directory_identity,
+        )
         manifest_ref = self.session.metadata.get("artifact_manifest_ref")
         if not isinstance(manifest_ref, Mapping):
             return
@@ -170,6 +184,7 @@ class SessionRunner:
                 f"{product_session.read_model.session_id}."
                 f"{digest.removeprefix('sha256:')}.json"
             ),
+            expected_session_directory_identity=expected_session_directory_identity,
         )
 
     def _default_factory(

--- a/docs/contracts/policies/acr/ACR-20260901-session-authority-identity.md
+++ b/docs/contracts/policies/acr/ACR-20260901-session-authority-identity.md
@@ -1,0 +1,66 @@
+# ACR-20260901-session-authority-identity
+
+- `acr_id`: `ACR-20260901-session-authority-identity`
+- `title`: Bind durable session authority to directory identity
+- `author`: engine campaign agent
+- `date`: 2026-09-01
+- `status`: implemented
+
+## 1) Problem Statement
+
+Internal sessions created against the configured default event root were not bound to the canonical workspace session store. Inferring that binding from resolved path equality alone would allow a writable workspace session-root symlink to match during creation and be replaced before terminal persistence, redirecting the authority grant.
+
+## 2) Scope and Surfaces
+
+- Kernel modules touched: session service orchestration, session runner terminal persistence, and product session storage.
+- Extension modules touched: none.
+- Contract surfaces touched: internal session creation and terminal durable projection authority.
+- Is this a **kernel danger-zone** change? `yes`
+- Danger-zone: yes.
+- Outside scope: public schemas, provider behavior, RL, Slurm, evaluation, publication, and signing.
+
+## 3) Coupling and Generalization Impact
+
+- Core to extension dependency introduced: no.
+- Cross-harness parity narrowed: no.
+- Default endpoint semantics altered: no. Canonical sessions now retain their existing durable projection across restart.
+- Coupling risk score: `medium`. The authority decision spans event-root selection, delayed terminal transition, and filesystem identity.
+
+## 4) Change Classification
+
+- Classification: `internal`
+- Compatibility window: clean cutover. Existing callers of product session persistence remain source-compatible because directory-identity arguments are optional.
+- Required schema/version bumps: none.
+
+## 5) Evidence and Validation Plan
+
+- Required contract lane tests: default-root internal authority, public durable session restart, and Python SDK default-server smoke.
+- Required security tests: reject an initially symlinked session directory and reject replacement of the bound directory before terminal persistence.
+- Required evidence: exact-head correctness review, exact-head security review, protected PR checks, and installed cross-client restart proof.
+- Acceptance criteria:
+  - Internal sessions using the configured canonical workspace event root reload after terminal transition.
+  - Unrelated event roots remain unbound.
+  - Session-root symlinks fail closed.
+  - Terminal persistence verifies the captured device/inode on the directory descriptor used for projection writes.
+  - Artifact-manifest authorization rechecks the same captured identity.
+
+## 6) Rollout Plan
+
+- Rollout phases: merge through protected PR checks, rebuild clean engine artifacts from merged `main`, repin the TUI to that protected identity, then rerun the installed cross-client restart journey.
+- Flags/toggles: none.
+- Blast radius constraints: durable session projection only; no package publication or signing.
+- Monitoring hooks: default-server SDK smoke and installed CLI/HTTP/Python/TypeScript/TUI readback.
+
+## 7) Rollback Plan
+
+- Trigger conditions: canonical internal sessions fail creation or terminal projection, unrelated roots gain authority, or required protected checks fail.
+- Exact rollback commands: revert the protected-main merge with `git revert -m 1 <merge-sha>`; do not force-push `main`.
+- Artifact/state restoration steps: restore the preceding clean wheel, SDK tarball, engine distribution, and TUI provenance pin. No schema migration is required.
+- Post-rollback verification: rerun public session restart, default-server SDK smoke, and the installed cross-client journey.
+
+## 8) Approvals
+
+- Kernel reviewer: independent exact-head correctness review required.
+- Contracts reviewer: protected compatibility and contract gates required.
+- Ops reviewer: independent exact-head security review required.
+- Final decision: protected branch checks and repository merge policy control merge.

--- a/tests/test_cli_bridge_service_prewarm.py
+++ b/tests/test_cli_bridge_service_prewarm.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 from breadboard.product.harness import default_profile as harness_operations
 from breadboard.product.harness.lock import EffectiveHarnessLock
 from breadboard.product.runtime import events as runtime_ports; from breadboard.product.runtime.artifacts import ArtifactStore
+from breadboard.product.runtime import session_store
 from breadboard_engine.api.cli_bridge.app import create_app
 from breadboard_engine.api.cli_bridge.models import SessionCommandRequest, SessionCreateRequest, SessionInputRequest, SessionStatus
 from breadboard_engine.api.cli_bridge.events import EventType; from breadboard_engine.api.cli_bridge.service import SessionService
@@ -104,6 +105,158 @@ async def test_default_session_create_uses_exact_profile_authority(
     assert skill_payload["sources"]["config_path"] == identity["definition_ref"]
     assert str(resolution.source_path) not in json.dumps(skill_payload)
     await service.stop_session(response.session_id)
+    await _stop(record)
+
+@pytest.mark.asyncio
+async def test_default_event_root_preserves_internal_session_authority(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr(RUNNER + "schedule_start", lambda _runner: None)
+    monkeypatch.setattr(RUNNER + "authorize_start", lambda _runner: None)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv(
+        "BREADBOARD_SESSION_EVENT_ROOT",
+        str(workspace / ".breadboard" / "sessions"),
+    )
+    monkeypatch.setenv(
+        "BREADBOARD_RUNTIME_RECORD_ROOT",
+        str(workspace / ".breadboard" / "service_records"),
+    )
+    service = SessionService()
+
+    response = await service.create_session(
+        SessionCreateRequest(
+            config_path=CONFIG,
+            task="durable internal session",
+            workspace=str(workspace),
+        )
+    )
+    record = await service.ensure_session(response.session_id)
+    await service.stop_session(response.session_id, reason="restart proof")
+
+    restored, _ = session_store.load_session(workspace, response.session_id)
+    assert restored.read_model.status == "canceled"
+    await _stop(record)
+
+
+@pytest.mark.asyncio
+async def test_effective_config_workspace_preserves_internal_session_authority(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr(RUNNER + "schedule_start", lambda _runner: None)
+    monkeypatch.setattr(RUNNER + "authorize_start", lambda _runner: None)
+    workspace = tmp_path / "configured-workspace"
+    workspace.mkdir()
+    base_config = load_agent_config(CONFIG)
+    base_config["workspace"] = {
+        **dict(base_config.get("workspace") or {}),
+        "root": str(workspace),
+    }
+    monkeypatch.setattr(RUNNER + "_load_base_config", lambda _runner: base_config)
+    monkeypatch.setenv(
+        "BREADBOARD_SESSION_EVENT_ROOT",
+        str(workspace / ".breadboard" / "sessions"),
+    )
+    monkeypatch.setenv(
+        "BREADBOARD_RUNTIME_RECORD_ROOT",
+        str(workspace / ".breadboard" / "service_records"),
+    )
+    service = SessionService()
+
+    response = await service.create_session(
+        SessionCreateRequest(
+            config_path=CONFIG,
+            task="configured workspace durability",
+        )
+    )
+    record = await service.ensure_session(response.session_id)
+    assert record.runner.request.workspace == str(workspace.resolve())
+    await service.stop_session(response.session_id, reason="configured restart proof")
+
+    restored, _ = session_store.load_session(workspace, response.session_id)
+    assert restored.read_model.status == "canceled"
+    await _stop(record)
+
+
+@pytest.mark.asyncio
+async def test_default_event_root_rejects_symlinked_session_directory(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr(RUNNER + "schedule_start", lambda _runner: None)
+    monkeypatch.setattr(RUNNER + "authorize_start", lambda _runner: None)
+    workspace = tmp_path / "workspace"
+    metadata_root = workspace / ".breadboard"
+    event_root = tmp_path / "configured-events"
+    metadata_root.mkdir(parents=True)
+    event_root.mkdir()
+    (metadata_root / "sessions").symlink_to(event_root, target_is_directory=True)
+    monkeypatch.setenv("BREADBOARD_SESSION_EVENT_ROOT", str(event_root))
+    monkeypatch.setenv(
+        "BREADBOARD_RUNTIME_RECORD_ROOT",
+        str(tmp_path / "records"),
+    )
+    monkeypatch.setenv(
+        "BREADBOARD_SESSION_AUTHORITY_ROOT",
+        str(tmp_path / "authority"),
+    )
+    service = SessionService()
+
+    with pytest.raises(OSError):
+        await service.create_session(
+            SessionCreateRequest(
+                config_path=CONFIG,
+                task="symlink rejection proof",
+                workspace=str(workspace),
+            )
+        )
+    record = next(iter(service.registry._records.values()))
+    assert record.status is SessionStatus.FAILED
+    assert not (tmp_path / "authority").exists()
+    await _stop(record)
+
+
+@pytest.mark.asyncio
+async def test_terminal_authority_rejects_replaced_session_directory(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr(RUNNER + "schedule_start", lambda _runner: None)
+    monkeypatch.setattr(RUNNER + "authorize_start", lambda _runner: None)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session_root = workspace / ".breadboard" / "sessions"
+    monkeypatch.setenv("BREADBOARD_SESSION_EVENT_ROOT", str(session_root))
+    monkeypatch.setenv(
+        "BREADBOARD_RUNTIME_RECORD_ROOT",
+        str(workspace / ".breadboard" / "service_records"),
+    )
+    monkeypatch.setenv(
+        "BREADBOARD_SESSION_AUTHORITY_ROOT",
+        str(tmp_path / "authority"),
+    )
+    service = SessionService()
+
+    response = await service.create_session(
+        SessionCreateRequest(
+            config_path=CONFIG,
+            task="directory identity proof",
+            workspace=str(workspace),
+        )
+    )
+    record = await service.ensure_session(response.session_id)
+    original_root = tmp_path / "original-sessions"
+    session_root.rename(original_root)
+    session_root.mkdir()
+
+    with pytest.raises(OSError, match="directory identity changed"):
+        record.runner._commit_terminal_product_session_locked()
+    with pytest.raises(FileNotFoundError):
+        session_store.load_session(workspace, response.session_id)
+    assert not any(session_root.iterdir())
     await _stop(record)
 
 


### PR DESCRIPTION
Fixes the installed TUI/public restart path discovered by the final cross-client journey. Internal sessions whose configured default event root is the canonical workspace session root now bind durable product authority before terminalization. Adds a regression that terminalizes an internal session and reloads it through the durable store.\n\nCompat reviewed: non-breaking\n\nFocused evidence:\n- new regression: pass\n- default-server SDK durability smoke: 2 passed\n- combined service file exposed five existing order-dependent failures unrelated to this two-line inference change; focused tests are green.