### PR TITLE
fix: preserve generation identity across installed engine relocation

### DIFF
--- a/breadboard_engine/api/cli_bridge/registry/persistence.py
+++ b/breadboard_engine/api/cli_bridge/registry/persistence.py
@@ -1100,6 +1100,8 @@ class PersistenceMixin:
         target.created_at = source.created_at
         target.last_activity_at = source.last_activity_at
         target.logging_dir = source.logging_dir
+        if source.runtime_generation_source_ref is not None:
+            target.runtime_generation_source_ref = source.runtime_generation_source_ref
         previous_metadata = dict(target.metadata or {})
         replacement_metadata = dict(source.metadata or {})
         for key, value in previous_metadata.items():
@@ -1396,6 +1398,7 @@ class PersistenceMixin:
                     else None
                 ),
                 "config_path": str(metadata.get("config_path") or ""),
+                "runtime_generation_source_ref": record.runtime_generation_source_ref,
                 "workspace": str(metadata.get("workspace") or ""),
                 "session_event_root": str(metadata.get("session_event_root") or ""),
                 "durable_product_workspace": str(
@@ -1559,6 +1562,13 @@ class PersistenceMixin:
             not isinstance(logging_dir, str) or not logging_dir
         ):
             raise ValueError("retained session logging directory is invalid")
+        runtime_generation_source_ref = session.get("runtime_generation_source_ref")
+        if runtime_generation_source_ref is not None and (
+            not isinstance(runtime_generation_source_ref, str)
+            or not runtime_generation_source_ref
+            or not Path(runtime_generation_source_ref).is_absolute()
+        ):
+            raise ValueError("retained runtime generation source reference is invalid")
         model = _retained_model_id(session.get("model"))
         reward_summary = session.get("reward_summary")
         if reward_summary is not None:
@@ -1653,6 +1663,7 @@ class PersistenceMixin:
             replay_head_sequence=persisted_replay_head_sequence,
             metadata=metadata,
             loaded_from_retained_state=True,
+            runtime_generation_source_ref=runtime_generation_source_ref,
         )
         for item in payload.get("turns") or []:
             marker = item.get("logical_event_count_before_admission")

--- a/breadboard_engine/api/cli_bridge/registry/records.py
+++ b/breadboard_engine/api/cli_bridge/registry/records.py
@@ -241,6 +241,7 @@ class SessionRecord:
     admission_lock: "asyncio.Lock" = field(default_factory=asyncio.Lock, repr=False)
     loaded_from_retained_state: bool = field(default=False, repr=False)
     retained_turn_journal_digest: Optional[str] = field(default=None, repr=False)
+    runtime_generation_source_ref: Optional[str] = field(default=None, repr=False)
 
     def projected_status(self) -> SessionStatus:
         if self.product_session is None:

--- a/breadboard_engine/api/cli_bridge/runtime_emission.py
+++ b/breadboard_engine/api/cli_bridge/runtime_emission.py
@@ -236,15 +236,9 @@ def _config_path(repo_root: Path, config_path: str) -> Path:
     return candidate if candidate.exists() else raw.resolve()
 def compile_runtime_effective_config_graph(session_id: str, runtime_config: Mapping[str, Any], source_ref: str, *, repo_root: Path | None = None) -> dict[str, Any]:
     root = (repo_root or Path(__file__).resolve().parents[3]).resolve()
-    source_path = _config_path(root, source_ref).resolve()
-    # Bundle extraction directories are placement, not generation identity.
-    try:
-        source_ref = source_path.relative_to(root).as_posix()
-    except ValueError:
-        source_ref = str(source_path)
     return compile_effective_config_graph(graph_id=f"{session_id}_effective_config_graph", layers=[{
         "layer_id": "runtime:effective", "source_kind": "runtime", "scope": "session", "precedence": 0,
-        "source_ref": source_ref, "values": _sanitize_persisted_runtime_config(runtime_config),
+        "source_ref": str(_config_path(root, source_ref)), "values": _sanitize_persisted_runtime_config(runtime_config),
     }])
 def _tool_names(config: Mapping[str, Any]) -> list[str]:
     from ...conductor.components import initialize_yaml_tools

