### PR TITLE
fix(sdk): enforce the exact Python world field mask

### DIFF
--- a/breadboard_sdk/types.py
+++ b/breadboard_sdk/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, List, Literal, Optional, TypedDict
+from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple, TypedDict
 
 from .generated.session_event_bindings import (
     PublicSessionEventKind,
@@ -34,7 +34,7 @@ class SessionAnnotationPayload(TypedDict):
 
 class WorldFieldMask(TypedDict):
     schema_version: Literal["bb.world_field_mask.v1"]
-    paths: List[Literal["/occurred_at", "/timestamp"]]
+    paths: Tuple[Literal["/occurred_at"], Literal["/timestamp"]]
 
 
 

--- a/docs/contracts/policies/acr/ACR-20260831-public-interface-parity.md
+++ b/docs/contracts/policies/acr/ACR-20260831-public-interface-parity.md
@@ -141,3 +141,7 @@ remains with the permission owner. No permission API or default policy changes.
 ### W9 point-in-time snapshot correction
 
 `follow=false` stops after draining its captured batch, including durable post-terminal annotations already present at capture. It no longer rereads durable storage after yielding that batch. Events appended while the response is streaming appear only in a later snapshot. The ASGI regression appends a held-out annotation after the first response chunk and checks both responses. Live-follow behavior and public schemas are unchanged.
+
+### W9 exact Python world-mask type
+
+`WorldFieldMask.paths` is the fixed ordered tuple `("/occurred_at", "/timestamp")`, matching AM29, the canonical schema and the TypeScript tuple. The prior list annotation admitted incomplete, reordered and duplicated paths. A clean mypy consumer accepted an incomplete mask before correction and rejects it afterward; the valid tuple type-checks and serializes to the unchanged JSON array. No new operation, schema or runtime owner.

--- a/tests/test_breadboard_sdk_client.py
+++ b/tests/test_breadboard_sdk_client.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import json
 
-from typing import Any
+from typing import Any, get_type_hints
 
 import pytest
+from pydantic import TypeAdapter, ValidationError
 
 from breadboard_sdk.generated.public_bindings import (
     PUBLIC_BINDINGS_BY_OPERATION_ID,
@@ -16,7 +17,7 @@ import breadboard_sdk.client as client_module
 from breadboard_sdk.client import BreadBoardClient
 from breadboard_sdk.compat import CompatibilityBreadboardClient
 
-from breadboard_sdk.types import SessionEvent
+from breadboard_sdk.types import SessionEvent, WorldFieldMask
 
 
 class _JsonResponse:
@@ -499,3 +500,11 @@ def test_compatibility_create_session_omits_only_an_absent_config_path(
             },
         ),
     ]
+
+
+def test_python_world_mask_type_enforces_canonical_pointer_order() -> None:
+    adapter = TypeAdapter(get_type_hints(WorldFieldMask)["paths"])
+    canonical = b'["/occurred_at","/timestamp"]'
+    assert adapter.dump_json(adapter.validate_json(canonical)) == canonical
+    with pytest.raises(ValidationError):
+        adapter.validate_json(b'["/timestamp","/occurred_at"]')


### PR DESCRIPTION
## Scope

Correct the Python SDK P2 on PR110 under AM29. `WorldFieldMask.paths` now requires the fixed ordered tuple matching the schema and TypeScript. JSON serialization is unchanged. This child targets W9, not main.

## Module card

Module: Python public world-mask contract. Workstream: W9 SDK-PY.
Interface: `WorldFieldMask.paths`, exactly `/occurred_at` then `/timestamp`.
Hidden: callers do not restate the mask cardinality and positional constraints.
Dependencies: category 1, Python typing. Existing Pydantic validates the consumer regression.
Adapters: no port, inlined.
Callers: exported Python SDK type consumers. Repository Python reference search found only the declaration; LSP has no configured server. The clean typed consumer and retained public annotation consumer exercise it.
Deleted: the variable-length list-of-union annotation. No alias or compatibility path.
Test surface: validation derived from the exported SDK type, with a handwritten canonical array and rejected reverse ordering.
Deletion test: restoring the list loses the public mask ordering guarantee and makes the retained regression fail.
Laws touched: E2.11. Public impact: AM29 correction only, no new schema or operation.

## Proof

The retained regression fails against `5b080a062b305af49c7eaab0e52c1c38cbef4cb0` because the reversed mask is accepted, then passes on this branch. A clean mypy 2.3.1 consumer likewise accepted an incomplete mask before correction and rejects it afterward; the valid tuple type-checks and emits the unchanged JSON array. Existing Python SDK client tests passed, and the phase20 freeze check passed.

The local wheel packaging check stopped before packaging because this host lacks the required `setuptools==84.0.0`. This is infrastructure red, not a product change; exact-head CI supplies the declared build environment. No release or publication.