### PR TITLE
fix(bridge): preserve complete live history during retained refresh

### DIFF
--- a/breadboard_engine/api/cli_bridge/registry/persistence.py
+++ b/breadboard_engine/api/cli_bridge/registry/persistence.py
@@ -1111,7 +1111,12 @@ class PersistenceMixin:
         PersistenceMixin._replace_metadata(target, replacement_metadata)
         target.reward_summary = source.reward_summary
         target.event_seq = source.event_seq
-        target.replay_history_partial = source.replay_history_partial
+        # The disk loader lacks this process's live event buffer.
+        target.replay_history_partial = (
+            target.replay_history_partial
+            or source.replay_head_sequence != target.replay_head_sequence
+            or source.replay_head_event_id != target.replay_head_event_id
+        )
         target.replay_head_event_id = source.replay_head_event_id
         target.replay_head_sequence = source.replay_head_sequence
         target.terminal_event_envelopes[:] = source.terminal_event_envelopes

--- a/docs/contracts/policies/acr/ACR-20260831-public-interface-parity.md
+++ b/docs/contracts/policies/acr/ACR-20260831-public-interface-parity.md
@@ -145,3 +145,7 @@ remains with the permission owner. No permission API or default policy changes.
 ### W9 exact Python world-mask type
 
 `WorldFieldMask.paths` is the fixed ordered tuple `("/occurred_at", "/timestamp")`, matching AM29, the canonical schema and the TypeScript tuple. The prior list annotation admitted incomplete, reordered and duplicated paths. A clean mypy consumer accepted an incomplete mask before correction and rejects it afterward; the valid tuple type-checks and serializes to the unchanged JSON array. No new operation, schema or runtime owner.
+
+### W9 live replay completeness
+
+Retained-state refresh no longer copies a cold loader's partial-history marker onto the live event buffer. An unchanged durable head preserves local completeness; a changed head marks a replay gap. A replacement registry still reports partial history when it lacks the stream. The registry consumer regression checks fresh reads, listing and a foreign head advance. The TUI's rejection of partial history without a cursor remains unchanged.

--- a/tests/test_cli_bridge_managed_state.py
+++ b/tests/test_cli_bridge_managed_state.py
@@ -232,3 +232,41 @@ async def test_reward_summary_survives_refresh_and_registry_replacement(
     replaced = await replacement.get(session_id)
     assert replaced is not None
     assert replaced.to_summary().reward_summary == reward_summary
+
+
+@pytest.mark.asyncio
+async def test_live_replay_survives_refresh_without_hiding_foreign_head(
+    tmp_path: Path,
+) -> None:
+    state_root = tmp_path / "session-state"
+    registry = SessionRegistry(state_root)
+    record = await registry.create(
+        SessionRecord(session_id="live-replay", status=SessionStatus.RUNNING)
+    )
+    first = SessionEvent(
+        EventType.WARNING, record.session_id, {"message": "ready"}, event_id="event-1"
+    )
+    await registry.persist(record, cursor_event=first)
+    record.event_log.append(first)
+
+    refreshed = await registry.get(record.session_id)
+    assert refreshed is not None
+    assert refreshed.to_summary().retained_history == "complete"
+    assert (await registry.list())[0].retained_history == "complete"
+
+    replacement = SessionRegistry(state_root)
+    reloaded = await replacement.get(record.session_id)
+    assert reloaded is not None
+    assert reloaded.to_summary().retained_history == "partial"
+    second = SessionEvent(
+        EventType.WARNING, record.session_id, {"message": "remote"}, event_id="event-2"
+    )
+    await replacement.persist(reloaded, cursor_event=second)
+
+    refreshed = await registry.get(record.session_id)
+    assert refreshed is not None
+    snapshot = refreshed.to_summary()
+    assert snapshot.retained_history == "partial"
+    assert snapshot.head_sequence == 2
+    assert snapshot.head_event_id == "event-2"
+    assert snapshot.earliest_retained_sequence == 1


### PR DESCRIPTION
## Scope

The freshly built W9 bb now creates its Session, but then rejects the snapshot as partial history without a resume cursor. Retained refresh copied a cold disk loader's partial marker onto a process that still held the complete live event buffer. This child targets W9 after PR115.

## Module card

Module: retained Session registry refresh. Workstream: W9 installed composition.
Interface: existing registry get/list/records and retained mutations preserve local replay completeness when the durable head is unchanged; a changed head remains a gap.
Hidden: readers need not distinguish disk reconstruction from the existing live event buffer.
Dependencies: category 1 registry and replay owners; category 2 local retained storage.
Adapters: existing live registry and replacement registry over the same retained store.
Callers: _refresh_record_from_disk_locked and _refresh_records_from_disk_locked; their get/list/records and mutation callers remain unchanged. LSP has no configured server; repository references mapped both callsites.
Deleted: copying the cold-loader completeness marker over the live reader's state. No client fallback, alias, schema or owner added.
Test surface: public registry persistence/read/list operations and SessionSummary observations. A replacement registry advances the head to prove a real missing prefix stays partial.
Deletion test: restoring the old copy makes the fresh Session unreadable to the installed TUI and fails the retained regression.
Laws touched: E2.11 and E3.10. Public impact: existing W9 replay contract correction; TUI fail-closed guard unchanged.

## Proof

The retained consumer regression fails before the fix with `partial != complete`. After correction, 15 managed-state and retained-admission cases pass, including replacement-registry partial history and a foreign head advance. Phase20 freeze passes. The original installed journey is being rebuilt against this exact correction; no installed pass is claimed yet.

No release, publication, accepted-evidence rewrite or secret access.