--- a/breadboard_engine/api/cli_bridge/runtime_emission.py
+++ b/breadboard_engine/api/cli_bridge/runtime_emission.py
@@ -236,9 +236,15 @@ def _config_path(repo_root: Path, config_path: str) -> Path:
     return candidate if candidate.exists() else raw.resolve()
 def compile_runtime_effective_config_graph(session_id: str, runtime_config: Mapping[str, Any], source_ref: str, *, repo_root: Path | None = None) -> dict[str, Any]:
     root = (repo_root or Path(__file__).resolve().parents[3]).resolve()
+    source_path = _config_path(root, source_ref).resolve()
+    # Bundle extraction directories are placement, not generation identity.
+    try:
+        source_ref = source_path.relative_to(root).as_posix()
+    except ValueError:
+        source_ref = str(source_path)
     return compile_effective_config_graph(graph_id=f"{session_id}_effective_config_graph", layers=[{
         "layer_id": "runtime:effective", "source_kind": "runtime", "scope": "session", "precedence": 0,
-        "source_ref": str(_config_path(root, source_ref)), "values": _sanitize_persisted_runtime_config(runtime_config),
+        "source_ref": source_ref, "values": _sanitize_persisted_runtime_config(runtime_config),
     }])
 def _tool_names(config: Mapping[str, Any]) -> list[str]:
     from ...conductor.components import initialize_yaml_tools

--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -1567,6 +1567,15 @@ class SessionService:
             for key in (request.overrides or {})
         )
         request_metadata = dict(request.metadata or {})
