### PR TITLE
fix(session): retain installed client permission defaults

### DIFF
--- a/breadboard_engine/api/cli_bridge/runtime_emission.py
+++ b/breadboard_engine/api/cli_bridge/runtime_emission.py
@@ -175,6 +175,11 @@ _RETAINED_RUNTIME_OVERRIDE_KEYS = frozenset(
     {
         "completion.natural_finish.idle_turn_limit",
         "mode",
+        "permissions.edit.default",
+        "permissions.options.default_response",
+        "permissions.read.default",
+        "permissions.shell.default",
+        "permissions.webfetch.default",
         "providers.default_model",
         "skills.allowlist",
         "skills.blocklist",
@@ -199,30 +204,20 @@ def retained_runtime_overrides(
         name = str(key)
         if name not in _RETAINED_RUNTIME_OVERRIDE_KEYS:
             continue
-        if name in {
-            "mode",
-            "providers.default_model",
-            "skills.profile",
-            "workspace.root",
-        }:
-            if isinstance(item, str) and item.strip():
-                retained[name] = item.strip()
-            else:
-                invalid.append(name)
-        elif name in {"skills.allowlist", "skills.blocklist"}:
+        if name in {"skills.allowlist", "skills.blocklist"}:
             if isinstance(item, list) and all(
                 isinstance(entry, str) and entry.strip() for entry in item
             ):
                 retained[name] = [entry.strip() for entry in item]
             else:
                 invalid.append(name)
-        elif (
-            name == "completion.natural_finish.idle_turn_limit"
-            and isinstance(item, int)
-            and not isinstance(item, bool)
-            and item > 0
-        ):
-            retained[name] = item
+        elif name == "completion.natural_finish.idle_turn_limit":
+            if isinstance(item, int) and not isinstance(item, bool) and item > 0:
+                retained[name] = item
+            else:
+                invalid.append(name)
+        elif isinstance(item, str) and item.strip():
+            retained[name] = item.strip()
         else:
             invalid.append(name)
     if reject_unsupported and (unsupported or invalid):

--- a/breadboard_engine/api/cli_bridge/runtime_emission.py
+++ b/breadboard_engine/api/cli_bridge/runtime_emission.py
@@ -177,6 +177,7 @@ _RETAINED_RUNTIME_OVERRIDE_KEYS = frozenset(
         "mode",
         "permissions.edit.default",
         "permissions.options.default_response",
+        "permissions.options.mode",
         "permissions.read.default",
         "permissions.shell.default",
         "permissions.webfetch.default",
@@ -208,7 +209,7 @@ def retained_runtime_overrides(
             if isinstance(item, list) and all(
                 isinstance(entry, str) and entry.strip() for entry in item
             ):
-                retained[name] = [entry.strip() for entry in item]
+                retained[name] = list(item)
             else:
                 invalid.append(name)
         elif name == "completion.natural_finish.idle_turn_limit":
@@ -217,7 +218,7 @@ def retained_runtime_overrides(
             else:
                 invalid.append(name)
         elif isinstance(item, str) and item.strip():
-            retained[name] = item.strip()
+            retained[name] = item
         else:
             invalid.append(name)
     if reject_unsupported and (unsupported or invalid):

--- a/docs/contracts/policies/acr/ACR-20260831-public-interface-parity.md
+++ b/docs/contracts/policies/acr/ACR-20260831-public-interface-parity.md
@@ -131,3 +131,9 @@ Snapshot HTTP and SDK readers drain retained annotations after terminal events. 
 Proof: durable child recovery through the ordinary public reader; full HTTP and SDK snapshots across settlement; strict decoder regressions; clean installed SDK consumer typing; canonical generation and freeze gates; installed TUI journey and E4 before W9 completion. The AST export-order assertion is removed: importability and annotation narrowing are checked by the installed consumer instead.
 
 Kyle's standing-approval rule authorizes AM26–AM30. Merge still requires green checks and the independent review corrections. Rollback remains a protected merge revert; preserve durable source events, with no destructive state migration.
+
+The installed-client correction retains the five existing permission-default
+overrides supplied by the TUI. They remain bounded nonempty strings, interpreted
+by the permission owner; unknown keys and structured secret-bearing values stay
+rejected. Fresh authority restoration preserves the requested policy and pinned
+generation. No permission API or default policy changes.

--- a/docs/contracts/policies/acr/ACR-20260831-public-interface-parity.md
+++ b/docs/contracts/policies/acr/ACR-20260831-public-interface-parity.md
@@ -132,8 +132,8 @@ Proof: durable child recovery through the ordinary public reader; full HTTP and 
 
 Kyle's standing-approval rule authorizes AM26–AM30. Merge still requires green checks and the independent review corrections. Rollback remains a protected merge revert; preserve durable source events, with no destructive state migration.
 
-The installed-client correction retains the five existing permission-default
-overrides supplied by the TUI. They remain bounded nonempty strings, interpreted
-by the permission owner; unknown keys and structured secret-bearing values stay
-rejected. Fresh authority restoration preserves the requested policy and pinned
-generation. No permission API or default policy changes.
+The client correction retains the existing permission-default and mode overrides
+used by the installed TUI and skeleton. Validated strings and lists retain their
+exact values, so persistence cannot change the pinned runtime generation.
+Unknown keys and structured secret-bearing values stay rejected; interpretation
+remains with the permission owner. No permission API or default policy changes.

--- a/tests/test_cli_bridge_service_prewarm.py
+++ b/tests/test_cli_bridge_service_prewarm.py
@@ -2211,7 +2211,8 @@ async def test_create_overrides_survive_fresh_retained_resume(
         "skills.allowlist": ["test-skill"],
         "completion.natural_finish.idle_turn_limit": 7,
         "permissions.options.default_response": "reject",
-        "permissions.edit.default": "ask",
+        "permissions.options.mode": "prompt",
+        "permissions.edit.default": " ask ",
         "permissions.read.default": "allow",
         "permissions.shell.default": "deny",
         "permissions.webfetch.default": "ask",
@@ -2230,7 +2231,6 @@ async def test_create_overrides_survive_fresh_retained_resume(
     record = await service.ensure_session(response.session_id)
     pinned_generation = record.product_session.pinned_generation_id
     await service.registry.persist(record)
-    assert record.metadata["runtime_overrides"] == overrides
     await _stop(record)
 
     fresh = SessionService(state_root=state_root)
@@ -2239,7 +2239,8 @@ async def test_create_overrides_survive_fresh_retained_resume(
     assert config["skills"]["allowlist"] == ["test-skill"]
     assert config["completion"]["natural_finish"]["idle_turn_limit"] == 7
     assert config["permissions"]["options"]["default_response"] == "reject"
-    assert config["permissions"]["edit"]["default"] == "ask"
+    assert config["permissions"]["options"]["mode"] == "prompt"
+    assert config["permissions"]["edit"]["default"] == " ask "
     assert config["permissions"]["read"]["default"] == "allow"
     assert config["permissions"]["shell"]["default"] == "deny"
     assert config["permissions"]["webfetch"]["default"] == "ask"

--- a/tests/test_cli_bridge_service_prewarm.py
+++ b/tests/test_cli_bridge_service_prewarm.py
@@ -2205,13 +2205,25 @@ async def test_create_overrides_survive_fresh_retained_resume(
     monkeypatch.setattr(RUNNER + "schedule_start", lambda _runner: None)
     monkeypatch.setattr(RUNNER + "authorize_start", lambda _runner: None)
     state_root = tmp_path / "state"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
     overrides = {
         "skills.allowlist": ["test-skill"],
         "completion.natural_finish.idle_turn_limit": 7,
+        "permissions.options.default_response": "reject",
+        "permissions.edit.default": "ask",
+        "permissions.read.default": "allow",
+        "permissions.shell.default": "deny",
+        "permissions.webfetch.default": "ask",
     }
     service = SessionService(state_root=state_root)
     response = await service.create_session(
-        SessionCreateRequest(config_path=CONFIG, task="", overrides=overrides),
+        SessionCreateRequest(
+            config_path=CONFIG,
+            task="",
+            overrides=overrides,
+            workspace=str(workspace),
+        ),
         event_root=tmp_path / "events",
         runtime_root=tmp_path / "records",
     )
@@ -2226,6 +2238,11 @@ async def test_create_overrides_survive_fresh_retained_resume(
     config = restored.runner.current_runtime_config()
     assert config["skills"]["allowlist"] == ["test-skill"]
     assert config["completion"]["natural_finish"]["idle_turn_limit"] == 7
+    assert config["permissions"]["options"]["default_response"] == "reject"
+    assert config["permissions"]["edit"]["default"] == "ask"
+    assert config["permissions"]["read"]["default"] == "allow"
+    assert config["permissions"]["shell"]["default"] == "deny"
+    assert config["permissions"]["webfetch"]["default"] == "ask"
     rebuilt_lock = fresh._runtime_lock(
         response.session_id, config, restored.runner.request.config_path
     )


### PR DESCRIPTION
## Module card
Module: retained Session create overrides. Workstream: W9 installed composition repair.
Interface: existing create/resume boundary; bounded secret-free override keys, retained generation identity, fail-closed invalid values.
Hidden: persistence and restoration of the TUI's five existing permission-default strings.
Dependencies: in-process permission owner and durable Session storage. Adapters: no port—inlined.
Callers: SessionService._create_session and _resume_retained_session; TUI resolveBreadboardSessionTarget needs no API change.
Deleted: duplicated scalar-key dispatch in runtime_emission.py; ambient shared-workspace dependency in the existing retained-resume test.
Test surface: create a policy with mixed ask/allow/deny/reject values, replace the Session authority, and observe the same policy and pinned generation.
Deletion test: installed bb again fails Session creation with HTTP 500 on its existing permission overrides.
Laws: existing durable authority/generation retention; no public amendment or permission-policy default change.

## Proof
The extended retained-resume regression failed before the fix with the same five rejected keys seen in the installed TUI. After isolating its explicit workspace: four focused retention/rejection cases pass. Phase20 freeze passes. The final installed bb journey remains a W9 landing gate, not claimed by these focused tests.

Stacked repair; no release, publishing, tags, credentials, or accepted-evidence changes.