### PR TITLE
fix: preserve implicit permission policy during retained recovery

### DIFF
--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -1567,6 +1567,15 @@ class SessionService:
             for key in (request.overrides or {})
         )
         request_metadata = dict(request.metadata or {})
+        if not request.permission_mode:
+            metadata_permission_mode = request_metadata.get("permission_mode")
+            if (
+                isinstance(metadata_permission_mode, str)
+                and metadata_permission_mode.strip()
+            ):
+                request = request.model_copy(
+                    update={"permission_mode": metadata_permission_mode}
+                )
         role_document = request_metadata.pop(MODEL_ROLES_METADATA_KEY, None)
         if (
             role_document is None
@@ -2597,24 +2606,45 @@ class SessionService:
             runtime_overrides = metadata.get("runtime_overrides")
             request_overrides = retained_runtime_overrides(runtime_overrides)
             record.metadata = metadata
-            runner = SessionRunner(
-                session=record,
-                registry=self.registry,
-                request=SessionCreateRequest(
-                    config_path=config_path,
-                    task="",
-                    overrides=request_overrides,
-                    metadata=metadata,
-                    workspace=workspace,
-                    permission_mode=permission_mode,
-                ),
+
+            def build_runtime_candidate(
+                authored_permission_mode: str | None,
+            ) -> tuple[SessionRunner, dict[str, Any], str]:
+                runner = SessionRunner(
+                    session=record,
+                    registry=self.registry,
+                    request=SessionCreateRequest(
+                        config_path=config_path,
+                        task="",
+                        overrides=request_overrides,
+                        metadata=metadata,
+                        workspace=workspace,
+                        permission_mode=authored_permission_mode,
+                    ),
+                )
+                runtime_config = runner.prepare_runtime_config()
+                rebuilt_generation = self._runtime_lock(
+                    record.session_id,
+                    runtime_config,
+                    runner.request.config_path,
+                ).as_dict()["graph_hash"]
+                return runner, runtime_config, rebuilt_generation
+
+            authored_permission_mode = (
+                permission_mode
+                if permission_mode not in {"prompt", "ask", "interactive"}
+                else None
             )
-            runtime_config = runner.prepare_runtime_config()
-            rebuilt_generation = self._runtime_lock(
-                record.session_id,
-                runtime_config,
-                runner.request.config_path,
-            ).as_dict()["graph_hash"]
+            runner, runtime_config, rebuilt_generation = build_runtime_candidate(
+                authored_permission_mode
+            )
+            if (
+                rebuilt_generation != record.product_session.pinned_generation_id
+                and authored_permission_mode is None
+            ):
+                runner, runtime_config, rebuilt_generation = build_runtime_candidate(
+                    permission_mode
+                )
         except Exception as error:
             raise ReplayError(
                 "generation_unavailable",

--- a/breadboard_engine/api/cli_bridge/session_runner.py
+++ b/breadboard_engine/api/cli_bridge/session_runner.py
@@ -954,15 +954,13 @@ class SessionRunner:
         if isinstance(self._mode, str) and self._mode.strip():
             overrides["mode"] = self._mode.strip()
         base_cfg = self._load_base_config()
-        requested_permission_mode = (
-            (
-                self.request.permission_mode
-                or self.session.metadata.get("permission_mode")
-                or ""
-            )
-            .strip()
-            .lower()
-        )
+        requested_permission_mode = self.request.permission_mode
+        if (
+            not requested_permission_mode
+            and "permission_mode" not in self.request.model_fields_set
+        ):
+            requested_permission_mode = self.session.metadata.get("permission_mode")
+        requested_permission_mode = str(requested_permission_mode or "").strip().lower()
         permissions_cfg = (
             base_cfg.get("permissions")
             if isinstance(base_cfg.get("permissions"), dict)

--- a/docs/contracts/policies/acr/ACR-20260903-session-generation-adoption.md
+++ b/docs/contracts/policies/acr/ACR-20260903-session-generation-adoption.md
@@ -59,6 +59,15 @@ A Product Session must retain the exact effective Lock identity that governed ea
 - Artifact/state restoration steps: no schema or data migration exists; restore the preceding runtime package artifacts.
 - Post-rollback verification: rerun Product Session replay and model-role runtime tests.
 
+## Retained permission recovery — 2026-09-05
+
+Retained startup keeps `metadata.permission_mode` as the resolved public
+projection, not as a new authored directive. It first rebuilds the implicit
+request without feeding that projection back into permission defaults, then
+tries the bounded projected mode only when the pinned generation requires it.
+Generation mismatch refusal remains authoritative; no effective configuration
+or provider-specific exception is persisted.
+
 ## 8) Approvals
 
 - Kernel reviewer: independent exact-head review required.

--- a/tests/test_cli_bridge_service_prewarm.py
+++ b/tests/test_cli_bridge_service_prewarm.py
@@ -109,6 +109,48 @@ async def test_default_session_create_uses_exact_profile_authority(
     assert str(resolution.source_path) not in json.dumps(skill_payload)
     await service.stop_session(response.session_id)
     await _stop(record)
+@pytest.mark.asyncio
+async def test_implicit_permission_policy_survives_fresh_retained_resume(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setattr(RUNNER + "schedule_start", lambda _runner: None)
+    monkeypatch.setattr(RUNNER + "authorize_start", lambda _runner: None)
+    state_root = tmp_path / "state"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    service = SessionService(state_root=state_root)
+    response = await service.create_session(
+        SessionCreateRequest(
+            task="",
+            workspace=str(workspace),
+            overrides={"providers.default_model": "cli_mock/reference"},
+        ),
+        event_root=tmp_path / "events",
+        runtime_root=tmp_path / "records",
+    )
+    record = await service.ensure_session(response.session_id)
+    expected_permissions = {
+        "options": {"mode": "prompt"},
+        "shell": {"default": "ask"},
+    }
+    initial_config = record.runner.current_runtime_config()
+    pinned_generation = record.product_session.pinned_generation_id
+    assert initial_config["permissions"] == expected_permissions
+    assert record.metadata["permission_mode"] == "prompt"
+    await service.registry.persist(record)
+    await _stop(record)
+
+    fresh = SessionService(state_root=state_root)
+    restored = await fresh.ensure_session(response.session_id)
+    assert restored.runner.current_runtime_config()["permissions"] == expected_permissions
+    assert restored.metadata["permission_mode"] == "prompt"
+    rebuilt_lock = fresh._runtime_lock(
+        response.session_id,
+        restored.runner.current_runtime_config(),
+        restored.runner.request.config_path,
+    )
+    assert rebuilt_lock["graph_hash"] == pinned_generation
+    await _stop(restored)
 
 @pytest.mark.asyncio
 async def test_create_strips_caller_internal_runtime_metadata(


### PR DESCRIPTION
## Change
A Session created without permission_mode retains a resolved display mode of prompt. Recovery previously reapplied that projection as an authored directive, inserted permission defaults absent from the original config, and rejected the rebuilt generation. Reconstruction now distinguishes an explicit None request from metadata fallback, preserves metadata-authored creation, and selects the implicit or projected-mode reconstruction only by exact agreement with the pinned generation.

## Module card
- Module: existing Session request compilation and retained recovery. Workstream: W9.5 / C3 and C9.
- Interface: unchanged SessionService.create_session and ensure_session; implicit and explicit permission policies survive replacement, or exact generation drift refuses recovery.
- Hidden: authored permission input differs from the public resolved display mode.
- Dependencies: category 1, existing SessionRunner, PermissionAuthority, and runtime graph compiler. No new port or adapter.
- Callers: SessionService._create_session and _resume_retained_session use SessionRunner.prepare_runtime_config. Existing direct runner callers retain metadata fallback when permission_mode is omitted.
- Deleted: unconditional feeding of the projected permission mode into retained startup; the prior one-candidate reconstruction cannot restore an implicit policy. No full effective config is persisted as a new authority.
- Test surface: retained SessionService recovery plus existing override, drift, and PermissionAuthority precedence behavior.
- Deletion test: without this correction, a default Session with no authored permission mode acquires additional ask defaults during recovery and cannot resume its pinned generation.
- Laws: immutable generation, faithful replay, permission authority. Public impact: no schema/SDK signature change; existing generation ACR updated.

## Proof
- Main reproduced the failure and inspected the initial versus recovered permission configurations before repair.
- Seven focused implicit-policy, override-retention, generation-drift, and permission-mode cases pass.
- scripts/check_phase20_freeze.py passes.
- CI supplies broad verification. Independent review is being pinned to the committed head.

The installed package-source relocation correction is separate in PR117. Neither PR relaxes the generation-mismatch check.

Compat reviewed: non-breaking. Independent review approved b86ac828a1099c1dc2b09fabc4474db49101ce19. Public signatures and wire schemas are unchanged; explicit/implicit policy precedence and exact generation refusal are preserved.