+        if not request.permission_mode:
+            metadata_permission_mode = request_metadata.get("permission_mode")
+            if (
+                isinstance(metadata_permission_mode, str)
+                and metadata_permission_mode.strip()
+            ):
+                request = request.model_copy(
+                    update={"permission_mode": metadata_permission_mode}
+                )
         role_document = request_metadata.pop(MODEL_ROLES_METADATA_KEY, None)
         if (
             role_document is None
@@ -2597,24 +2606,45 @@ class SessionService:
             runtime_overrides = metadata.get("runtime_overrides")
             request_overrides = retained_runtime_overrides(runtime_overrides)
             record.metadata = metadata
-            runner = SessionRunner(
-                session=record,
-                registry=self.registry,
-                request=SessionCreateRequest(
-                    config_path=config_path,
-                    task="",
-                    overrides=request_overrides,
-                    metadata=metadata,
-                    workspace=workspace,
-                    permission_mode=permission_mode,
-                ),
+
+            def build_runtime_candidate(
+                authored_permission_mode: str | None,
+            ) -> tuple[SessionRunner, dict[str, Any], str]:
+                runner = SessionRunner(
+                    session=record,
+                    registry=self.registry,
+                    request=SessionCreateRequest(
+                        config_path=config_path,
+                        task="",
+                        overrides=request_overrides,
+                        metadata=metadata,
+                        workspace=workspace,
+                        permission_mode=authored_permission_mode,
+                    ),
+                )
+                runtime_config = runner.prepare_runtime_config()
+                rebuilt_generation = self._runtime_lock(
+                    record.session_id,
+                    runtime_config,
+                    runner.request.config_path,
+                ).as_dict()["graph_hash"]
+                return runner, runtime_config, rebuilt_generation
+
+            authored_permission_mode = (
+                permission_mode
+                if permission_mode not in {"prompt", "ask", "interactive"}
+                else None
             )
-            runtime_config = runner.prepare_runtime_config()
-            rebuilt_generation = self._runtime_lock(
-                record.session_id,
-                runtime_config,
-                runner.request.config_path,
-            ).as_dict()["graph_hash"]
+            runner, runtime_config, rebuilt_generation = build_runtime_candidate(
+                authored_permission_mode
+            )
+            if (
+                rebuilt_generation != record.product_session.pinned_generation_id
+                and authored_permission_mode is None
+            ):
+                runner, runtime_config, rebuilt_generation = build_runtime_candidate(
+                    permission_mode
+                )
         except Exception as error:
             raise ReplayError(
                 "generation_unavailable",

--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -1663,6 +1663,7 @@ class SessionService:
         runtime_graph = compile_runtime_effective_config_graph(
             session_id, persisted_runtime_config, request.config_path
         )
+        record.runtime_generation_source_ref = runtime_graph["source_layers"][0]["source_ref"]
         if role_lock is not None:
             runtime_graph = embed_model_role_lock(runtime_graph, role_lock)
             metadata["model_role_lock_hash"] = role_lock.lock_hash
@@ -2610,10 +2611,13 @@ class SessionService:
                 ),
             )
             runtime_config = runner.prepare_runtime_config()
+            generation_source_ref = (
+                record.runtime_generation_source_ref or runner.request.config_path
+            )
             rebuilt_generation = self._runtime_lock(
                 record.session_id,
                 runtime_config,
-                runner.request.config_path,
+                generation_source_ref,
             ).as_dict()["graph_hash"]
         except Exception as error:
             raise ReplayError(
@@ -2625,6 +2629,9 @@ class SessionService:
                 "generation_mismatch",
                 f"retained session {record.session_id!r} runtime generation does not match its durable journal",
             )
+        if record.runtime_generation_source_ref is None:
+            record.runtime_generation_source_ref = generation_source_ref
+            await self.registry.persist(record)
         self._bind_restored_durable_product_session(
             record,
             runner,
@@ -3500,7 +3507,9 @@ class SessionService:
                 else dict(runtime_config)
             )
             candidate_lock = self._runtime_lock(
-                session_id, candidate_config, runner.request.config_path
+                session_id,
+                candidate_config,
+                record.runtime_generation_source_ref or runner.request.config_path,
             )
             runner.transition_product_session(
                 "reconfigure",

--- a/breadboard_engine/api/cli_bridge/session_runner.py
+++ b/breadboard_engine/api/cli_bridge/session_runner.py
@@ -954,15 +954,13 @@ class SessionRunner:
         if isinstance(self._mode, str) and self._mode.strip():
             overrides["mode"] = self._mode.strip()
         base_cfg = self._load_base_config()
-        requested_permission_mode = (
-            (
-                self.request.permission_mode
-                or self.session.metadata.get("permission_mode")
-                or ""
-            )
-            .strip()
-            .lower()
-        )
+        requested_permission_mode = self.request.permission_mode
+        if (
+            not requested_permission_mode
+            and "permission_mode" not in self.request.model_fields_set
+        ):
+            requested_permission_mode = self.session.metadata.get("permission_mode")
+        requested_permission_mode = str(requested_permission_mode or "").strip().lower()
         permissions_cfg = (
             base_cfg.get("permissions")
             if isinstance(base_cfg.get("permissions"), dict)

--- a/docs/contracts/policies/acr/ACR-20260903-session-generation-adoption.md
+++ b/docs/contracts/policies/acr/ACR-20260903-session-generation-adoption.md
@@ -65,3 +65,9 @@ A Product Session must retain the exact effective Lock identity that governed ea
 - Contracts reviewer: protected compatibility and danger-zone gates required.
 - Ops reviewer: protected branch checks required.
 - Final decision: protected branch checks and repository merge policy control merge.
+
+## W9 packaged-engine correction
+
+Runtime generation compilation now identifies package-local configuration sources relative to the engine root. Temporary extraction directories no longer change an otherwise identical generation. External configuration sources retain their absolute identity. The recovery generation check remains intact.
+
+The retained Session regression copies the packaged profile into two engine roots and compares restored state with the durable owner's pre-replacement snapshot. The existing changed-configuration case still requires `generation_mismatch`. No public schema or SDK signature changes.

--- a/docs/contracts/policies/acr/ACR-20260903-session-generation-adoption.md
+++ b/docs/contracts/policies/acr/ACR-20260903-session-generation-adoption.md
@@ -68,6 +68,8 @@ A Product Session must retain the exact effective Lock identity that governed ea
 
 ## W9 packaged-engine correction
 
-Runtime generation compilation now identifies package-local configuration sources relative to the engine root. Temporary extraction directories no longer change an otherwise identical generation. External configuration sources retain their absolute identity. The recovery generation check remains intact.
+The runtime graph hash recipe remains unchanged. Private Session state retains the original generation source reference separately from the current configuration-loading path. Recovery and explicit generation adoption compile with that retained input, then require exact agreement with the durable generation. The retained absolute reference is a hash input, not a file opened during recovery.
 
-The retained Session regression copies the packaged profile into two engine roots and compares restored state with the durable owner's pre-replacement snapshot. The existing changed-configuration case still requires `generation_mismatch`. No public schema or SDK signature changes.
+Older records without that input use the existing current-path reconstruction. The source reference is retained only after the full graph matches the pinned generation. Already-relocated historical records whose original source was never recorded still fail typed; no identity is guessed and no generation is silently adopted.
+
+The regression covers new state and the old absolute-source recipe with the new private field absent. It first recovers old state at the same path, removes the original package directory, recovers under a replacement root, adopts a model generation, and recovers again. Each recovered state is compared with the preceding durable owner's snapshot. Real configuration drift remains rejected. No public schema or SDK signature changes.

--- a/docs/contracts/policies/acr/ACR-20260903-session-generation-adoption.md
+++ b/docs/contracts/policies/acr/ACR-20260903-session-generation-adoption.md
@@ -59,6 +59,15 @@ A Product Session must retain the exact effective Lock identity that governed ea
 - Artifact/state restoration steps: no schema or data migration exists; restore the preceding runtime package artifacts.
 - Post-rollback verification: rerun Product Session replay and model-role runtime tests.
 
+## Retained permission recovery — 2026-09-05
+
+Retained startup keeps `metadata.permission_mode` as the resolved public
+projection, not as a new authored directive. It first rebuilds the implicit
+request without feeding that projection back into permission defaults, then
+tries the bounded projected mode only when the pinned generation requires it.
+Generation mismatch refusal remains authoritative; no effective configuration
+or provider-specific exception is persisted.
+
 ## 8) Approvals
 
 - Kernel reviewer: independent exact-head review required.

--- a/tests/test_cli_bridge_service_prewarm.py
+++ b/tests/test_cli_bridge_service_prewarm.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from types import SimpleNamespace; from pathlib import Path; import asyncio, hashlib, json, os, threading, pytest, yaml
 import copy
+import shutil
+from functools import partial
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from breadboard.product.harness import default_profile as harness_operations
@@ -12,6 +14,7 @@ from breadboard_engine.api.cli_bridge.models import SessionCommandRequest, Sessi
 from breadboard_engine.api.cli_bridge.events import EventType; from breadboard_engine.api.cli_bridge.service import SessionService
 from breadboard_engine.api.cli_bridge.session_runner import MAX_ATTACHMENT_BYTES
 from breadboard_engine.api.cli_bridge.runtime_emission import _tool_names
+from breadboard_engine.api.cli_bridge.runtime_emission import compile_runtime_effective_config_graph
 from breadboard_engine.auth.enforcer import apply_dotted_overrides; from breadboard_engine.compilation.v2_loader import load_agent_config
 from breadboard_engine.agent_llm_openai import OpenAIConductor
 from breadboard_engine.api.cli_bridge import session_artifacts
@@ -2284,6 +2287,63 @@ async def test_create_rejects_override_that_cannot_be_retained(
         )
 
     assert service.registry._records == {}
+
+
+@pytest.mark.asyncio
+async def test_default_session_survives_engine_package_relocation(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(RUNNER + "schedule_start", lambda _runner: None)
+    monkeypatch.setattr(RUNNER + "authorize_start", lambda _runner: None)
+    profile = harness_operations.resolve_default_profile()
+    definition_ref = profile.public_identity()["definition_ref"]
+    roots = (tmp_path / "first-engine", tmp_path / "replacement-engine")
+    for root in roots:
+        shutil.copytree(profile.source_path.parent, (root / definition_ref).parent)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    state_root = tmp_path / "state"
+
+    monkeypatch.setattr(
+        harness_operations,
+        "daily_driver_template_path",
+        lambda: str(roots[0] / definition_ref),
+    )
+    harness_operations.resolve_default_profile.cache_clear()
+    monkeypatch.setattr(
+        SERVICE + "compile_runtime_effective_config_graph",
+        partial(compile_runtime_effective_config_graph, repo_root=roots[0]),
+    )
+    service = SessionService(state_root=state_root)
+    response = await service.create_session(
+        SessionCreateRequest(
+            task="",
+            workspace=str(workspace),
+            overrides={"providers.default_model": "cli_mock/reference"},
+            permission_mode="configured",
+        ),
+        event_root=tmp_path / "events",
+        runtime_root=tmp_path / "records",
+    )
+    record = await service.ensure_session(response.session_id)
+    durable_state = copy.deepcopy(record.product_session.read_model)
+    await service.registry.persist(record)
+    await _stop(record)
+
+    monkeypatch.setattr(
+        harness_operations,
+        "daily_driver_template_path",
+        lambda: str(roots[1] / definition_ref),
+    )
+    harness_operations.resolve_default_profile.cache_clear()
+    monkeypatch.setattr(
+        SERVICE + "compile_runtime_effective_config_graph",
+        partial(compile_runtime_effective_config_graph, repo_root=roots[1]),
+    )
+    replacement = SessionService(state_root=state_root)
+    restored = await replacement.ensure_session(response.session_id)
+    assert restored.product_session.read_model == durable_state
+    await _stop(restored)
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_bridge_service_prewarm.py
+++ b/tests/test_cli_bridge_service_prewarm.py
@@ -15,6 +15,7 @@ from breadboard_engine.api.cli_bridge.events import EventType; from breadboard_e
 from breadboard_engine.api.cli_bridge.session_runner import MAX_ATTACHMENT_BYTES
 from breadboard_engine.api.cli_bridge.runtime_emission import _tool_names
 from breadboard_engine.api.cli_bridge.runtime_emission import compile_runtime_effective_config_graph
+from breadboard_engine.compilation import compile_effective_config_graph
 from breadboard_engine.auth.enforcer import apply_dotted_overrides; from breadboard_engine.compilation.v2_loader import load_agent_config
 from breadboard_engine.agent_llm_openai import OpenAIConductor
 from breadboard_engine.api.cli_bridge import session_artifacts
@@ -2146,9 +2147,11 @@ async def test_runtime_reconfigure_survives_fresh_retained_resume(
     monkeypatch.setattr(RUNNER + "schedule_start", lambda _runner: None)
     monkeypatch.setattr(RUNNER + "authorize_start", lambda _runner: None)
     state_root = tmp_path / "state"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
     service = SessionService(state_root=state_root)
     response = await service.create_session(
-        SessionCreateRequest(config_path=CONFIG, task=""),
+        SessionCreateRequest(config_path=CONFIG, task="", workspace=str(workspace)),
         event_root=tmp_path / "events",
         runtime_root=tmp_path / "records",
     )
@@ -2289,9 +2292,10 @@ async def test_create_rejects_override_that_cannot_be_retained(
     assert service.registry._records == {}
 
 
+@pytest.mark.parametrize("legacy_state", [False, True])
 @pytest.mark.asyncio
 async def test_default_session_survives_engine_package_relocation(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, legacy_state
 ) -> None:
     monkeypatch.setattr(RUNNER + "schedule_start", lambda _runner: None)
     monkeypatch.setattr(RUNNER + "authorize_start", lambda _runner: None)
@@ -2304,6 +2308,20 @@ async def test_default_session_survives_engine_package_relocation(
     workspace.mkdir()
     state_root = tmp_path / "state"
 
+    def legacy_runtime_graph(session_id, runtime_config, _source_ref):
+        # The pre-change generation recipe used this absolute source layer.
+        return compile_effective_config_graph(
+            graph_id=f"{session_id}_effective_config_graph",
+            layers=[{
+                "layer_id": "runtime:effective",
+                "source_kind": "runtime",
+                "scope": "session",
+                "precedence": 0,
+                "source_ref": str(roots[0] / definition_ref),
+                "values": runtime_config,
+            }],
+        )
+
     monkeypatch.setattr(
         harness_operations,
         "daily_driver_template_path",
@@ -2312,7 +2330,9 @@ async def test_default_session_survives_engine_package_relocation(
     harness_operations.resolve_default_profile.cache_clear()
     monkeypatch.setattr(
         SERVICE + "compile_runtime_effective_config_graph",
-        partial(compile_runtime_effective_config_graph, repo_root=roots[0]),
+        legacy_runtime_graph if legacy_state else partial(
+            compile_runtime_effective_config_graph, repo_root=roots[0]
+        ),
     )
     service = SessionService(state_root=state_root)
     response = await service.create_session(
@@ -2329,6 +2349,20 @@ async def test_default_session_survives_engine_package_relocation(
     durable_state = copy.deepcopy(record.product_session.read_model)
     await service.registry.persist(record)
     await _stop(record)
+    if legacy_state:
+        state_path = next(state_root.glob("*.json"))
+        saved_state = json.loads(state_path.read_text())
+        saved_state["session"].pop("runtime_generation_source_ref", None)
+        state_path.write_text(json.dumps(saved_state), encoding="utf-8")
+        monkeypatch.setattr(
+            SERVICE + "compile_runtime_effective_config_graph",
+            partial(compile_runtime_effective_config_graph, repo_root=roots[0]),
+        )
+        upgraded = SessionService(state_root=state_root)
+        same_path = await upgraded.ensure_session(response.session_id)
+        assert same_path.product_session.read_model == durable_state
+        await _stop(same_path)
+    shutil.rmtree(roots[0])
 
     monkeypatch.setattr(
         harness_operations,
@@ -2343,7 +2377,20 @@ async def test_default_session_survives_engine_package_relocation(
     replacement = SessionService(state_root=state_root)
     restored = await replacement.ensure_session(response.session_id)
     assert restored.product_session.read_model == durable_state
+    await replacement.execute_command(
+        response.session_id,
+        SessionCommandRequest(
+            command="set_model", payload={"model": "mock/reference"}
+        ),
+    )
+    adopted_state = copy.deepcopy(restored.product_session.read_model)
+    assert adopted_state.effective_lock_hash != durable_state.effective_lock_hash
+    await replacement.registry.persist(restored)
     await _stop(restored)
+    after_adoption = SessionService(state_root=state_root)
+    resumed = await after_adoption.ensure_session(response.session_id)
+    assert resumed.product_session.read_model == adopted_state
+    await _stop(resumed)
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_bridge_service_prewarm.py
+++ b/tests/test_cli_bridge_service_prewarm.py
@@ -109,6 +109,48 @@ async def test_default_session_create_uses_exact_profile_authority(
     assert str(resolution.source_path) not in json.dumps(skill_payload)
     await service.stop_session(response.session_id)
     await _stop(record)
+@pytest.mark.asyncio
+async def test_implicit_permission_policy_survives_fresh_retained_resume(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(RUNNER + "schedule_start", lambda _runner: None)
+    monkeypatch.setattr(RUNNER + "authorize_start", lambda _runner: None)
+    state_root = tmp_path / "state"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    service = SessionService(state_root=state_root)
+    response = await service.create_session(
+        SessionCreateRequest(
+            task="",
+            workspace=str(workspace),
+            overrides={"providers.default_model": "cli_mock/reference"},
+        ),
+        event_root=tmp_path / "events",
+        runtime_root=tmp_path / "records",
+    )
+    record = await service.ensure_session(response.session_id)
+    expected_permissions = {
+        "options": {"mode": "prompt"},
+        "shell": {"default": "ask"},
+    }
+    initial_config = record.runner.current_runtime_config()
+    pinned_generation = record.product_session.pinned_generation_id
+    assert initial_config["permissions"] == expected_permissions
+    assert record.metadata["permission_mode"] == "prompt"
+    await service.registry.persist(record)
+    await _stop(record)
+
+    fresh = SessionService(state_root=state_root)
+    restored = await fresh.ensure_session(response.session_id)
+    assert restored.runner.current_runtime_config()["permissions"] == expected_permissions
+    assert restored.metadata["permission_mode"] == "prompt"
+    rebuilt_lock = fresh._runtime_lock(
+        response.session_id,
+        restored.runner.current_runtime_config(),
+        restored.runner.request.config_path,
+    )
+    assert rebuilt_lock["graph_hash"] == pinned_generation
+    await _stop(restored)
 
 @pytest.mark.asyncio
 async def test_create_strips_caller_internal_runtime_metadata(


### PR DESCRIPTION
## Scope
W9 installed-engine recovery correction, stacked under #110. Preserves the existing generation hash recipe rather than normalizing its historical source path. Integrates independently reviewed implicit-policy correction #118, already merged into W9.

## Module card
Module: SessionService retained-generation recovery; W9 installed-composition repair, C3/C9.
Interface: create_session(request) pins the original graph input; ensure_session(id) restores exactly or fails typed; execute_command(id, reconfiguration) explicitly adopts only through existing quiescent generation rules.
Hidden: current package path loads configuration; original absolute source reference remains only a private graph-hash input. No public shape change.
Dependencies: category 1 existing compiler; category 2 existing session-state filesystem persistence.
Adapters: no new port — inlined at existing owners.
Callers: SessionService._create_session, _resume_retained_session and execute_command; SessionRegistry retained-state serialization, deserialization and refresh.
Deleted: replaces current-extraction-path generation reconstruction in service.py with the retained original input; removes the rejected package-relative normalization from runtime_emission.py. Compiler/hash recipe remains unchanged. The reconfiguration regression no longer relies on ambient tmp/agent_ws.
Test surface: existing SessionService/SessionRegistry recovery interface; independent prior durable state is compared after package relocation, adoption and restart.
Deletion test: without retained source identity, a newly extracted installed engine rejects an unchanged Session generation after replacement.
Laws touched: generation identity and exact replay under C3/C1; public continuity under C9. Public impact: none; existing generation ACR updated.

## Compatibility and verification
Old state without the private reference enrolls only after exact generation verification at its original path. Already-relocated historical state without that evidence remains a typed mismatch; no guessed adoption or journal rewrite.

29 focused managed-state/recovery cases passed, including pre-change same-path migration followed by relocation, new-session relocation, adoption plus another restart, implicit permission recovery, and real configuration drift refusal. Phase 20 freeze passed.

Independent review rejected the initial normalization proposal for breaking mixed-version same-path recovery. The failure was reproduced; the approach was replaced. The single renewal is reviewing b005fb06140f87940f669585303ca027286c3c6a; installed proof is running independently.

Compat reviewed: non-breaking.