### PR TITLE
fix(cli-bridge): preserve retained replay boundary during restart

### DIFF
--- a/breadboard_engine/api/cli_bridge/events.py
+++ b/breadboard_engine/api/cli_bridge/events.py
@@ -42,6 +42,7 @@ def replay_retention_facts(
     head_sequence: int,
     retained_history_partial: bool,
     persisted_head_event_id: str | None = None,
+    retained_boundary: tuple[int, str] | None = None,
 ) -> Dict[str, Any]:
     retained = [event for event in events if event.stable_cursor and event.seq is not None]
     first = retained[0] if retained else None
@@ -50,19 +51,21 @@ def replay_retention_facts(
     retained_history = (
         "partial" if retained_history_partial or (head_sequence and first is None) else "complete"
     )
+    earliest_sequence = first.seq if first is not None else head_sequence if virtual_head_retained else None
+    earliest_event_id = first.event_id if first is not None else persisted_head_event_id if virtual_head_retained else None
+    if retained_boundary is not None and (
+        (first is None and retained_boundary[0] == head_sequence)
+        or (first is not None and first.seq == retained_boundary[0] + 1)
+    ):
+        earliest_sequence, earliest_event_id = retained_boundary
     facts: Dict[str, Any] = {
         "replayRetention": {
             "maxEvents": REPLAY_RETENTION_MAX_EVENTS,
             "maxAgeMs": REPLAY_RETENTION_MAX_AGE_MS,
             "configurationDigest": replay_configuration_digest(),
         },
-        "earliestRetainedSequence": (
-            first.seq if first is not None else head_sequence if virtual_head_retained else None
-        ),
-        "earliestRetainedEventId": (
-            first.event_id if first is not None
-            else persisted_head_event_id if virtual_head_retained else None
-        ),
+        "earliestRetainedSequence": earliest_sequence,
+        "earliestRetainedEventId": earliest_event_id,
         "headSequence": head_sequence,
         "headEventId": (
             head.event_id

--- a/breadboard_engine/api/cli_bridge/registry/persistence.py
+++ b/breadboard_engine/api/cli_bridge/registry/persistence.py
@@ -1114,11 +1114,13 @@ class PersistenceMixin:
         target.reward_summary = source.reward_summary
         target.event_seq = source.event_seq
         # The disk loader lacks this process's live event buffer.
-        target.replay_history_partial = (
-            target.replay_history_partial
-            or source.replay_head_sequence != target.replay_head_sequence
+        head_changed = (
+            source.replay_head_sequence != target.replay_head_sequence
             or source.replay_head_event_id != target.replay_head_event_id
         )
+        target.replay_history_partial = target.replay_history_partial or head_changed
+        if head_changed:
+            target.retained_replay_boundary = source.retained_replay_boundary
         target.replay_head_event_id = source.replay_head_event_id
         target.replay_head_sequence = source.replay_head_sequence
         target.terminal_event_envelopes[:] = source.terminal_event_envelopes
@@ -1661,6 +1663,10 @@ class PersistenceMixin:
             replay_history_partial=bool(persisted_event_seq),
             replay_head_event_id=persisted_head_event_id,
             replay_head_sequence=persisted_replay_head_sequence,
+            retained_replay_boundary=(
+                (persisted_replay_head_sequence, persisted_head_event_id)
+                if persisted_head_event_id is not None else None
+            ),
             metadata=metadata,
             loaded_from_retained_state=True,
             runtime_generation_source_ref=runtime_generation_source_ref,

--- a/breadboard_engine/api/cli_bridge/registry/records.py
+++ b/breadboard_engine/api/cli_bridge/registry/records.py
@@ -218,6 +218,8 @@ class SessionRecord:
     replay_history_partial: bool = False
     replay_head_event_id: Optional[str] = None
     replay_head_sequence: int = 0
+    # A loaded cursor without its event body anchors the newly buffered suffix.
+    retained_replay_boundary: Optional[tuple[int, str]] = field(default=None, repr=False)
     terminal_event_envelopes: list[Dict[str, Any]] = field(default_factory=list, repr=False)
     subscribers: Dict["asyncio.Queue[Optional[SessionEvent]]", SubscriberState] = field(
         default_factory=dict,
@@ -275,6 +277,7 @@ class SessionRecord:
             ),
             retained_history_partial=self.replay_history_partial,
             persisted_head_event_id=self.replay_head_event_id,
+            retained_boundary=self.retained_replay_boundary,
         )
         terminal_turns = [
             {

--- a/breadboard_engine/api/cli_bridge/service.py
+++ b/breadboard_engine/api/cli_bridge/service.py
@@ -1963,6 +1963,7 @@ class SessionService:
                 head_sequence=record.event_seq,
                 retained_history_partial=record.replay_history_partial,
                 persisted_head_event_id=record.replay_head_event_id,
+                retained_boundary=record.retained_replay_boundary,
             ),
             stable_cursor=False,
         )
@@ -2750,19 +2751,8 @@ class SessionService:
                 self._ensure_event_sequence(record)
                 events = list(record.event_log)
                 if from_id:
-                    start_index = self._resolve_start_index(events, from_id)
-                    if start_index is not None and not self._retained_replay_suffix_is_contiguous(
-                        record,
-                        events,
-                        start_index,
-                    ):
-                        start_index = None
-                    if start_index is None and self._is_retained_head_cursor(record, from_id):
-                        events = [
-                            event for event in events
-                            if event.seq is not None and event.seq > record.replay_head_sequence
-                        ]
-                    elif start_index is None:
+                    start_index = self._resolve_replay_start_index(record, events, from_id)
+                    if start_index is None:
                         if not validated:
                             raise HTTPException(
                                 status_code=status.HTTP_409_CONFLICT,
@@ -3034,14 +3024,8 @@ class SessionService:
                 return
             self._ensure_event_sequence(record)
             events = list(record.event_log)
-            start_index = self._resolve_start_index(events, from_id)
-            if start_index is not None and not self._retained_replay_suffix_is_contiguous(
-                record,
-                events,
-                start_index,
-            ):
-                start_index = None
-            if start_index is None and not self._is_retained_head_cursor(record, from_id):
+            start_index = self._resolve_replay_start_index(record, events, from_id)
+            if start_index is None:
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail={
@@ -3063,38 +3047,47 @@ class SessionService:
             else:
                 seq = max(seq, int(event.seq))
         record.event_seq = seq
-    @staticmethod
-    def _is_retained_head_cursor(record: SessionRecord, from_id: str) -> bool:
-        return (
-            record.replay_head_sequence > 0
-            and record.replay_head_event_id is not None
-            and from_id
-            in {
-                record.replay_head_event_id,
-                str(record.replay_head_sequence),
-            }
-        )
 
-    @staticmethod
-    def _retained_replay_suffix_is_contiguous(
+    def _resolve_replay_start_index(
+        self,
         record: SessionRecord,
         events: list[SessionEvent],
-        start_index: int,
-    ) -> bool:
+        from_id: str,
+    ) -> int | None:
+        start_index = self._resolve_start_index(events, from_id)
+        if start_index is not None:
+            cursor_sequence = events[start_index - 1].seq
+        elif record.replay_head_event_id is not None and (
+            from_id == record.replay_head_event_id
+            or from_id == str(record.replay_head_sequence)
+        ):
+            cursor_sequence = record.replay_head_sequence
+        elif record.retained_replay_boundary is not None and (
+            from_id == record.retained_replay_boundary[1]
+            or from_id == str(record.retained_replay_boundary[0])
+        ):
+            cursor_sequence = record.retained_replay_boundary[0]
+        else:
+            return None
+        if cursor_sequence is None:
+            return None
+        if start_index is None:
+            start_index = 0
+            while start_index < len(events):
+                sequence = events[start_index].seq
+                if sequence is None or sequence > cursor_sequence:
+                    break
+                start_index += 1
         if not record.replay_history_partial:
-            return True
-        if start_index <= 0:
-            return False
-        cursor_sequence = events[start_index - 1].seq
-        replay_head = record.replay_head_sequence
-        if cursor_sequence is None or cursor_sequence > replay_head:
-            return False
+            return start_index
+        if cursor_sequence > record.replay_head_sequence:
+            return None
         expected_sequence = cursor_sequence + 1
-        for event in events[start_index:]:
-            if event.seq != expected_sequence or expected_sequence > replay_head:
-                return False
+        for index in range(start_index, len(events)):
+            if events[index].seq != expected_sequence:
+                return None
             expected_sequence += 1
-        return expected_sequence == replay_head + 1
+        return start_index if expected_sequence == record.replay_head_sequence + 1 else None
 
     def _resolve_start_index(
         self, events: list[SessionEvent], from_id: str

--- a/docs/contracts/policies/acr/ACR-20260831-public-interface-parity.md
+++ b/docs/contracts/policies/acr/ACR-20260831-public-interface-parity.md
@@ -149,3 +149,9 @@ remains with the permission owner. No permission API or default policy changes.
 ### W9 live replay completeness
 
 Retained-state refresh no longer copies a cold loader's partial-history marker onto the live event buffer. An unchanged durable head preserves local completeness; a changed head marks a replay gap. A replacement registry still reports partial history when it lacks the stream. The registry consumer regression checks fresh reads, listing and a foreign head advance. The TUI's rejection of partial history without a cursor remains unchanged.
+
+### W9 retained replay boundary
+
+Cold recovery keeps its metadata-only head cursor as a private in-memory boundary while new dispatches advance the durable head. Subscription and preflight share one contiguous-suffix resolver, so an append between them is replayed rather than dropped. A foreign durable-head change replaces the boundary; unavailable history still fails the replay check. Summary and stream-open retention facts include the boundary when it precedes the buffered suffix.
+
+No nonterminal payload, public field, schema, generation input or client guard changes. The regression observes the advertised cursor and delivery of N+1 then N+2 across cold recovery. The obsolete helper assertion is removed; the existing ID/numeric subscription and gap-refusal checks remain. The installed journey supplies the process-replacement proof. Rollback is a protected revert with no persisted-state migration.

--- a/tests/test_cli_bridge_managed_state.py
+++ b/tests/test_cli_bridge_managed_state.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import stat
@@ -8,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from breadboard_engine.api.cli_bridge.events import EventType, SessionEvent
-from breadboard_engine.api.cli_bridge.models import SessionStatus
+from breadboard_engine.api.cli_bridge.models import SessionCreateRequest, SessionStatus
 from breadboard_engine.api.cli_bridge.registry import SessionRecord, SessionRegistry, TurnRecord
 from breadboard_engine.api.cli_bridge.runtime_emission import (
     ManagedStateRootError,
@@ -270,3 +271,83 @@ async def test_live_replay_survives_refresh_without_hiding_foreign_head(
     assert snapshot.head_sequence == 2
     assert snapshot.head_event_id == "event-2"
     assert snapshot.earliest_retained_sequence == 1
+
+
+@pytest.mark.asyncio
+async def test_retained_head_resume_keeps_events_published_before_subscription(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    root = _managed_root(tmp_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.setenv("BREADBOARD_ENGINE_LAUNCH_ID", LAUNCH_ID)
+    monkeypatch.setenv("BREADBOARD_ENGINE_STATE_ROOT", str(root))
+    monkeypatch.setattr(
+        "breadboard_engine.api.cli_bridge.session_runner.SessionRunner.schedule_start",
+        lambda _runner: None,
+    )
+    monkeypatch.setattr(
+        "breadboard_engine.api.cli_bridge.session_runner.SessionRunner.authorize_start",
+        lambda _runner: None,
+    )
+    records: list[SessionRecord] = []
+    try:
+        original = SessionService()
+        response = await original.create_session(
+            SessionCreateRequest(
+                task="", workspace=str(workspace),
+                overrides={"providers.default_model": "cli_mock/reference"},
+            )
+        )
+        record = await original.ensure_session(response.session_id)
+        records.append(record)
+        boundary = SessionEvent(
+            EventType.WARNING, record.session_id, {"message": "before restart"},
+            event_id="before-restart",
+        )
+        await record.event_queue.put(boundary)
+        await record.event_queue.join()
+        boundary_sequence = boundary.seq
+        assert boundary_sequence is not None
+
+        restarted = SessionService()
+        await restarted.validate_event_stream(
+            record.session_id, from_id=boundary.event_id, replay=True
+        )
+        retained = await restarted.registry.get(record.session_id)
+        assert retained is not None
+        records.append(retained)
+        first_live = SessionEvent(
+            EventType.WARNING, record.session_id, {"message": "after restart"},
+            event_id="after-restart",
+        )
+        await retained.event_queue.put(first_live)
+        await retained.event_queue.join()
+
+        prepared = await restarted.prepare_event_stream(
+            record.session_id, replay=True, from_id=boundary.event_id
+        )
+        next_live = SessionEvent(
+            EventType.WARNING, record.session_id, {"message": "after subscription"},
+            event_id="after-subscription",
+        )
+        await retained.event_queue.put(next_live)
+        await retained.event_queue.put(None)
+        await retained.event_queue.join()
+        stream = restarted.prepared_event_stream(prepared)
+        stream_open = await anext(stream)
+        assert stream_open.payload["earliestRetainedSequence"] == boundary_sequence
+        assert stream_open.payload["earliestRetainedEventId"] == boundary.event_id
+        delivered = [event async for event in stream if event.stable_cursor]
+        assert [(event.event_id, event.seq) for event in delivered] == [
+            ("after-restart", boundary_sequence + 1),
+            ("after-subscription", boundary_sequence + 2),
+        ]
+    finally:
+        dispatchers = [
+            record.dispatcher_task for record in records
+            if record.dispatcher_task is not None
+        ]
+        for dispatcher in dispatchers:
+            dispatcher.cancel()
+        await asyncio.gather(*dispatchers, return_exceptions=True)

--- a/tests/test_session_state_events.py
+++ b/tests/test_session_state_events.py
@@ -2515,10 +2515,6 @@ async def test_finish_turn_promotes_queued_turn_without_stopping_dispatcher(tmp_
     )
     assert replay_queue.empty()
     await restarted_service._unregister_subscriber(restored, replay_queue)
-    assert restarted_service._is_retained_head_cursor(
-        restored,
-        str(replay_head.seq),
-    )
     numeric_replay_queue: asyncio.Queue[SessionEvent | None] = asyncio.Queue()
     await restarted_service._register_subscriber(
         restored,


### PR DESCRIPTION
## Scope
W9 installed-composition correction, stacked under #110. The rebuilt installed journey passes generation recovery after #117/#118, then loses the first replayed event: cold recovery remembers a cursor without its body, and an append between validation and subscription replaces that anchor.

## Module card
Module: retained CLI-bridge replay; W9 installed composition, C1/C9.
Interface: SessionService.validate_event_stream / prepare_event_stream accept a known cursor only for a contiguous available suffix; prepared_event_stream delivers that suffix before later live events. SessionSummary and stream.open advertise the retained cursor boundary.
Hidden: loaded metadata-only cursor remains an in-memory boundary while the durable head advances. Foreign durable-head replacement resets that boundary.
Dependencies: category 1 existing dispatch lock and event primitives; category 2 existing retained Session filesystem owner.
Adapters: no new port — inlined at existing owners.
Callers: SessionService._register_subscriber, validate_event_stream, _stream_open_event; SessionRecord.to_summary; PersistenceMixin._deserialize_record and _apply_durable_fields. No LSP is configured; scoped reference search identified both replay-retention callers and both cursor-resolution callers.
Deleted: removes _is_retained_head_cursor and _retained_replay_suffix_is_contiguous; replaces duplicated validation/filtering in service.py with one state-aware resolver. The obsolete private-helper assertion is removed; adjacent ID/numeric subscription and gap-refusal coverage remains. No client workaround or alternate ledger.
Test surface: real SessionService dispatch, persisted state and a fresh service; hand-written expected delivery of N+1 then N+2 after an append between validation and subscription.
Deletion test: removing the loaded boundary loses the first post-restart event or rejects a valid advertised cursor, causing the installed SDK to fail with sequence_discontinuity.
Laws touched: exact replay and fail-closed continuity (E3.4/E3.5); public consumer consistency (E3.10). Public impact: none; existing response shapes and generation identity unchanged. No event body is newly persisted.

## Verification
Regression failed before correction: sequence 3 arrived without sequence 2. It now passes, including stream.open cursor facts. Sixteen focused cases plus the existing ID/numeric subscription and gap-refusal test pass; freeze passes.

Standards: the initial obsolete-helper finding is corrected; bounded renewal is clean. Spec: retained-boundary, partial-history, foreign-refresh and ordering semantics are clean; the same obsolete assertion is removed. No compatibility wrapper or new implementation assertion.

Exact head 326f2ab0 has 58 successful checks and seven skipped; the review thread is resolved. The installed binary built from production head 09d61718 passes the full clean journey (Session 486a8086-b884-496a-ba1f-456005f5fb3b, cursor 180), including engine replacement, recovered input, TUI resume and tamper checks. The subsequent 326f2ab0 commit changes only the obsolete assertion and existing ACR. Five stale generated bundles were removed before the clean run; no product guard or fixture assertion was weakened.

Compat reviewed: non-breaking.