### PR TITLE
fix(public): stop snapshots at their captured durable boundary

### DIFF
--- a/breadboard_engine/api/public/session.py
+++ b/breadboard_engine/api/public/session.py
@@ -657,7 +657,7 @@ async def events(
                     return
             if emitted >= limit:
                 return
-            if not follow and batch.source != "durable":
+            if not follow:
                 return
             batch = await runtime.read_session_event_batch(
                 session_operations.ListSessionEventsRequest(

--- a/docs/contracts/policies/acr/ACR-20260831-public-interface-parity.md
+++ b/docs/contracts/policies/acr/ACR-20260831-public-interface-parity.md
@@ -137,3 +137,7 @@ used by the installed TUI and skeleton. Validated strings and lists retain their
 exact values, so persistence cannot change the pinned runtime generation.
 Unknown keys and structured secret-bearing values stay rejected; interpretation
 remains with the permission owner. No permission API or default policy changes.
+
+### W9 point-in-time snapshot correction
+
+`follow=false` stops after draining its captured batch, including durable post-terminal annotations already present at capture. It no longer rereads durable storage after yielding that batch. Events appended while the response is streaming appear only in a later snapshot. The ASGI regression appends a held-out annotation after the first response chunk and checks both responses. Live-follow behavior and public schemas are unchanged.

--- a/tests/api/public/test_session.py
+++ b/tests/api/public/test_session.py
@@ -9,6 +9,7 @@ from threading import Barrier, Lock, Thread
 from time import monotonic, sleep
 from types import SimpleNamespace
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 from jsonschema import Draft202012Validator
@@ -508,18 +509,8 @@ def test_public_session_events_snapshot_excludes_annotation_appended_after_first
         message_id="message-a",
         trajectory_id="trajectory-a",
     )
+    session.complete()
     session_store.create_session(tmp_path, session)
-
-    response = client.portal.call(
-        public_session_api.events,
-        session_id,
-        SimpleNamespace(app=client.app),
-        follow=False,
-    )
-    stream = response.body_iterator
-    first_chunk = client.portal.call(stream.__anext__)
-    assert "event: session.started\n" in first_chunk
-
     held_out = AnnotationRecord(
         annotation_id="held-out",
         message_id="message-a",
@@ -528,22 +519,39 @@ def test_public_session_events_snapshot_excludes_annotation_appended_after_first
         author="reviewer",
         generation="generation-a",
     )
-    session_store.mutate_session(
-        tmp_path,
-        session_id,
-        lambda current: current.annotate(held_out),
-    )
+    appended = False
 
-    chunks = [first_chunk]
-    while True:
-        try:
-            chunks.append(client.portal.call(stream.__anext__))
-        except StopAsyncIteration:
-            break
-    original_records = _stream_records(SimpleNamespace(text="".join(chunks)))
-    assert [event["kind"] for event in original_records] == [
+    async def append_during_response(scope, receive, send):
+        async def send_chunk(message):
+            nonlocal appended
+            await send(message)
+            if (
+                message["type"] == "http.response.body"
+                and message.get("body")
+                and not appended
+            ):
+                appended = True
+                session_store.mutate_session(
+                    tmp_path,
+                    session_id,
+                    lambda current: current.annotate(held_out),
+                )
+
+        await client.app(scope, receive, send_chunk)
+
+    async def read_snapshot():
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=append_during_response),
+            base_url="http://127.0.0.1",
+        ) as reader:
+            return await reader.get(f"/v1/sessions/{session_id}/events?follow=false")
+
+    response = client.portal.call(read_snapshot)
+    assert response.status_code == 200, response.text
+    assert [event["kind"] for event in _stream_records(response)] == [
         "session.started",
         "assistant_message",
+        "session.completed",
     ]
 
     fresh_snapshot = client.get(

--- a/tests/api/public/test_session.py
+++ b/tests/api/public/test_session.py
@@ -494,6 +494,67 @@ def test_live_event_limit_returns_annotation_before_later_input(
     assert records[0]["visibility"]["provider_visible"] is False
 
 
+def test_public_session_events_snapshot_excludes_annotation_appended_after_first_chunk(
+    client: TestClient,
+    tmp_path: Path,
+) -> None:
+    session_id = "snapshot-boundary"
+    lock = EffectiveHarnessLock._from_record(
+        {"graph_hash": "sha256:" + "a" * 64}
+    )
+    session = Session.start(lock, "snapshot boundary", session_id=session_id)
+    session.assistant_message(
+        "candidate",
+        message_id="message-a",
+        trajectory_id="trajectory-a",
+    )
+    session_store.create_session(tmp_path, session)
+
+    response = client.portal.call(
+        public_session_api.events,
+        session_id,
+        SimpleNamespace(app=client.app),
+        follow=False,
+    )
+    stream = response.body_iterator
+    first_chunk = client.portal.call(stream.__anext__)
+    assert "event: session.started\n" in first_chunk
+
+    held_out = AnnotationRecord(
+        annotation_id="held-out",
+        message_id="message-a",
+        trajectory_id="trajectory-a",
+        label="preferred",
+        author="reviewer",
+        generation="generation-a",
+    )
+    session_store.mutate_session(
+        tmp_path,
+        session_id,
+        lambda current: current.annotate(held_out),
+    )
+
+    chunks = [first_chunk]
+    while True:
+        try:
+            chunks.append(client.portal.call(stream.__anext__))
+        except StopAsyncIteration:
+            break
+    original_records = _stream_records(SimpleNamespace(text="".join(chunks)))
+    assert [event["kind"] for event in original_records] == [
+        "session.started",
+        "assistant_message",
+    ]
+
+    fresh_snapshot = client.get(
+        f"/v1/sessions/{session_id}/events?follow=false"
+    )
+    assert fresh_snapshot.status_code == 200
+    fresh_records = _stream_records(fresh_snapshot)
+    assert fresh_records[-1]["kind"] == "annotation"
+    assert fresh_records[-1]["payload"]["annotation_id"] == "held-out"
+
+
 def test_public_session_events_snapshot_closes_without_live_follow(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Module card
Module: public Session event snapshots. Workstream: W9 AM26 correction.
Interface: existing GET /v1/sessions/{id}/events?follow=false; one captured source boundary, existing public limit and cursor semantics.
Hidden: durable read batching and concurrent annotation writes.
Dependencies: in-process Session runtime and durable event owner. Adapters: no new port.
Callers: existing HTTP/SDK readers; no signature or schema change.
Deleted: durable-only reload after a non-follow request's captured first batch.
Test surface: real ASGI response serialization plus durable Session mutation; an annotation appended after the first response body chunk is absent from that response and present in a fresh snapshot.
Deletion test: one research snapshot can again absorb writes committed after its selected source boundary.
Public impact: fulfills AM26; live follow still stops at terminal, and retained post-settlement annotations already captured remain visible.

## Proof
The real HTTP regression failed pre-fix with an extra annotation in the original response. After the correction, four focused snapshot/annotation/event-limit cases pass. Phase20 freeze passes. The initial direct-handler fixture was replaced with the real ASGI route and a loopback origin so it exercises normal capability authorization rather than bypassing it.

Stacked repair for PR110 thread PRRT_kwDOPguwnc6fivK-. No release, credentials, new schema or evidence ledger.